### PR TITLE
Don't pass ServiceUser to Inspector

### DIFF
--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -775,7 +775,6 @@ func (r *IronicReconciler) inspectorDeploymentCreateOrUpdate(
 			// Add in transfers from umbrella Ironic (this instance) spec
 			// TODO: Add logic to determine when to set/overwrite, etc
 			deployment.Spec.Standalone = instance.Spec.Standalone
-			deployment.Spec.ServiceUser = instance.Spec.ServiceUser
 			deployment.Spec.DatabaseHostname = instance.Status.DatabaseHostname
 			deployment.Spec.DatabaseUser = instance.Spec.DatabaseUser
 			deployment.Spec.DatabaseInstance = instance.Spec.DatabaseInstance


### PR DESCRIPTION
Let's keep the ServiceUser for Inspector separate like we used to with TripleO?

```
+----------------------------------+------------------+
| ID                               | Name             |
+----------------------------------+------------------+
| f2c959795e7841ecb51f25ab6d7a177a | ironic           |
| a71fc9ce71ae4de6a9cf3f6a32407cb6 | ironic-inspector |
+----------------------------------+------------------+
```