### PR TITLE
Only probe JSON-RPC port when use json-rpc transport

### DIFF
--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -562,6 +562,7 @@ func (r *IronicReconciler) conductorDeploymentCreateOrUpdate(instance *ironicv1.
 		deployment.Spec.DatabaseUser = instance.Spec.DatabaseUser
 		deployment.Spec.Secret = instance.Spec.Secret
 		deployment.Spec.TransportURLSecret = instance.Status.TransportURLSecret
+		deployment.Spec.RPCTransport = instance.Spec.RPCTransport
 
 		if len(deployment.Spec.NodeSelector) == 0 {
 			deployment.Spec.NodeSelector = instance.Spec.NodeSelector
@@ -684,12 +685,10 @@ func (r *IronicReconciler) generateServiceConfigMaps(
 	return nil
 }
 
-//
 // createHashOfInputHashes - creates a hash of hashes which gets added to the resources which requires a restart
 // if any of the input resources change, like configs, passwords, ...
 //
 // returns the hash, whether the hash changed (as a bool) and any error
-//
 func (r *IronicReconciler) createHashOfInputHashes(
 	ctx context.Context,
 	instance *ironicv1.Ironic,
@@ -709,9 +708,7 @@ func (r *IronicReconciler) createHashOfInputHashes(
 	return hash, changed, nil
 }
 
-//
 // transportURLCreateOrUpdate - creates or updates rabbitmq transport URL
-//
 func (r *IronicReconciler) transportURLCreateOrUpdate(instance *ironicv1.Ironic) (*rabbitmqv1.TransportURL, controllerutil.OperationResult, error) {
 	transportURL := &rabbitmqv1.TransportURL{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/ironicconductor/statefulset.go
+++ b/pkg/ironicconductor/statefulset.go
@@ -131,17 +131,33 @@ func StatefulSet(
 		//
 		// https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 		//
-		// Make a POST request to the JSON-RPC port
-		livenessProbe.Exec = &corev1.ExecAction{
-			Command: []string{
-				"sh", "-c", "ss -ltn | grep :8089",
-			},
-		}
-		// Make a POST request to the JSON-RPC port
-		readinessProbe.Exec = &corev1.ExecAction{
-			Command: []string{
-				"sh", "-c", "ss -ltn | grep :8089",
-			},
+
+		if instance.Spec.RPCTransport == "json-rpc" {
+			// Make a POST request to the JSON-RPC port
+			livenessProbe.Exec = &corev1.ExecAction{
+				Command: []string{
+					"sh", "-c", "ss -ltn | grep :8089",
+				},
+			}
+			// Make a POST request to the JSON-RPC port
+			readinessProbe.Exec = &corev1.ExecAction{
+				Command: []string{
+					"sh", "-c", "ss -ltn | grep :8089",
+				},
+			}
+		} else {
+			// TODO
+			livenessProbe.Exec = &corev1.ExecAction{
+				Command: []string{
+					"/bin/true",
+				},
+			}
+			// TODO
+			readinessProbe.Exec = &corev1.ExecAction{
+				Command: []string{
+					"/bin/true",
+				},
+			}
 		}
 		httpbootLivenessProbe.Exec = &corev1.ExecAction{
 			Command: []string{


### PR DESCRIPTION
When using "oslo" transport we should not probe the json-rpc port 8089. The probe fails and the container keeps restarting.