### PR TITLE
Drop paths-ignore from build operator workflow

### DIFF
--- a/.github/workflows/build-ironic-operator.yaml
+++ b/.github/workflows/build-ironic-operator.yaml
@@ -4,19 +4,6 @@ on:
   push:
     branches:
       - '*'
-    paths-ignore:
-      - .gitignore
-      - .pull_request_pipeline
-      - changelog.txt
-      - kuttl-test.yaml
-      - LICENSE
-      - OWNERS
-      - PROJECT
-      - README.md
-      - .github/
-      - build/
-      - docs/
-      - tests/
 
 env:
   imageregistry: 'quay.io'


### PR DESCRIPTION
We build containers and push to registry in post merge. Not building container for each hash can cause issue becuase of missing container tags, and pin-custom-bundle-dockerfile.sh can't match the git $REF with any /ironic-operator-bundle image tag.