### PR TITLE
Use ProvisionNetwork to specify an additional network

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,29 @@ spec:
     replicas: 1
     containerImage: quay.io/tripleomastercentos9/openstack-ironic-conductor:current-tripleo
     pxeContainerImage: quay.io/tripleomastercentos9/openstack-ironic-pxe:current-tripleo
+    provisionNetwork: provision-net
   secret: ironic-secret
+```
+
+This example assumes the existence of additional network `provision_net` to use
+for exposing provision boot services (DHCP, TFTP, HTTP). Currently this
+additional network needs to be managed manually with
+`NetworkAttachmentDefinition` resources. For example, applying the following
+will result in network interface `eno1` being available in the conductor pod:
+
+```yaml
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: provision-net
+spec:
+  config: |-
+    {
+      "cniVersion": "0.3.1",
+      "name": "provision-net",
+      "type": "host-device",
+      "device": "eno1"
+    }
 ```
 
 # Design

--- a/api/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/api/bases/ironic.openstack.org_ironicconductors.yaml
@@ -100,14 +100,6 @@ spec:
                     description: Start - Start of DHCP range
                     type: string
                 type: object
-              nodeProvisioningAddresses:
-                additionalProperties:
-                  items:
-                    type: string
-                  type: array
-                description: NodeProvisioningAddresses Map of nodes to node host network
-                  IP addresses to bind for TFTP/DHCP/HTTP provisioning services
-                type: object
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -129,9 +121,9 @@ spec:
                       password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string
                 type: object
-              provisioningInterface:
-                description: ProvisioningInterface - Host network interface used by
-                  Ironic, TFTP, DHCP and HTTP
+              provisionNetwork:
+                description: ProvisionNetwork - Additional network to attach to expose
+                  boot DHCP, TFTP, HTTP services.
                 type: string
               pxeContainerImage:
                 description: PxeContainerImage - Ironic DHCP/TFTP/HTTP Container Image

--- a/api/bases/ironic.openstack.org_ironics.yaml
+++ b/api/bases/ironic.openstack.org_ironics.yaml
@@ -259,15 +259,6 @@ spec:
                         description: Start - Start of DHCP range
                         type: string
                     type: object
-                  nodeProvisioningAddresses:
-                    additionalProperties:
-                      items:
-                        type: string
-                      type: array
-                    description: NodeProvisioningAddresses Map of nodes to node host
-                      network IP addresses to bind for TFTP/DHCP/HTTP provisioning
-                      services
-                    type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
@@ -290,9 +281,9 @@ spec:
                           in mariadb-operator'
                         type: string
                     type: object
-                  provisioningInterface:
-                    description: ProvisioningInterface - Host network interface used
-                      by Ironic, TFTP, DHCP and HTTP
+                  provisionNetwork:
+                    description: ProvisionNetwork - Additional network to attach to
+                      expose boot DHCP, TFTP, HTTP services.
                     type: string
                   pxeContainerImage:
                     description: PxeContainerImage - Ironic DHCP/TFTP/HTTP Container

--- a/api/v1beta1/ironicconductor_types.go
+++ b/api/v1beta1/ironicconductor_types.go
@@ -43,8 +43,8 @@ type IronicConductorSpec struct {
 	PxeContainerImage string `json:"pxeContainerImage,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// ProvisioningInterface - Host network interface used by Ironic, TFTP, DHCP and HTTP
-	ProvisioningInterface string `json:"provisioningInterface,omitempty"`
+	// ProvisionNetwork - Additional network to attach to expose boot DHCP, TFTP, HTTP services.
+	ProvisionNetwork string `json:"provisionNetwork,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// DHCPRange - DHCP range to use for provisioning
@@ -76,11 +76,6 @@ type IronicConductorSpec struct {
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes for running the Conductor service
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
-
-	// +kubebuilder:validation:Optional
-	// NodeProvisioningAddresses Map of nodes to node host network IP addresses to bind for TFTP/DHCP/HTTP
-	// provisioning services
-	NodeProvisioningAddresses map[string][]string `json:"nodeProvisioningAddresses,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// Debug - enable debug for different deploy stages. If an init container is used, it runs and the

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -283,21 +283,6 @@ func (in *IronicConductorSpec) DeepCopyInto(out *IronicConductorSpec) {
 			(*out)[key] = val
 		}
 	}
-	if in.NodeProvisioningAddresses != nil {
-		in, out := &in.NodeProvisioningAddresses, &out.NodeProvisioningAddresses
-		*out = make(map[string][]string, len(*in))
-		for key, val := range *in {
-			var outVal []string
-			if val == nil {
-				(*out)[key] = nil
-			} else {
-				in, out := &val, &outVal
-				*out = make([]string, len(*in))
-				copy(*out, *in)
-			}
-			(*out)[key] = outVal
-		}
-	}
 	out.Debug = in.Debug
 	if in.DefaultConfigOverwrite != nil {
 		in, out := &in.DefaultConfigOverwrite, &out.DefaultConfigOverwrite

--- a/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
@@ -100,14 +100,6 @@ spec:
                     description: Start - Start of DHCP range
                     type: string
                 type: object
-              nodeProvisioningAddresses:
-                additionalProperties:
-                  items:
-                    type: string
-                  type: array
-                description: NodeProvisioningAddresses Map of nodes to node host network
-                  IP addresses to bind for TFTP/DHCP/HTTP provisioning services
-                type: object
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -129,9 +121,9 @@ spec:
                       password from the Secret TODO: not used, need change in mariadb-operator'
                     type: string
                 type: object
-              provisioningInterface:
-                description: ProvisioningInterface - Host network interface used by
-                  Ironic, TFTP, DHCP and HTTP
+              provisionNetwork:
+                description: ProvisionNetwork - Additional network to attach to expose
+                  boot DHCP, TFTP, HTTP services.
                 type: string
               pxeContainerImage:
                 description: PxeContainerImage - Ironic DHCP/TFTP/HTTP Container Image

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -259,15 +259,6 @@ spec:
                         description: Start - Start of DHCP range
                         type: string
                     type: object
-                  nodeProvisioningAddresses:
-                    additionalProperties:
-                      items:
-                        type: string
-                      type: array
-                    description: NodeProvisioningAddresses Map of nodes to node host
-                      network IP addresses to bind for TFTP/DHCP/HTTP provisioning
-                      services
-                    type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
@@ -290,9 +281,9 @@ spec:
                           in mariadb-operator'
                         type: string
                     type: object
-                  provisioningInterface:
-                    description: ProvisioningInterface - Host network interface used
-                      by Ironic, TFTP, DHCP and HTTP
+                  provisionNetwork:
+                    description: ProvisionNetwork - Additional network to attach to
+                      expose boot DHCP, TFTP, HTTP services.
                     type: string
                   pxeContainerImage:
                     description: PxeContainerImage - Ironic DHCP/TFTP/HTTP Container

--- a/config/samples/ironic_v1beta1_ironic.yaml
+++ b/config/samples/ironic_v1beta1_ironic.yaml
@@ -16,13 +16,5 @@ spec:
   ironicConductor:
     replicas: 1
     containerImage: quay.io/tripleomastercentos9/openstack-ironic-conductor:current-tripleo
-    ## For each node provide the IP address of the interface on the provisioning network
-    #nodeProvisioningAddresses:
-    #  node1:
-    #    - 172.22.0.1
-    #  node2:
-    #    - 172.22.0.2
-    #  node3:
-    #    - 172.22.0.3
     pxeContainerImage: quay.io/tripleomastercentos9/openstack-ironic-pxe:current-tripleo
   secret: ironic-secret

--- a/config/samples/ironic_v1beta1_ironic_standalone.yaml
+++ b/config/samples/ironic_v1beta1_ironic_standalone.yaml
@@ -17,13 +17,5 @@ spec:
   ironicConductor:
     replicas: 1
     containerImage: quay.io/tripleomastercentos9/openstack-ironic-conductor:current-tripleo
-    ## For each node provide the IP address of the interface on the provisioning network
-    #nodeProvisioningAddresses:
-    #  node1:
-    #    - 172.22.0.1
-    #  node2:
-    #    - 172.22.0.2
-    #  node3:
-    #    - 172.22.0.3
     pxeContainerImage: quay.io/tripleomastercentos9/openstack-ironic-pxe:current-tripleo
   secret: ironic-secret

--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -593,7 +593,6 @@ func (r *IronicReconciler) generateServiceConfigMaps(
 	templateParameters := make(map[string]interface{})
 	templateParameters["ServiceUser"] = instance.Spec.ServiceUser
 	templateParameters["KeystoneInternalURL"] = authURL
-	templateParameters["ProvisioningInterface"] = instance.Spec.IronicConductor.ProvisioningInterface
 	templateParameters["DHCPRange"] = instance.Spec.IronicConductor.DHCPRange
 	templateParameters["Standalone"] = instance.Spec.Standalone
 

--- a/pkg/ironicconductor/service.go
+++ b/pkg/ironicconductor/service.go
@@ -1,12 +1,10 @@
 package ironicconductor
 
 import (
-	routev1 "github.com/openshift/api/route/v1"
 	ironicv1 "github.com/openstack-k8s-operators/ironic-operator/api/v1beta1"
 	ironic "github.com/openstack-k8s-operators/ironic-operator/pkg/ironic"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	intstr "k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // Service - Service for conductor pod services
@@ -14,7 +12,6 @@ func Service(
 	serviceName string,
 	instance *ironicv1.IronicConductor,
 	serviceLabels map[string]string,
-	externalIPs []string,
 ) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -30,67 +27,6 @@ func Service(
 					Port:     8089,
 					Protocol: corev1.ProtocolTCP,
 				},
-				{
-					Name:     ironic.HttpbootComponent,
-					Port:     8088,
-					Protocol: corev1.ProtocolTCP,
-				},
-				{
-					Name:     ironic.DhcpComponent,
-					Port:     67,
-					Protocol: corev1.ProtocolUDP,
-				},
-			},
-			// ExternalIPs: externalIPs,
-		},
-	}
-}
-
-// HttpbootRoute - Route for conductor httpboot service
-func HttpbootRoute(
-	serviceName string,
-	instance *ironicv1.IronicConductor,
-	serviceLabels map[string]string,
-) *routev1.Route {
-
-	return &routev1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      serviceName + "-" + ironic.HttpbootComponent,
-			Namespace: instance.Namespace,
-			Labels:    serviceLabels,
-		},
-		Spec: routev1.RouteSpec{
-			To: routev1.RouteTargetReference{
-				Kind: "Service",
-				Name: serviceName,
-			},
-			Port: &routev1.RoutePort{
-				TargetPort: intstr.FromString(ironic.HttpbootComponent),
-			},
-		},
-	}
-}
-
-// DhcpRoute - Route for conductor httpboot service
-func DhcpRoute(
-	serviceName string,
-	instance *ironicv1.IronicConductor,
-	serviceLabels map[string]string,
-) *routev1.Route {
-
-	return &routev1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      serviceName + "-" + ironic.DhcpComponent,
-			Namespace: instance.Namespace,
-			Labels:    serviceLabels,
-		},
-		Spec: routev1.RouteSpec{
-			To: routev1.RouteTargetReference{
-				Kind: "Service",
-				Name: serviceName,
-			},
-			Port: &routev1.RoutePort{
-				TargetPort: intstr.FromString(ironic.DhcpComponent),
 			},
 		},
 	}

--- a/pkg/ironicconductor/statefulset.go
+++ b/pkg/ironicconductor/statefulset.go
@@ -16,6 +16,8 @@ limitations under the License.
 package ironicconductor
 
 import (
+	"fmt"
+
 	ironicv1 "github.com/openstack-k8s-operators/ironic-operator/api/v1beta1"
 	ironic "github.com/openstack-k8s-operators/ironic-operator/pkg/ironic"
 	common "github.com/openstack-k8s-operators/lib-common/modules/common"
@@ -31,6 +33,21 @@ const (
 	// ServiceCommand -
 	ServiceCommand = "/usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start"
 )
+
+// getNetworks List -
+func getNetworksList(
+	instance *ironicv1.IronicConductor,
+) string {
+	networks := "["
+	if instance.Spec.ProvisionNetwork != "" {
+		networks += fmt.Sprintf(
+			`{"name": "%s", "namespace": "%s"}`,
+			instance.Spec.ProvisionNetwork, instance.Namespace,
+		)
+	}
+	networks += "]"
+	return networks
+}
 
 // StatefulSet func
 func StatefulSet(
@@ -185,6 +202,9 @@ func StatefulSet(
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
+					Annotations: map[string]string{
+						"k8s.v1.cni.cncf.io/networks": getNetworksList(instance),
+					},
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: ironic.ServiceAccount,

--- a/templates/ironic/bin/pxe-init.sh
+++ b/templates/ironic/bin/pxe-init.sh
@@ -15,8 +15,9 @@
 # under the License.
 set -ex
 
-# Create HTTP serving directories
-mkdir -p /var/lib/ironic/httpboot/tftpboot/pxelinux.cfg
+# Create TFTP, HTTP serving directories
+mkdir -p /var/lib/ironic/tftpboot/pxelinux.cfg
+mkdir /var/lib/ironic/httpboot
 
 # Check for expected EFI directories
 if [ -d "/boot/efi/EFI/centos" ]; then
@@ -29,10 +30,12 @@ else
 fi
 
 # Copy iPXE and grub files to tftpboot, httpboot
-for dir in httpboot httpboot/tftpboot; do
+for dir in httpboot tftpboot; do
     cp /usr/share/ipxe/ipxe-snponly-x86_64.efi /var/lib/ironic/$dir/snponly.efi
     cp /usr/share/ipxe/undionly.kpxe           /var/lib/ironic/$dir/undionly.kpxe
     cp /usr/share/ipxe/ipxe.lkrn               /var/lib/ironic/$dir/ipxe.lkrn
     cp /boot/efi/EFI/$efi_dir/shimx64.efi      /var/lib/ironic/$dir/bootx64.efi
     cp /boot/efi/EFI/$efi_dir/grubx64.efi      /var/lib/ironic/$dir/grubx64.efi
+    # Ensure all files are readable
+    chmod -R +r /var/lib/ironic/$dir
 done

--- a/templates/ironic/config/dnsmasq.conf
+++ b/templates/ironic/config/dnsmasq.conf
@@ -1,5 +1,7 @@
 # Disable listening for DNS
 port=0
+enable-tftp
+tftp-root=/var/lib/ironic/tftpboot
 
 log-dhcp
 dhcp-range={{ .DHCPRange.Start }},{{ .DHCPRange.End }}

--- a/templates/ironic/config/ironic.conf
+++ b/templates/ironic/config/ironic.conf
@@ -107,7 +107,7 @@ erase_devices_metadata_priority=10
 auth_strategy=noauth
 
 [pxe]
-tftp_root=/var/lib/ironic/httpboot/tftpboot
-tftp_master_path=/var/lib/ironic/httpboot/tftpboot/master_images
+tftp_root=/var/lib/ironic/tftpboot
+tftp_master_path=/var/lib/ironic/tftpboot/master_images
 uefi_pxe_bootfile_name=shimx64.efi
 ipxe_timeout=60


### PR DESCRIPTION
For now NetworkAttachmentDefinition needs to be manually defined, and
the same name used in ProvisionNetwork to expose boot services to an
external interface.

Ideally another operator will take the responsiblity of managing all
NetworkAttachmentDefinition resources (ovs-operator has similar
requirements).