### PR TITLE
add_service_db_finalizer_logic

### DIFF
--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -188,6 +188,18 @@ func (r *IronicReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *IronicReconciler) reconcileDelete(ctx context.Context, instance *ironicv1.Ironic, helper *helper.Helper) (ctrl.Result, error) {
 	r.Log.Info("Reconciling Ironic delete")
 
+	// remove db finalizer first
+	db, err := database.GetDatabaseByName(ctx, helper, instance.Name)
+	if err != nil && !k8s_errors.IsNotFound(err) {
+		return ctrl.Result{}, err
+	}
+
+	if !k8s_errors.IsNotFound(err) {
+		if err := db.DeleteFinalizer(ctx, helper); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
 	// Service is deleted so remove the finalizer.
 	controllerutil.RemoveFinalizer(instance, helper.GetFinalizer())
 	r.Log.Info("Reconciled Ironic delete successfully")


### PR DESCRIPTION
Ever since  : https://github.com/openstack-k8s-operators/lib-common/pull/87

Podified operators which use service dbs and the db.CreateOrPatchDB method , now will get the finalizer set on the db automatically when using the newest lib-common, but they won't have the code remove it on cleanup i.e reconcileDelete, which might make the delete operator action hang.

This adds the service Db removal code in the operator delete (reconcileDelete) function to work with the above.

Also updated lib-common to latest as to not break lib-common's exported functions