### PR TITLE
Add handling for top level NodeSelector

### DIFF
--- a/api/bases/ironic.openstack.org_ironicapis.yaml
+++ b/api/bases/ironic.openstack.org_ironicapis.yaml
@@ -93,8 +93,9 @@ spec:
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector to target subset of worker nodes for running
-                  the API service
+                description: NodeSelector to target subset of worker nodes running
+                  this service. Setting here overrides any global NodeSelector settings
+                  within the Ironic CR
                 type: object
               passwordSelectors:
                 default:

--- a/api/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/api/bases/ironic.openstack.org_ironicconductors.yaml
@@ -103,8 +103,9 @@ spec:
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector to target subset of worker nodes for running
-                  the Conductor service
+                description: NodeSelector to target subset of worker nodes running
+                  this service. Setting here overrides any global NodeSelector settings
+                  within the Ironic CR
                 type: object
               passwordSelectors:
                 default:

--- a/api/bases/ironic.openstack.org_ironics.yaml
+++ b/api/bases/ironic.openstack.org_ironics.yaml
@@ -133,8 +133,9 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector to target subset of worker nodes for
-                      running the API service
+                    description: NodeSelector to target subset of worker nodes running
+                      this service. Setting here overrides any global NodeSelector
+                      settings within the Ironic CR
                     type: object
                   passwordSelectors:
                     default:
@@ -265,8 +266,9 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector to target subset of worker nodes for
-                      running the Conductor service
+                    description: NodeSelector to target subset of worker nodes running
+                      this service. Setting here overrides any global NodeSelector
+                      settings within the Ironic CR
                     type: object
                   passwordSelectors:
                     default:
@@ -353,7 +355,8 @@ spec:
                 additionalProperties:
                   type: string
                 description: NodeSelector to target subset of worker nodes running
-                  this service
+                  this service. Setting NodeSelector here acts as a default value
+                  and can be overridden by service specific NodeSelector Settings.
                 type: object
               passwordSelectors:
                 default:

--- a/api/bases/ironic.openstack.org_ironics.yaml
+++ b/api/bases/ironic.openstack.org_ironics.yaml
@@ -349,6 +349,12 @@ spec:
                 required:
                 - storageRequest
                 type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector to target subset of worker nodes running
+                  this service
+                type: object
               passwordSelectors:
                 default:
                   database: IronicDatabasePassword

--- a/api/v1beta1/ironic_types.go
+++ b/api/v1beta1/ironic_types.go
@@ -92,6 +92,12 @@ type IronicSpec struct {
 	// +kubebuilder:validation:Required
 	// IronicAPI - Spec definition for the conductor service of this Ironic deployment
 	IronicConductor IronicConductorSpec `json:"ironicConductor"`
+
+	// +kubebuilder:validation:Optional
+	// NodeSelector to target subset of worker nodes running this service. Setting
+	// NodeSelector here acts as a default value and can be overridden by service
+	// specific NodeSelector Settings.
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 
 // PasswordSelector to identify the DB and AdminUser password from the Secret

--- a/api/v1beta1/ironicapi_types.go
+++ b/api/v1beta1/ironicapi_types.go
@@ -63,7 +63,8 @@ type IronicAPISpec struct {
 	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Optional
-	// NodeSelector to target subset of worker nodes for running the API service
+	// NodeSelector to target subset of worker nodes running this service. Setting here overrides
+	// any global NodeSelector settings within the Ironic CR
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/ironicconductor_types.go
+++ b/api/v1beta1/ironicconductor_types.go
@@ -75,7 +75,8 @@ type IronicConductorSpec struct {
 	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Optional
-	// NodeSelector to target subset of worker nodes for running the Conductor service
+	// NodeSelector to target subset of worker nodes running this service. Setting here overrides
+	// any global NodeSelector settings within the Ironic CR
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/ironic.openstack.org_ironicapis.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicapis.yaml
@@ -93,8 +93,9 @@ spec:
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector to target subset of worker nodes for running
-                  the API service
+                description: NodeSelector to target subset of worker nodes running
+                  this service. Setting here overrides any global NodeSelector settings
+                  within the Ironic CR
                 type: object
               passwordSelectors:
                 default:

--- a/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
@@ -103,8 +103,9 @@ spec:
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector to target subset of worker nodes for running
-                  the Conductor service
+                description: NodeSelector to target subset of worker nodes running
+                  this service. Setting here overrides any global NodeSelector settings
+                  within the Ironic CR
                 type: object
               passwordSelectors:
                 default:

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -133,8 +133,9 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector to target subset of worker nodes for
-                      running the API service
+                    description: NodeSelector to target subset of worker nodes running
+                      this service. Setting here overrides any global NodeSelector
+                      settings within the Ironic CR
                     type: object
                   passwordSelectors:
                     default:
@@ -265,8 +266,9 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector to target subset of worker nodes for
-                      running the Conductor service
+                    description: NodeSelector to target subset of worker nodes running
+                      this service. Setting here overrides any global NodeSelector
+                      settings within the Ironic CR
                     type: object
                   passwordSelectors:
                     default:
@@ -353,7 +355,8 @@ spec:
                 additionalProperties:
                   type: string
                 description: NodeSelector to target subset of worker nodes running
-                  this service
+                  this service. Setting NodeSelector here acts as a default value
+                  and can be overridden by service specific NodeSelector Settings.
                 type: object
               passwordSelectors:
                 default:

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -349,6 +349,12 @@ spec:
                 required:
                 - storageRequest
                 type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector to target subset of worker nodes running
+                  this service
+                type: object
               passwordSelectors:
                 default:
                   database: IronicDatabasePassword

--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -514,6 +514,7 @@ func (r *IronicReconciler) conductorDeploymentCreateOrUpdate(instance *ironicv1.
 		deployment.Spec.DatabaseHostname = instance.Status.DatabaseHostname
 		deployment.Spec.DatabaseUser = instance.Spec.DatabaseUser
 		deployment.Spec.Secret = instance.Spec.Secret
+		deployment.Spec.NodeSelector = instance.Spec.NodeSelector
 
 		err := controllerutil.SetControllerReference(instance, deployment, r.Scheme)
 		if err != nil {
@@ -555,10 +556,8 @@ func (r *IronicReconciler) apiDeploymentCreateOrUpdate(instance *ironicv1.Ironic
 	return deployment, op, err
 }
 
-//
 // generateServiceConfigMaps - create create configmaps which hold scripts and service configuration
 // TODO add DefaultConfigOverwrite
-//
 func (r *IronicReconciler) generateServiceConfigMaps(
 	ctx context.Context,
 	instance *ironicv1.Ironic,
@@ -626,10 +625,8 @@ func (r *IronicReconciler) generateServiceConfigMaps(
 	return nil
 }
 
-//
 // createHashOfInputHashes - creates a hash of hashes which gets added to the resources which requires a restart
 // if any of the input resources change, like configs, passwords, ...
-//
 func (r *IronicReconciler) createHashOfInputHashes(
 	ctx context.Context,
 	instance *ironicv1.Ironic,

--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -514,8 +514,9 @@ func (r *IronicReconciler) conductorDeploymentCreateOrUpdate(instance *ironicv1.
 		deployment.Spec.DatabaseHostname = instance.Status.DatabaseHostname
 		deployment.Spec.DatabaseUser = instance.Spec.DatabaseUser
 		deployment.Spec.Secret = instance.Spec.Secret
-		deployment.Spec.NodeSelector = instance.Spec.NodeSelector
-
+		if len(deployment.Spec.NodeSelector) == 0 {
+			deployment.Spec.NodeSelector = instance.Spec.NodeSelector
+		}
 		err := controllerutil.SetControllerReference(instance, deployment, r.Scheme)
 		if err != nil {
 			return err
@@ -544,6 +545,9 @@ func (r *IronicReconciler) apiDeploymentCreateOrUpdate(instance *ironicv1.Ironic
 		deployment.Spec.DatabaseHostname = instance.Status.DatabaseHostname
 		deployment.Spec.DatabaseUser = instance.Spec.DatabaseUser
 		deployment.Spec.Secret = instance.Spec.Secret
+		if len(deployment.Spec.NodeSelector) == 0 {
+			deployment.Spec.NodeSelector = instance.Spec.NodeSelector
+		}
 
 		err := controllerutil.SetControllerReference(instance, deployment, r.Scheme)
 		if err != nil {


### PR DESCRIPTION
Users should be able to define a nodeSelector at the top level and override it for any individual CR. If it's not changed in individual CR's, it should default to the top level nodeSelector.