### PR TITLE
Fix IngressDomain for CRC environments

### DIFF
--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -489,6 +489,10 @@ func (r *IronicConductorReconciler) reconcileNormal(ctx context.Context, instanc
 		common.AppSelector:       ironic.ServiceName,
 		ironic.ComponentSelector: ironic.HttpbootComponent,
 	}
+	// TODO: Ideally we would be able to get the ingress domain from the kubernetes API
+	//       and avoid the "Requeue to inject IngressDomain into conductor pods" in reconcileServices()
+	//   `$ oc -n openshift-ingress-operator get ingresscontrollers.operator.openshift.io/default -o json | jq .status.domain
+	//   "apps.shiftstack.ocp.lab.example.com"`
 	ingressDomain := ironicconductor.IngressDomain(ctx, instance, helper, conductorRouteLabels)
 
 	// Define a new StatefulSet object

--- a/pkg/ironicconductor/service.go
+++ b/pkg/ironicconductor/service.go
@@ -108,5 +108,5 @@ func IngressDomain(
 		return ""
 	}
 	hostname := routeList.Items[0].Spec.Host
-	return strings.Split(hostname, ".apps.")[1]
+	return strings.SplitN(hostname, ".", 2)[1]
 }

--- a/pkg/ironicconductor/statefulset.go
+++ b/pkg/ironicconductor/statefulset.go
@@ -305,7 +305,7 @@ func StatefulSet(
 	deployHTTPURL := "http://%(ProvisionNetworkIP)s:8088/"
 	if instance.Spec.ProvisionNetwork == "" {
 		// Build what the fully qualified Route hostname will be when the Route exists
-		deployHTTPURL = "http://%(PodName)s-%(PodNamespace)s.apps.%(IngressDomain)s/"
+		deployHTTPURL = "http://%(PodName)s-%(PodNamespace)s.%(IngressDomain)s/"
 	}
 
 	initContainerDetails := ironic.APIDetails{

--- a/pkg/ironicinspector/service.go
+++ b/pkg/ironicinspector/service.go
@@ -98,5 +98,5 @@ func IngressDomain(
 		return ""
 	}
 	hostname := routeList.Items[0].Spec.Host
-	return strings.Split(hostname, ".apps.")[1]
+	return strings.SplitN(hostname, ".", 2)[1]
 }

--- a/pkg/ironicinspector/statefulset.go
+++ b/pkg/ironicinspector/statefulset.go
@@ -269,7 +269,7 @@ func StatefulSet(
 	inspectorHTTPURL := "http://%(InspectorNetworkIP)s:8088/"
 	if instance.Spec.InspectionNetwork == "" {
 		// Build what the fully qualified Route hostname will be when the Route exists
-		inspectorHTTPURL = "http://%(PodName)s-%(PodNamespace)s.apps.%(IngressDomain)s/"
+		inspectorHTTPURL = "http://%(PodName)s-%(PodNamespace)s.%(IngressDomain)s/"
 	}
 
 	initContainerDetails := APIDetails{


### PR DESCRIPTION
In CRC environments the IngressDomain is apps-crc.testing. Splitting on `.apps.` does not work in this case.

This changes the methid to get IngressDomain of the route to instead split on `.` and limit the split to the first occurrence.

Jira: [OSP-22249](https://issues.redhat.com//browse/OSP-22249)