### PR TITLE
Fix Inspector status and APIEndpoints+ServiceIDs

### DIFF
--- a/api/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/api/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -330,7 +330,7 @@ spec:
                   type: string
                 type: array
               readyCount:
-                description: ReadyCount of ironic Conductor instances
+                description: ReadyCount of Ironic Inspector instances
                 format: int32
                 type: integer
               serviceIDs:

--- a/api/v1beta1/ironicinspector_types.go
+++ b/api/v1beta1/ironicinspector_types.go
@@ -154,7 +154,7 @@ type IronicInspectorStatus struct {
 	// IronicInspector Database Hostname
 	DatabaseHostname string `json:"databaseHostname,omitempty"`
 
-	// ReadyCount of ironic Conductor instances
+	// ReadyCount of Ironic Inspector instances
 	ReadyCount int32 `json:"readyCount,omitempty"`
 
 	// ServiceIDs

--- a/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -330,7 +330,7 @@ spec:
                   type: string
                 type: array
               readyCount:
-                description: ReadyCount of ironic Conductor instances
+                description: ReadyCount of Ironic Inspector instances
                 format: int32
                 type: integer
               serviceIDs:

--- a/controllers/ironicapi_controller.go
+++ b/controllers/ironicapi_controller.go
@@ -176,13 +176,13 @@ func (r *IronicAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, nil
 	}
 	if instance.Status.Hash == nil {
-		instance.Status.Hash = map[string]string{}
+		instance.Status.Hash = make(map[string]string)
 	}
 	if instance.Status.APIEndpoints == nil {
-		instance.Status.APIEndpoints = map[string]map[string]string{}
+		instance.Status.APIEndpoints = make(map[string]map[string]string)
 	}
 	if instance.Status.ServiceIDs == nil {
-		instance.Status.ServiceIDs = map[string]string{}
+		instance.Status.ServiceIDs = make(map[string]string)
 	}
 
 	// Handle service delete
@@ -339,9 +339,6 @@ func (r *IronicAPIReconciler) reconcileInit(
 	// Update instance status with service endpoint url from route host information for v2
 	//
 	// TODO: need to support https default here
-	if instance.Status.APIEndpoints == nil {
-		instance.Status.APIEndpoints = map[string]map[string]string{}
-	}
 	instance.Status.APIEndpoints[ironic.ServiceName] = apiEndpoints
 	// V1 - end
 
@@ -353,10 +350,6 @@ func (r *IronicAPIReconciler) reconcileInit(
 	// create users and endpoints
 	// TODO: rework this
 	//
-	if instance.Status.ServiceIDs == nil {
-		instance.Status.ServiceIDs = map[string]string{}
-	}
-
 	if !instance.Spec.Standalone {
 
 		for _, ksSvc := range keystoneServices {

--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -168,10 +168,11 @@ func (r *IronicConductorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, nil
 	}
 	if instance.Status.Hash == nil {
-		instance.Status.Hash = map[string]string{}
+		instance.Status.Hash = make(map[string]string)
 	}
+	// TODO: We don't use ServiceIDs in conductor controller
 	if instance.Status.ServiceIDs == nil {
-		instance.Status.ServiceIDs = map[string]string{}
+		instance.Status.ServiceIDs = make(map[string]string)
 	}
 
 	// Define a new PVC object
@@ -320,9 +321,6 @@ func (r *IronicConductorReconciler) reconcileServices(
 	// create users and endpoints
 	// TODO: rework this
 	//
-	if instance.Status.ServiceIDs == nil {
-		instance.Status.ServiceIDs = map[string]string{}
-	}
 
 	r.Log.Info("Reconciled Conductor Services successfully")
 	return ctrl.Result{}, nil


### PR DESCRIPTION
Inspector status:
  Adds requeue if inspector ReadyCount is 0, if we don't do that
  the reconcile loop end's without setting proper statuses.

APIEndpoints+ServiceIDs:
  Uses a for range loop to merge the maps instead of reassigning
  the entire map.
  Also initilaze maps with make(), doing so resolves:
    `panic: assignment to entry in nil map` issues.

Also add's some RequeueAfter time.