### PR TITLE
Add storageClass for Ironic CRD

### DIFF
--- a/api/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/api/bases/ironic.openstack.org_ironicconductors.yaml
@@ -244,6 +244,7 @@ spec:
                 description: Whether to deploy a standalone Ironic.
                 type: boolean
               storageClass:
+                default: ""
                 description: StorageClass
                 type: string
               storageRequest:
@@ -253,6 +254,7 @@ spec:
                 description: TransportURLSecret - Secret containing RabbitMQ transportURL
                 type: string
             required:
+            - storageClass
             - storageRequest
             type: object
           status:

--- a/api/bases/ironic.openstack.org_ironics.yaml
+++ b/api/bases/ironic.openstack.org_ironics.yaml
@@ -440,6 +440,7 @@ spec:
                       description: Whether to deploy a standalone Ironic.
                       type: boolean
                     storageClass:
+                      default: ""
                       description: StorageClass
                       type: string
                     storageRequest:
@@ -450,6 +451,7 @@ spec:
                         transportURL
                       type: string
                   required:
+                  - storageClass
                   - storageRequest
                   type: object
                 type: array
@@ -730,12 +732,17 @@ spec:
                 default: false
                 description: Whether to deploy a standalone Ironic.
                 type: boolean
+              storageClass:
+                description: Storage class to host data. This is passed to IronicConductors
+                  unless storageClass is explicitly set for the conductor.
+                type: string
             required:
             - databaseInstance
             - ironicAPI
             - ironicConductors
             - ironicInspector
             - secret
+            - storageClass
             type: object
           status:
             description: IronicStatus defines the observed state of Ironic

--- a/api/v1beta1/ironic_types.go
+++ b/api/v1beta1/ironic_types.go
@@ -119,6 +119,12 @@ type IronicSpec struct {
 	// NodeSelector here acts as a default value and can be overridden by service
 	// specific NodeSelector Settings.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
+	// Storage class to host data. This is passed to IronicConductors unless
+	// storageClass is explicitly set for the conductor.
+	// +kubebuilder:validation:Required
+	StorageClass string `json:"storageClass"`
+
 }
 
 // PasswordSelector to identify the DB and AdminUser password from the Secret

--- a/api/v1beta1/ironicconductor_types.go
+++ b/api/v1beta1/ironicconductor_types.go
@@ -110,9 +110,10 @@ type IronicConductorSpec struct {
 	// https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
+	// +kubebuilder:default=""
 	// StorageClass
-	StorageClass string `json:"storageClass,omitempty"`
+	StorageClass string `json:"storageClass"`
 
 	// +kubebuilder:validation:Required
 	// StorageRequest

--- a/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
@@ -244,6 +244,7 @@ spec:
                 description: Whether to deploy a standalone Ironic.
                 type: boolean
               storageClass:
+                default: ""
                 description: StorageClass
                 type: string
               storageRequest:
@@ -253,6 +254,7 @@ spec:
                 description: TransportURLSecret - Secret containing RabbitMQ transportURL
                 type: string
             required:
+            - storageClass
             - storageRequest
             type: object
           status:

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -440,6 +440,7 @@ spec:
                       description: Whether to deploy a standalone Ironic.
                       type: boolean
                     storageClass:
+                      default: ""
                       description: StorageClass
                       type: string
                     storageRequest:
@@ -450,6 +451,7 @@ spec:
                         transportURL
                       type: string
                   required:
+                  - storageClass
                   - storageRequest
                   type: object
                 type: array
@@ -730,12 +732,17 @@ spec:
                 default: false
                 description: Whether to deploy a standalone Ironic.
                 type: boolean
+              storageClass:
+                description: Storage class to host data. This is passed to IronicConductors
+                  unless storageClass is explicitly set for the conductor.
+                type: string
             required:
             - databaseInstance
             - ironicAPI
             - ironicConductors
             - ironicInspector
             - secret
+            - storageClass
             type: object
           status:
             description: IronicStatus defines the observed state of Ironic

--- a/config/samples/ironic_v1beta1_ironic.yaml
+++ b/config/samples/ironic_v1beta1_ironic.yaml
@@ -10,6 +10,7 @@ spec:
     debug = true
   databaseInstance: openstack
   databaseUser: ironic
+  storageClass: local-storage
   ironicAPI:
     replicas: 1
     containerImage: quay.io/tripleozedcentos9/openstack-ironic-api:current-tripleo
@@ -18,7 +19,6 @@ spec:
     containerImage: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
     pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
     storageRequest: 10G
-    storageClass: local-storage
   ironicInspector:
     replicas: 1
     containerImage: quay.io/tripleozedcentos9/openstack-ironic-inspector:current-tripleo

--- a/config/samples/ironic_v1beta1_ironic_conductor_groups.yaml
+++ b/config/samples/ironic_v1beta1_ironic_conductor_groups.yaml
@@ -10,6 +10,7 @@ spec:
     debug = true
   databaseInstance: openstack
   databaseUser: ironic
+  storageClass: standard-csi
   ironicAPI:
     replicas: 1
     containerImage: quay.io/tripleozedcentos9/openstack-ironic-api:current-tripleo
@@ -18,19 +19,18 @@ spec:
     containerImage: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
     pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
     storageRequest: 10G
-    storageClass: standard-csi
   - conductorGroup: auckland
     replicas: 1
     containerImage: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
     pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
     storageRequest: 10G
-    storageClass: standard-csi
+    storageClass: standard-csi-auckland
   - conductorGroup: stockholm
     replicas: 1
     containerImage: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
     pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
     storageRequest: 10G
-    storageClass: standard-csi
+    storageClass: standard-csi-stockholm
   ironicInspector:
     replicas: 1
     containerImage: quay.io/tripleozedcentos9/openstack-ironic-inspector:current-tripleo

--- a/config/samples/ironic_v1beta1_ironic_standalone.yaml
+++ b/config/samples/ironic_v1beta1_ironic_standalone.yaml
@@ -11,6 +11,7 @@ spec:
     debug = true
   databaseInstance: openstack
   databaseUser: ironic
+  storageClass: local-storage
   ironicAPI:
     replicas: 1
     containerImage: quay.io/tripleozedcentos9/openstack-ironic-api:current-tripleo
@@ -19,7 +20,6 @@ spec:
     containerImage: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
     pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
     storageRequest: 10G
-    storageClass: local-storage
   ironicInspector:
     replicas: 1
     containerImage: quay.io/tripleozedcentos9/openstack-ironic-inspector:current-tripleo

--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -651,8 +651,12 @@ func (r *IronicReconciler) conductorDeploymentCreateOrUpdate(
 		deployment.Spec.TransportURLSecret = instance.Status.TransportURLSecret
 		deployment.Spec.RPCTransport = instance.Spec.RPCTransport
 		deployment.Spec.KeystoneVars = keystoneVars
+		if deployment.Spec.StorageClass == "" {
+			deployment.Spec.StorageClass = instance.Spec.StorageClass
+		}
 
 		if len(deployment.Spec.NodeSelector) == 0 {
+			// TODO(hjensas) - Use a webhook to set instance.Spec.IronicConductors[x].StorageClass instead.
 			deployment.Spec.NodeSelector = instance.Spec.NodeSelector
 		}
 		err := controllerutil.SetControllerReference(instance, deployment, r.Scheme)


### PR DESCRIPTION
Add storageClass to Ironic CRD and pass the value
to IronicConductor if storageClass is not defined
in the conductor spec.

This should allow use of "STORAGE_CLASS" variable
with install_yamls Makefile/kustomization while
still giving the option to override storageClass
per "conducto group".

Jira: [OSP-22470](https://issues.redhat.com//browse/OSP-22470)