### PR TITLE
Get Ingress Domain from API

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -244,6 +244,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - operator.openshift.io
+  resources:
+  - ingresscontrollers
+  verbs:
+  - get
+  - list
+- apiGroups:
   - rabbitmq.openstack.org
   resources:
   - transporturls

--- a/pkg/ironicconductor/service.go
+++ b/pkg/ironicconductor/service.go
@@ -1,17 +1,12 @@
 package ironicconductor
 
 import (
-	"context"
-	"strings"
-
 	routev1 "github.com/openshift/api/route/v1"
 	ironicv1 "github.com/openstack-k8s-operators/ironic-operator/api/v1beta1"
 	ironic "github.com/openstack-k8s-operators/ironic-operator/pkg/ironic"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Service - Service for conductor pod services
@@ -84,29 +79,4 @@ func Route(
 			Port: routePort,
 		},
 	}
-}
-
-// IngressDomain - List existing conductor routes to extract the IngressDomain
-func IngressDomain(
-	ctx context.Context,
-	instance *ironicv1.IronicConductor,
-	helper *helper.Helper,
-	routeLabels map[string]string,
-) string {
-	routeList := &routev1.RouteList{}
-	listOpts := []client.ListOption{
-		client.InNamespace(instance.Namespace),
-	}
-	labels := client.MatchingLabels(routeLabels)
-	listOpts = append(listOpts, labels)
-	err := helper.GetClient().List(ctx, routeList, listOpts...)
-	if err != nil {
-		return ""
-	}
-
-	if len(routeList.Items) == 0 {
-		return ""
-	}
-	hostname := routeList.Items[0].Spec.Host
-	return strings.Split(hostname, ".apps.")[1]
 }

--- a/pkg/ironicinspector/service.go
+++ b/pkg/ironicinspector/service.go
@@ -1,17 +1,12 @@
 package ironicinspector
 
 import (
-	"context"
-	"strings"
-
 	routev1 "github.com/openshift/api/route/v1"
 	ironicv1 "github.com/openstack-k8s-operators/ironic-operator/api/v1beta1"
 	ironic "github.com/openstack-k8s-operators/ironic-operator/pkg/ironic"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Service - Service for conductor pod services
@@ -74,29 +69,4 @@ func Route(
 			Port: routePort,
 		},
 	}
-}
-
-// IngressDomain - List existing conductor routes to extract the IngressDomain
-func IngressDomain(
-	ctx context.Context,
-	instance *ironicv1.IronicInspector,
-	helper *helper.Helper,
-	routeLabels map[string]string,
-) string {
-	routeList := &routev1.RouteList{}
-	listOpts := []client.ListOption{
-		client.InNamespace(instance.Namespace),
-	}
-	labels := client.MatchingLabels(routeLabels)
-	listOpts = append(listOpts, labels)
-	err := helper.GetClient().List(ctx, routeList, listOpts...)
-	if err != nil {
-		return ""
-	}
-
-	if len(routeList.Items) == 0 {
-		return ""
-	}
-	hostname := routeList.Items[0].Spec.Host
-	return strings.Split(hostname, ".apps.")[1]
 }

--- a/pkg/ironicinspector/statefulset.go
+++ b/pkg/ironicinspector/statefulset.go
@@ -269,7 +269,7 @@ func StatefulSet(
 	inspectorHTTPURL := "http://%(InspectorNetworkIP)s:8088/"
 	if instance.Spec.InspectionNetwork == "" {
 		// Build what the fully qualified Route hostname will be when the Route exists
-		inspectorHTTPURL = "http://%(PodName)s-%(PodNamespace)s.apps.%(IngressDomain)s/"
+		inspectorHTTPURL = "http://%(PodName)s-%(PodNamespace)s.%(IngressDomain)s/"
 	}
 
 	initContainerDetails := APIDetails{


### PR DESCRIPTION
Add RBAC rules to allow the operator to get and list
```
 apiGroups: operator.openshift.io
 resources: ingresscontrollers
```

Add `GetIngressDomain()` method to inspector and conductor contollers. This method uses an unstructored object to get the default openshift-ingress-operator IngressController and parses the result to get the ingressDomain.

Since the ingressDomain is resolved prior to creating statefulsets and routes we no longer need to requeue to to inject the IngressDomain.