### PR TITLE
Use public endpoint for www_authenticate_uri

### DIFF
--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -649,13 +649,18 @@ func (r *IronicReconciler) generateServiceConfigMaps(
 	if err != nil {
 		return err
 	}
-	authURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointInternal)
+	keystoneInternalURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointInternal)
+	if err != nil {
+		return err
+	}
+	keystonePublicURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointPublic)
 	if err != nil {
 		return err
 	}
 	templateParameters := make(map[string]interface{})
 	templateParameters["ServiceUser"] = instance.Spec.ServiceUser
-	templateParameters["KeystoneInternalURL"] = authURL
+	templateParameters["KeystoneInternalURL"] = keystoneInternalURL
+	templateParameters["KeystonePublicURL"] = keystonePublicURL
 	templateParameters["DHCPRange"] = instance.Spec.IronicConductor.DHCPRange
 	templateParameters["Standalone"] = instance.Spec.Standalone
 

--- a/templates/ironic/config/ironic.conf
+++ b/templates/ironic/config/ironic.conf
@@ -37,7 +37,7 @@ project_domain_name=Default
 user_domain_name=Default
 project_name=service
 username={{ .ServiceUser }}
-www_authenticate_uri={{ .KeystoneInternalURL }}
+www_authenticate_uri={{ .KeystonePublicURL }}
 auth_url={{ .KeystoneInternalURL }}
 auth_type=password
 


### PR DESCRIPTION
The [keystone_authtoken] www_authenticate_uri option should point public endpoint instead of internal endpoint, because the uri is returned to clients when authentication fails.