### PR TITLE
Build esp.img with mtools, drop privileged from init container

### DIFF
--- a/pkg/ironic/initcontainer.go
+++ b/pkg/ironic/initcontainer.go
@@ -54,20 +54,6 @@ const (
 // InitContainer - init container for Ironic pods
 func InitContainer(init APIDetails) []corev1.Container {
 	runAsUser := int64(0)
-	trueVar := true
-
-	securityContext := &corev1.SecurityContext{
-		RunAsUser: &runAsUser,
-		Capabilities: &corev1.Capabilities{
-			Add: []corev1.Capability{
-				"MKNOD",
-			},
-		},
-	}
-
-	if init.Privileged {
-		securityContext.Privileged = &trueVar
-	}
 
 	envVars := map[string]env.Setter{}
 	envVars["DatabaseHost"] = env.SetValue(init.DatabaseHost)
@@ -170,15 +156,11 @@ func InitContainer(init APIDetails) []corev1.Container {
 		containers = append(containers, pxeInit)
 	}
 	if init.ConductorInit {
-		priv := true
 		conductorInit := corev1.Container{
 			Name:  "conductor-init",
 			Image: init.ContainerImage,
 			SecurityContext: &corev1.SecurityContext{
-				RunAsUser:  &runAsUser,
-				Privileged: &priv, // required for building esp.img (mount)
-				// TODO: try again to get this working with Capability SYS_ADMIN
-				// instead of privileged
+				RunAsUser: &runAsUser,
 			},
 			Command: []string{
 				"/bin/bash",

--- a/templates/ironic/bin/conductor-init.sh
+++ b/templates/ironic/bin/conductor-init.sh
@@ -37,17 +37,14 @@ fi
 # Build an ESP image
 pushd /var/lib/ironic/httpboot
 if [ ! -a "esp.img" ]; then
-    dd if=/dev/zero of=/tmp/esp.img bs=4096 count=1024
-    mkfs.fat -s 4 -r 512 -S 4096 /tmp/esp.img
+    dd if=/dev/zero of=esp.img bs=4096 count=1024
+    mkfs.msdos -F 12 -n 'ESP_IMAGE' esp.img
 
-    ESP_IMAGE_DIR=$(mktemp -t -d esp.XXXXXXXX)
-    mount /tmp/esp.img $ESP_IMAGE_DIR
-    mkdir -p $ESP_IMAGE_DIR/EFI/BOOT
-    cp bootx64.efi $ESP_IMAGE_DIR/EFI/BOOT/BOOTX64.efi
-    cp grubx64.efi $ESP_IMAGE_DIR/EFI/BOOT/GRUBX64.efi
-    umount $ESP_IMAGE_DIR
-
-    cp /tmp/esp.img ./
+    mmd -i esp.img EFI
+    mmd -i esp.img EFI/BOOT
+    mcopy -i esp.img -v bootx64.efi ::EFI/BOOT
+    mcopy -i esp.img -v grubx64.efi ::EFI/BOOT
+    mdir -i esp.img ::EFI/BOOT;
 fi
 popd
 


### PR DESCRIPTION
Building esp.img with mtools means mount isn't required, which means the conductor init container no longer needs to run as a privileged container.

This is the same mtools recipe used in the metal3 image[1]

[1] https://github.com/metal3-io/ironic-image/blob/main/prepare-efi.sh#L37-L44