### PR TITLE
Fix defaulting PasswordSelectors

### DIFF
--- a/api/bases/ironic.openstack.org_ironicapis.yaml
+++ b/api/bases/ironic.openstack.org_ironicapis.yaml
@@ -97,18 +97,21 @@ spec:
                   the API service
                 type: object
               passwordSelectors:
+                default:
+                  database: IronicDatabasePassword
+                  service: IronicPassword
                 description: PasswordSelectors - Selectors to identify the DB and
-                  AdminUser password and TransportURL from the Secret
+                  ServiceUser password and TransportURL from the Secret
                 properties:
-                  admin:
-                    default: IronicPassword
-                    description: Database - Selector to get the ironic service password
-                      from the Secret
-                    type: string
                   database:
                     default: IronicDatabasePassword
                     description: 'Database - Selector to get the ironic Database user
                       password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  service:
+                    default: IronicPassword
+                    description: Database - Selector to get the ironic service password
+                      from the Secret
                     type: string
                 type: object
               replicas:

--- a/api/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/api/bases/ironic.openstack.org_ironicconductors.yaml
@@ -107,18 +107,21 @@ spec:
                   the Conductor service
                 type: object
               passwordSelectors:
+                default:
+                  database: IronicDatabasePassword
+                  service: IronicPassword
                 description: PasswordSelectors - Selectors to identify the DB and
-                  AdminUser password and TransportURL from the Secret
+                  ServiceUser password and TransportURL from the Secret
                 properties:
-                  admin:
-                    default: IronicPassword
-                    description: Database - Selector to get the ironic service password
-                      from the Secret
-                    type: string
                   database:
                     default: IronicDatabasePassword
                     description: 'Database - Selector to get the ironic Database user
                       password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  service:
+                    default: IronicPassword
+                    description: Database - Selector to get the ironic service password
+                      from the Secret
                     type: string
                 type: object
               provisionNetwork:

--- a/api/bases/ironic.openstack.org_ironics.yaml
+++ b/api/bases/ironic.openstack.org_ironics.yaml
@@ -137,19 +137,22 @@ spec:
                       running the API service
                     type: object
                   passwordSelectors:
+                    default:
+                      database: IronicDatabasePassword
+                      service: IronicPassword
                     description: PasswordSelectors - Selectors to identify the DB
-                      and AdminUser password and TransportURL from the Secret
+                      and ServiceUser password and TransportURL from the Secret
                     properties:
-                      admin:
-                        default: IronicPassword
-                        description: Database - Selector to get the ironic service
-                          password from the Secret
-                        type: string
                       database:
                         default: IronicDatabasePassword
                         description: 'Database - Selector to get the ironic Database
                           user password from the Secret TODO: not used, need change
                           in mariadb-operator'
+                        type: string
+                      service:
+                        default: IronicPassword
+                        description: Database - Selector to get the ironic service
+                          password from the Secret
                         type: string
                     type: object
                   replicas:
@@ -266,19 +269,22 @@ spec:
                       running the Conductor service
                     type: object
                   passwordSelectors:
+                    default:
+                      database: IronicDatabasePassword
+                      service: IronicPassword
                     description: PasswordSelectors - Selectors to identify the DB
-                      and AdminUser password and TransportURL from the Secret
+                      and ServiceUser password and TransportURL from the Secret
                     properties:
-                      admin:
-                        default: IronicPassword
-                        description: Database - Selector to get the ironic service
-                          password from the Secret
-                        type: string
                       database:
                         default: IronicDatabasePassword
                         description: 'Database - Selector to get the ironic Database
                           user password from the Secret TODO: not used, need change
                           in mariadb-operator'
+                        type: string
+                      service:
+                        default: IronicPassword
+                        description: Database - Selector to get the ironic service
+                          password from the Secret
                         type: string
                     type: object
                   provisionNetwork:
@@ -336,18 +342,21 @@ spec:
                     type: boolean
                 type: object
               passwordSelectors:
+                default:
+                  database: IronicDatabasePassword
+                  service: IronicPassword
                 description: PasswordSelectors - Selectors to identify the DB and
-                  AdminUser password from the Secret
+                  ServiceUser password and TransportURL from the Secret
                 properties:
-                  admin:
-                    default: IronicPassword
-                    description: Database - Selector to get the ironic service password
-                      from the Secret
-                    type: string
                   database:
                     default: IronicDatabasePassword
                     description: 'Database - Selector to get the ironic Database user
                       password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  service:
+                    default: IronicPassword
+                    description: Database - Selector to get the ironic service password
+                      from the Secret
                     type: string
                 type: object
               preserveJobs:

--- a/api/v1beta1/ironic_types.go
+++ b/api/v1beta1/ironic_types.go
@@ -58,7 +58,8 @@ type IronicSpec struct {
 	Secret string `json:"secret,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// PasswordSelectors - Selectors to identify the DB and AdminUser password from the Secret
+	// +kubebuilder:default={database: IronicDatabasePassword, service: IronicPassword}
+	// PasswordSelectors - Selectors to identify the DB and ServiceUser password and TransportURL from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 
 	// +kubebuilder:validation:Optional
@@ -103,7 +104,7 @@ type PasswordSelector struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="IronicPassword"
 	// Database - Selector to get the ironic service password from the Secret
-	Service string `json:"admin,omitempty"`
+	Service string `json:"service,omitempty"`
 }
 
 // DHCPRange to define address range for DHCP requestes

--- a/api/v1beta1/ironicapi_types.go
+++ b/api/v1beta1/ironicapi_types.go
@@ -58,7 +58,8 @@ type IronicAPISpec struct {
 	Secret string `json:"secret,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// PasswordSelectors - Selectors to identify the DB and AdminUser password and TransportURL from the Secret
+	// +kubebuilder:default={database: IronicDatabasePassword, service: IronicPassword}
+	// PasswordSelectors - Selectors to identify the DB and ServiceUser password and TransportURL from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/ironicconductor_types.go
+++ b/api/v1beta1/ironicconductor_types.go
@@ -70,7 +70,8 @@ type IronicConductorSpec struct {
 	Secret string `json:"secret,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// PasswordSelectors - Selectors to identify the DB and AdminUser password and TransportURL from the Secret
+	// +kubebuilder:default={database: IronicDatabasePassword, service: IronicPassword}
+	// PasswordSelectors - Selectors to identify the DB and ServiceUser password and TransportURL from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/ironic.openstack.org_ironicapis.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicapis.yaml
@@ -97,18 +97,21 @@ spec:
                   the API service
                 type: object
               passwordSelectors:
+                default:
+                  database: IronicDatabasePassword
+                  service: IronicPassword
                 description: PasswordSelectors - Selectors to identify the DB and
-                  AdminUser password and TransportURL from the Secret
+                  ServiceUser password and TransportURL from the Secret
                 properties:
-                  admin:
-                    default: IronicPassword
-                    description: Database - Selector to get the ironic service password
-                      from the Secret
-                    type: string
                   database:
                     default: IronicDatabasePassword
                     description: 'Database - Selector to get the ironic Database user
                       password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  service:
+                    default: IronicPassword
+                    description: Database - Selector to get the ironic service password
+                      from the Secret
                     type: string
                 type: object
               replicas:

--- a/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
@@ -107,18 +107,21 @@ spec:
                   the Conductor service
                 type: object
               passwordSelectors:
+                default:
+                  database: IronicDatabasePassword
+                  service: IronicPassword
                 description: PasswordSelectors - Selectors to identify the DB and
-                  AdminUser password and TransportURL from the Secret
+                  ServiceUser password and TransportURL from the Secret
                 properties:
-                  admin:
-                    default: IronicPassword
-                    description: Database - Selector to get the ironic service password
-                      from the Secret
-                    type: string
                   database:
                     default: IronicDatabasePassword
                     description: 'Database - Selector to get the ironic Database user
                       password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  service:
+                    default: IronicPassword
+                    description: Database - Selector to get the ironic service password
+                      from the Secret
                     type: string
                 type: object
               provisionNetwork:

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -137,19 +137,22 @@ spec:
                       running the API service
                     type: object
                   passwordSelectors:
+                    default:
+                      database: IronicDatabasePassword
+                      service: IronicPassword
                     description: PasswordSelectors - Selectors to identify the DB
-                      and AdminUser password and TransportURL from the Secret
+                      and ServiceUser password and TransportURL from the Secret
                     properties:
-                      admin:
-                        default: IronicPassword
-                        description: Database - Selector to get the ironic service
-                          password from the Secret
-                        type: string
                       database:
                         default: IronicDatabasePassword
                         description: 'Database - Selector to get the ironic Database
                           user password from the Secret TODO: not used, need change
                           in mariadb-operator'
+                        type: string
+                      service:
+                        default: IronicPassword
+                        description: Database - Selector to get the ironic service
+                          password from the Secret
                         type: string
                     type: object
                   replicas:
@@ -266,19 +269,22 @@ spec:
                       running the Conductor service
                     type: object
                   passwordSelectors:
+                    default:
+                      database: IronicDatabasePassword
+                      service: IronicPassword
                     description: PasswordSelectors - Selectors to identify the DB
-                      and AdminUser password and TransportURL from the Secret
+                      and ServiceUser password and TransportURL from the Secret
                     properties:
-                      admin:
-                        default: IronicPassword
-                        description: Database - Selector to get the ironic service
-                          password from the Secret
-                        type: string
                       database:
                         default: IronicDatabasePassword
                         description: 'Database - Selector to get the ironic Database
                           user password from the Secret TODO: not used, need change
                           in mariadb-operator'
+                        type: string
+                      service:
+                        default: IronicPassword
+                        description: Database - Selector to get the ironic service
+                          password from the Secret
                         type: string
                     type: object
                   provisionNetwork:
@@ -336,18 +342,21 @@ spec:
                     type: boolean
                 type: object
               passwordSelectors:
+                default:
+                  database: IronicDatabasePassword
+                  service: IronicPassword
                 description: PasswordSelectors - Selectors to identify the DB and
-                  AdminUser password from the Secret
+                  ServiceUser password and TransportURL from the Secret
                 properties:
-                  admin:
-                    default: IronicPassword
-                    description: Database - Selector to get the ironic service password
-                      from the Secret
-                    type: string
                   database:
                     default: IronicDatabasePassword
                     description: 'Database - Selector to get the ironic Database user
                       password from the Secret TODO: not used, need change in mariadb-operator'
+                    type: string
+                  service:
+                    default: IronicPassword
+                    description: Database - Selector to get the ironic service password
+                      from the Secret
                     type: string
                 type: object
               preserveJobs:


### PR DESCRIPTION
When a CRD has an optional struct field the defaulting of that field needs special care. Both the field with the struct type need a full default value defined and each individual subfields in the struct needs default value defined. Otherwise in the first reconcile call the PasswordSelectors is empty and then in the second reconcile it is filled.

Now documented via https://github.com/openstack-k8s-operators/docs/pull/12