### PR TITLE
Correctly configure [DEFAULT]isolinux_bin

### DIFF
--- a/templates/ironic/config/ironic.conf
+++ b/templates/ironic/config/ironic.conf
@@ -30,6 +30,7 @@ tempdir=/var/lib/ironic/tmp
 auth_strategy={{if .Standalone}}noauth{{else}}keystone{{end}}
 
 grub_config_path=EFI/BOOT/grub.cfg
+isolinux_bin=/usr/share/syslinux/isolinux.bin
 
 {{if not .Standalone}}
 [keystone_authtoken]


### PR DESCRIPTION
The default value is /usr/lib/syslinux/isolinux.bin which is different to what the syslinux-nonlinux package installs.

This file won't exist until this dependency change[1] reaches the container image.

[1] https://review.rdoproject.org/r/c/openstack/ironic-distgit/+/46663