### PR TITLE
Cleanup DB sync job after hash is persisted

### DIFF
--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -436,8 +436,7 @@ func (r *IronicReconciler) reconcileInit(
 	dbSyncjob := job.NewJob(
 		jobDef,
 		ironicv1.DbSyncHash,
-		instance.Spec.PreserveJobs,
-		5,
+		time.Duration(5)*time.Second,
 		dbSyncHash,
 	)
 	ctrlResult, err = dbSyncjob.DoJob(
@@ -467,6 +466,12 @@ func (r *IronicReconciler) reconcileInit(
 			return ctrl.Result{}, err
 		}
 		r.Log.Info(fmt.Sprintf("Job %s hash added - %s", jobDef.Name, instance.Status.Hash[ironicv1.DbSyncHash]))
+	}
+	if !instance.Spec.PreserveJobs {
+		err = job.DeleteAllSucceededJobs(ctx, helper, []string{instance.Status.Hash[ironicv1.DbSyncHash]})
+		if err != nil {
+			return ctrlResult, err
+		}
 	}
 	instance.Status.Conditions.MarkTrue(condition.DBSyncReadyCondition, condition.DBSyncReadyMessage)
 

--- a/go.mod
+++ b/go.mod
@@ -106,3 +106,5 @@ replace sigs.k8s.io/structured-merge-diff/v4 v4.2.2 => sigs.k8s.io/structured-me
 // 3. execute go mod tidy command. After done these, go will auto replace the dev in go.mod to a suitiable pseudo-version.
 // replace github.com/openstack-k8s-operators/lib-common => github.com/<account>/lib-common v0.0.0-20220610121238-abedf5879ca4
 // replace github.com/openstack-k8s-operators/lib-common => /path/to/local/repo
+
+replace github.com/openstack-k8s-operators/lib-common/modules/common => github.com/gibizer/lib-common/modules/common v0.0.0-20221014143800-c6662e4a62ff

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/gibizer/lib-common/modules/common v0.0.0-20221014143800-c6662e4a62ff h1:R3q2BmVaVdvI/0/QUBO5khg7xXidsHQyKUViaFhU2t4=
+github.com/gibizer/lib-common/modules/common v0.0.0-20221014143800-c6662e4a62ff/go.mod h1:KWqK7l2ej+rIYngoNUrxE2YjKGlRAAgJXXM0uU2R6XY=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -264,8 +266,6 @@ github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDD
 github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20220927090553-6b3218c776f7 h1:JaY0kJdZQSc+wFTCvczr2P/sPEUhV9X3awMRJbPn9ig=
 github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20220927090553-6b3218c776f7/go.mod h1:q/owiyXlI2W4uQR4TeHPeeN75AGDfyZgQdNHeKUYN68=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20220928054455-66e396fb480e h1:qM8y8F9NkbI6Gr1h9bPnF1+QbX//Xk4HKhc7NCQgDIw=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20220928054455-66e396fb480e/go.mod h1:KWqK7l2ej+rIYngoNUrxE2YjKGlRAAgJXXM0uU2R6XY=
 github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20220928054455-66e396fb480e h1:xIpjEfuNJzdlKe7HbCFbc+qkcGqKM494lcIsrcUzA6k=
 github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20220928054455-66e396fb480e/go.mod h1:umGUqQO4JtgefAaIwZjP+TxfxsLMEEeK/6VNzk8ooaI=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20220928054455-66e396fb480e h1:Brs8Z28T7Ke2Eowj7jljFvxZn+knLYI/P+PitVoeJWs=


### PR DESCRIPTION
There was a lib-common issue where job.DoJob() deleted the Job right after it is succeeded. Then the controller tried to store the hash of the Job in Status. But if that failed (due to e.g. Conflict) then in the next Reconcile call lib-common would re-create and re-run the Job as the hash of the previous Job and the Job itself is lost.

The lib-common is fixed in a way that the automatic Job deletion is removed from DoJob() and that needs to be now done on the caller side via the new job.DeleteAllSuccededJobs() call.

This patch adapts to the new lib-common version by doing the Job cleanup right after the Status.Update() successfully persisted the Job's hash.

Depends-On: openstack-k8s-operators/lib-common#77