### PR TITLE
Don't pass DatabaseUser from ironic to inspector

### DIFF
--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -777,7 +777,11 @@ func (r *IronicReconciler) inspectorDeploymentCreateOrUpdate(
 			deployment.Spec.Standalone = instance.Spec.Standalone
 			deployment.Spec.ServiceUser = instance.Spec.ServiceUser
 			deployment.Spec.DatabaseHostname = instance.Status.DatabaseHostname
-			deployment.Spec.DatabaseUser = instance.Spec.DatabaseUser
+			// TODO: Revist DatabaseUser - It is currently implemented in lib-common,
+			//       but not in mariadb-operator. mariadb-operator always creates
+			//       database user with name == .DatabaseName
+			//       See: https://raw.githubusercontent.com/openstack-k8s-operators/mariadb-operator/master/templates/database.sh
+			// deployment.Spec.DatabaseUser = instance.Spec.DatabaseUser
 			deployment.Spec.DatabaseInstance = instance.Spec.DatabaseInstance
 			deployment.Spec.Secret = instance.Spec.Secret
 			deployment.Spec.RPCTransport = instance.Spec.RPCTransport


### PR DESCRIPTION
It does not work, the `DatabaseUser` is actually not configurable in the mariadb-operator ... the user defaults to `.DatabaseName`.

See: https://raw.githubusercontent.com/openstack-k8s-operators/mariadb-operator/master/templates/database.sh