### PR TITLE
Move GetIngressDomain to pkg/ironic/funcs.go

### DIFF
--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -25,9 +25,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -483,7 +481,11 @@ func (r *IronicConductorReconciler) reconcileNormal(ctx context.Context, instanc
 		ironic.ComponentSelector: ironic.ConductorComponent,
 	}
 
-	ingressDomain := r.GetIngressDomain(ctx, helper)
+	ingressDomain, err := ironic.GetIngressDomain(ctx, helper)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// Define a new StatefulSet object
 	ssDef, err := ironicconductor.StatefulSet(instance, inputHash, serviceLabels, ingressDomain)
 	if err != nil {
@@ -610,52 +612,4 @@ func (r *IronicConductorReconciler) createHashOfInputHashes(
 		r.Log.Info(fmt.Sprintf("Input maps hash %s - %s", common.InputHashName, hash))
 	}
 	return hash, changed, nil
-}
-
-// GetIngressDomain - Get the Ingress Domain of cluster
-func (r *IronicConductorReconciler) GetIngressDomain(
-	ctx context.Context,
-	helper *helper.Helper,
-) string {
-	ingress := &unstructured.Unstructured{}
-	ingress.SetGroupVersionKind(
-		schema.GroupVersionKind{
-			Group:   "operator.openshift.io",
-			Version: "v1",
-			Kind:    "IngressController",
-		},
-	)
-	err := helper.GetClient().Get(
-		context.Background(),
-		client.ObjectKey{
-			Namespace: "openshift-ingress-operator",
-			Name:      "default",
-		},
-		ingress,
-	)
-	if err != nil {
-		r.Log.Error(err, "Unable to retrieve Ingress Domain %v")
-		return ""
-	}
-	ingressDomain := ""
-
-	ingressStatus := ingress.UnstructuredContent()["status"]
-	ingressStatusMap, ok := ingressStatus.(map[string]interface{})
-	if !ok {
-		r.Log.Info(fmt.Sprintf("Wanted type map[string]interface{}; got %T", ingressStatus))
-	}
-	for k, v := range ingressStatusMap {
-		if k == "domain" {
-			ingressDomain = v.(string)
-			// Break out of the loop, we got what we need
-			break
-		}
-	}
-	if ingressDomain != "" {
-		r.Log.Info(fmt.Sprintf("Found ingress domain: %s", ingressDomain))
-	} else {
-		r.Log.Info("Unable to get the ingress domain.")
-	}
-
-	return ingressDomain
 }

--- a/pkg/ironic/funcs.go
+++ b/pkg/ironic/funcs.go
@@ -1,6 +1,14 @@
 package ironic
 
-import "sigs.k8s.io/controller-runtime/pkg/client"
+import (
+	"context"
+	"fmt"
+
+	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
 
 // GetOwningIronicName - Given a IronicAPI, IronicConductor
 // object, returning the parent Ironic object that created it (if any)
@@ -12,4 +20,53 @@ func GetOwningIronicName(instance client.Object) string {
 	}
 
 	return ""
+}
+
+// GetIngressDomain - Get the Ingress Domain of cluster
+func GetIngressDomain(
+	ctx context.Context,
+	helper *helper.Helper,
+) (string, error) {
+	Log := helper.GetLogger()
+
+	ingress := &unstructured.Unstructured{}
+	ingress.SetGroupVersionKind(
+		schema.GroupVersionKind{
+			Group:   "operator.openshift.io",
+			Version: "v1",
+			Kind:    "IngressController",
+		},
+	)
+	err := helper.GetClient().Get(
+		context.Background(),
+		client.ObjectKey{
+			Namespace: "openshift-ingress-operator",
+			Name:      "default",
+		},
+		ingress,
+	)
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve ingress domain %v", err)
+	}
+	ingressDomain := ""
+
+	ingressStatus := ingress.UnstructuredContent()["status"]
+	ingressStatusMap, ok := ingressStatus.(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("unable to retrieve ingress domain - wanted type map[string]interface{}; got %T", ingressStatus)
+	}
+	for k, v := range ingressStatusMap {
+		if k == "domain" {
+			ingressDomain = v.(string)
+			// Break out of the loop, we got what we need
+			break
+		}
+	}
+	if ingressDomain != "" {
+		Log.Info(fmt.Sprintf("Found ingress domain: %s", ingressDomain))
+	} else {
+		return "", fmt.Errorf("unable to retrieve ingress domain")
+	}
+
+	return ingressDomain, nil
 }


### PR DESCRIPTION
Instead of duplicate implementations of GetIngressDomain in each controller add a shared function in pkg/ironic/funcs.go that can be used by both conductor and inspector controllers.

Also adds error handling.