### PR TITLE
webhook - validatate dhcpRanges

### DIFF
--- a/api/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/api/bases/ironic.openstack.org_ironicconductors.yaml
@@ -102,6 +102,10 @@ spec:
                 items:
                   description: DHCPRange to define address range for DHCP requestes
                   properties:
+                    cidr:
+                      description: Cidr - IP address prefix (CIDR) representing an
+                        IP network.
+                      type: string
                     end:
                       description: End - End of DHCP range
                       type: string
@@ -115,21 +119,17 @@ spec:
                       description: Name - Name of the DHCPRange (used for tagging
                         in dnsmasq)
                       type: string
-                    netmask:
-                      description: Netmask - IP network netmask (network mask bits)
-                        for IPv4
-                      type: string
                     podIndex:
                       description: PodIndex - Maps the DHCPRange to a specific statefulset
                         pod index
                       type: integer
-                    prefix:
-                      description: Prefix - IP network prefix (network mask bits)
-                        for IPv6
-                      type: integer
                     start:
                       description: Start - Start of DHCP range
                       type: string
+                  required:
+                  - cidr
+                  - end
+                  - start
                   type: object
                 type: array
               networkAttachments:

--- a/api/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/api/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -104,6 +104,10 @@ spec:
                 items:
                   description: DHCPRange to define address range for DHCP requestes
                   properties:
+                    cidr:
+                      description: Cidr - IP address prefix (CIDR) representing an
+                        IP network.
+                      type: string
                     end:
                       description: End - End of DHCP range
                       type: string
@@ -117,21 +121,17 @@ spec:
                       description: Name - Name of the DHCPRange (used for tagging
                         in dnsmasq)
                       type: string
-                    netmask:
-                      description: Netmask - IP network netmask (network mask bits)
-                        for IPv4
-                      type: string
                     podIndex:
                       description: PodIndex - Maps the DHCPRange to a specific statefulset
                         pod index
                       type: integer
-                    prefix:
-                      description: Prefix - IP network prefix (network mask bits)
-                        for IPv6
-                      type: integer
                     start:
                       description: Start - Start of DHCP range
                       type: string
+                  required:
+                  - cidr
+                  - end
+                  - start
                   type: object
                 type: array
               inspectionNetwork:

--- a/api/bases/ironic.openstack.org_ironics.yaml
+++ b/api/bases/ironic.openstack.org_ironics.yaml
@@ -294,6 +294,10 @@ spec:
                       items:
                         description: DHCPRange to define address range for DHCP requestes
                         properties:
+                          cidr:
+                            description: Cidr - IP address prefix (CIDR) representing
+                              an IP network.
+                            type: string
                           end:
                             description: End - End of DHCP range
                             type: string
@@ -307,21 +311,17 @@ spec:
                             description: Name - Name of the DHCPRange (used for tagging
                               in dnsmasq)
                             type: string
-                          netmask:
-                            description: Netmask - IP network netmask (network mask
-                              bits) for IPv4
-                            type: string
                           podIndex:
                             description: PodIndex - Maps the DHCPRange to a specific
                               statefulset pod index
                             type: integer
-                          prefix:
-                            description: Prefix - IP network prefix (network mask
-                              bits) for IPv6
-                            type: integer
                           start:
                             description: Start - Start of DHCP range
                             type: string
+                        required:
+                        - cidr
+                        - end
+                        - start
                         type: object
                       type: array
                     networkAttachments:
@@ -516,6 +516,10 @@ spec:
                     items:
                       description: DHCPRange to define address range for DHCP requestes
                       properties:
+                        cidr:
+                          description: Cidr - IP address prefix (CIDR) representing
+                            an IP network.
+                          type: string
                         end:
                           description: End - End of DHCP range
                           type: string
@@ -529,21 +533,17 @@ spec:
                           description: Name - Name of the DHCPRange (used for tagging
                             in dnsmasq)
                           type: string
-                        netmask:
-                          description: Netmask - IP network netmask (network mask
-                            bits) for IPv4
-                          type: string
                         podIndex:
                           description: PodIndex - Maps the DHCPRange to a specific
                             statefulset pod index
                           type: integer
-                        prefix:
-                          description: Prefix - IP network prefix (network mask bits)
-                            for IPv6
-                          type: integer
                         start:
                           description: Start - Start of DHCP range
                           type: string
+                      required:
+                      - cidr
+                      - end
+                      - start
                       type: object
                     type: array
                   inspectionNetwork:

--- a/api/go.mod
+++ b/api/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230130113944-08eaed348cec
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
+	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	sigs.k8s.io/controller-runtime v0.14.4
 )
 
@@ -59,7 +60,6 @@ require (
 	k8s.io/component-base v0.26.1 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
-	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/api/v1beta1/ironic_types.go
+++ b/api/v1beta1/ironic_types.go
@@ -145,27 +145,29 @@ type DHCPRange struct {
 	// +kubebuilder:validation:Optional
 	// Name - Name of the DHCPRange (used for tagging in dnsmasq)
 	Name string `json:"name,omitempty"`
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
+	// Cidr - IP address prefix (CIDR) representing an IP network.
+	Cidr string `json:"cidr"`
+	// +kubebuilder:validation:Required
 	// Start - Start of DHCP range
-	Start string `json:"start,omitempty"`
-	// +kubebuilder:validation:Optional
+	Start string `json:"start"`
+	// +kubebuilder:validation:Required
 	// End - End of DHCP range
-	End string `json:"end,omitempty"`
+	End string `json:"end"`
 	// +kubebuilder:validation:Optional
 	// Gateway - IP address for the router
 	Gateway string `json:"gateway,omitempty"`
 	// +kubebuilder:validation:Optional
-	// Prefix - IP network prefix (network mask bits) for IPv6
-	Prefix int `json:"prefix,omitempty"`
-	// +kubebuilder:validation:Optional
-	// Netmask - IP network netmask (network mask bits) for IPv4
-	Netmask string `json:"netmask,omitempty"`
-	// +kubebuilder:validation:Optional
 	// MTU - Maximum Transmission Unit
 	MTU int `json:"mtu,omitempty"`
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:
 	// PodIndex - Maps the DHCPRange to a specific statefulset pod index
 	PodIndex int `json:"podIndex,omitempty"`
+	// Prefix - (Hidden) Internal use only, prefix (mask bits) for IPv6 is autopopulated from Cidr
+	Prefix int `json:"-"`
+	// Netmask - (Hidden) Inernal use only, netmask for IPv4 is autopopulated from Cidr
+	Netmask string `json:"-"`
 }
 
 // IronicDebug defines the observed state of Ironic

--- a/api/v1beta1/ironic_webhook.go
+++ b/api/v1beta1/ironic_webhook.go
@@ -17,13 +17,16 @@ limitations under the License.
 package v1beta1
 
 import (
+	"bytes"
 	"fmt"
+	"net"
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	k8snet "k8s.io/utils/net"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -31,6 +34,21 @@ import (
 
 // log is for logging in this package.
 var ironiclog = logf.Log.WithName("ironic-resource")
+
+const (
+	errNotIPAddr               = "not an IP address"
+	errInvalidCidr             = "IP address prefix (CIDR) %s"
+	errNotInCidr               = "address not in IP address prefix (CIDR) %s"
+	errMixedAddressFamily      = "cannot mix IPv4 and IPv6"
+	errInvalidRange            = "Start address: %s > End address %s"
+	errForbiddenAddressOverlap = "%v overlap with %v: %v"
+)
+
+type netIPStartEnd struct {
+	start net.IP       // Start address of DHCP Range
+	end   net.IP       // End address of DHCP Range
+	path  *field.Path  // Field path to DHCP Range in Ironic spec
+}
 
 // SetupWebhookWithManager sets up the webhook with the Manager
 func (r *Ironic) SetupWebhookWithManager(mgr ctrl.Manager) error {
@@ -55,6 +73,18 @@ func (r *Ironic) ValidateCreate() error {
 		allErrs = append(allErrs, err)
 	}
 
+	if err := r.validateConductorSpec(); err != nil {
+		allErrs = append(allErrs, err...)
+	}
+
+	if err := r.validateInspectorSpec(); err != nil {
+		allErrs = append(allErrs, err...)
+	}
+
+	if err := r.validateDHCPRangesOverlap(); err != nil {
+		allErrs = append(allErrs, err...)
+	}
+
 	if len(allErrs) != 0 {
 		return apierrors.NewInvalid(
 			schema.GroupKind{Group: "ironic.openstack.org", Kind: "Ironic"},
@@ -73,6 +103,18 @@ func (r *Ironic) ValidateUpdate(old runtime.Object) error {
 		allErrs = append(allErrs, err)
 	}
 
+	if err := r.validateConductorSpec(); err != nil {
+		allErrs = append(allErrs, err...)
+	}
+
+	if err := r.validateInspectorSpec(); err != nil {
+		allErrs = append(allErrs, err...)
+	}
+
+	if err := r.validateDHCPRangesOverlap(); err != nil {
+		allErrs = append(allErrs, err...)
+	}
+
 	if len(allErrs) != 0 {
 		return apierrors.NewInvalid(
 			schema.GroupKind{Group: "ironic.openstack.org", Kind: "Ironic"},
@@ -89,6 +131,43 @@ func (r *Ironic) ValidateDelete() error {
 	// TODO(user): fill in your validation logic upon object deletion.
 	return nil
 }
+
+func (r *Ironic) validateInspectorSpec() field.ErrorList {
+	var allErrs field.ErrorList
+	basePath := field.NewPath("spec").Child("ironicInspector").Child("dhcpRanges")
+
+	// Validate DHCP ranges
+	for idx, dhcpRange := range r.Spec.IronicInspector.DHCPRanges {
+		if err := r.validateDHCPRange(dhcpRange, basePath.Index(idx)); err != nil {
+			allErrs = append(allErrs, err...)
+		}
+	}
+
+	return allErrs
+}
+
+// validateConductorSpec
+func (r *Ironic) validateConductorSpec() field.ErrorList {
+	var allErrs field.ErrorList
+
+	// validateConductoGroupsUnique
+	if err := r.validateConductoGroupsUnique(); err != nil {
+		allErrs = append(allErrs, err)
+	}
+
+	// Validate DHCP ranges - Ironic Conductor
+	for condIdx, conductor := range r.Spec.IronicConductors {
+		for idx, dhcpRange := range conductor.DHCPRanges {
+			path := field.NewPath("spec").Child("ironicConductors").Index(condIdx).Child("dhcpRanges").Index(idx)
+			if err := r.validateDHCPRange(dhcpRange, path); err != nil {
+				allErrs = append(allErrs, err...)
+			}
+		}
+	}
+
+	return allErrs
+}
+
 
 // validateConductoGroupsUnique implements validation of IronicConductor ConductorGroup
 func (r *Ironic) validateConductoGroupsUnique() *field.Error {
@@ -126,4 +205,204 @@ func (r *Ironic) validateConductoGroupsUnique() *field.Error {
 	}
 
 	return nil
+}
+
+func (r *Ironic) validateDHCPRange(
+	dhcpRange DHCPRange,
+	path *field.Path,
+) field.ErrorList {
+	var allErrs field.ErrorList
+
+	cidr := dhcpRange.Cidr
+	start := dhcpRange.Start
+	end := dhcpRange.End
+	gateway := dhcpRange.Gateway
+
+	var startAddr net.IP
+	var endAddr net.IP
+	var gatewayAddr net.IP
+
+	_, ipPrefix, ipPrefixErr := net.ParseCIDR(cidr)
+	if ipPrefixErr != nil {
+		allErrs = append(allErrs, field.Invalid(path.Child("cidr"), cidr, errInvalidCidr))
+	}
+	startAddr = net.ParseIP(start)
+	if startAddr == nil {
+		allErrs = append(allErrs, field.Invalid(path.Child("start"), start, errNotIPAddr))
+	}
+	endAddr = net.ParseIP(end)
+	if endAddr == nil {
+		allErrs = append(allErrs, field.Invalid(path.Child("end"), end, errNotIPAddr))
+	}
+	if gateway != "" {
+		gatewayAddr = net.ParseIP(gateway)
+		if gatewayAddr == nil {
+			allErrs = append(allErrs, field.Invalid(path.Child("gateway"), gateway, errNotIPAddr))
+		}
+	}
+
+	//
+	// NOTE! return if any of these are invalid, continuing will potentially cause panic!
+	//
+	if ipPrefixErr != nil || startAddr == nil || endAddr == nil || gatewayAddr == nil {
+		return allErrs
+	}
+
+	// Validate IP Family for IPv4
+	if k8snet.IsIPv4CIDR(ipPrefix) {
+		if !(k8snet.IsIPv4(startAddr) && k8snet.IsIPv4(endAddr)) {
+			allErrs = append(allErrs, field.Invalid(path, dhcpRange, errMixedAddressFamily))
+		} else if gateway != "" && !k8snet.IsIPv4(gatewayAddr) {
+			allErrs = append(allErrs, field.Invalid(path, dhcpRange, errMixedAddressFamily))
+		}
+	}
+
+	// Validate IP Family for IPv6
+	if k8snet.IsIPv6CIDR(ipPrefix) {
+		if !(k8snet.IsIPv6(startAddr) && k8snet.IsIPv6(endAddr)) {
+			allErrs = append(allErrs, field.Invalid(path, dhcpRange, errMixedAddressFamily))
+		} else if gateway != "" && !k8snet.IsIPv6(gatewayAddr) {
+			allErrs = append(allErrs, field.Invalid(path, dhcpRange, errMixedAddressFamily))
+		}
+	}
+
+	// Validate start, end and gateway in cidr
+	if !ipPrefix.Contains(startAddr) {
+		allErrs = append(allErrs, field.Invalid(path.Child("start"), start, fmt.Sprintf(errNotInCidr, cidr)))
+	}
+	if !ipPrefix.Contains(endAddr) {
+		allErrs = append(allErrs, field.Invalid(path.Child("end"), end, fmt.Sprintf(errNotInCidr, cidr)))
+	}
+	if gateway != "" && !ipPrefix.Contains(gatewayAddr) {
+		allErrs = append(allErrs, field.Invalid(path.Child("gateway"), gateway, fmt.Sprintf(errNotInCidr, cidr)))
+	}
+
+	// Start address should be < End address
+	// The result will be 0 if a == b, -1 if a < b, and +1 if a > b.
+	if bytes.Compare(endAddr, startAddr) != 1 {
+		allErrs = append(allErrs, field.Invalid(path.Child("start"), start, fmt.Sprintf(errInvalidRange, start, end)))
+		allErrs = append(allErrs, field.Invalid(path.Child("end"), end, fmt.Sprintf(errInvalidRange, start, end)))
+	}
+
+	return allErrs
+}
+
+
+// validateDHCPRangesOverlap
+// Check for overlapping start->end in all DHCP ranges. (Conductor and Inspector)
+func (r *Ironic) validateDHCPRangesOverlap() field.ErrorList {
+	var allErrs field.ErrorList
+	var netIPStartEnds []netIPStartEnd
+	conductorPath := field.NewPath("spec").Child("ironicConductors")
+	inspectorPath := field.NewPath("spec").Child("ironicInspector").Child("dhcpRanges")
+
+	for idx, dhcpRange := range r.Spec.IronicInspector.DHCPRanges {
+		start := net.ParseIP(dhcpRange.Start)
+		end := net.ParseIP(dhcpRange.End)
+		if start == nil || end == nil {
+			// If net.ParseIP returns 'nil' the address is not valid, the issue
+			// has already been detected by previous validation ...
+			// can safely skip here.
+			continue
+		}
+		netIPStartEnds = append(
+			netIPStartEnds, 
+			netIPStartEnd{
+				start: start,
+				end: end,
+				path: inspectorPath.Index(idx),
+			},
+		)
+	}
+	
+	for condIdx, conductor := range r.Spec.IronicConductors {
+		for idx, dhcpRange := range conductor.DHCPRanges {
+			start := net.ParseIP(dhcpRange.Start)
+			end := net.ParseIP(dhcpRange.End)
+			if start == nil || end == nil {
+				// If net.ParseIP returns 'nil' the address is not valid, the issue
+			    // has already been detected by previous validation ... 
+				// can safely skip here.
+				continue
+			}
+			netIPStartEnds = append(
+				netIPStartEnds, 
+				netIPStartEnd{
+					start: start,
+					end: end,
+					path: conductorPath.Index(condIdx).Child("dhcpRanges").Index(idx),
+				},
+			)
+		}
+	}
+
+	for ax := 0; ax < len(netIPStartEnds); ax++ {
+		for bx := 0; bx < len(netIPStartEnds); bx++ {
+			if bx == ax {
+				continue
+			}
+			allErrs = r.validateStartEndOverlap(netIPStartEnds[ax], netIPStartEnds[bx])	
+		}
+	}
+
+	return allErrs
+}
+
+
+// validateStartEndOverlap -
+// Check that start->end does not overlap
+func (r *Ironic) validateStartEndOverlap(
+	a netIPStartEnd,
+	b netIPStartEnd,
+) field.ErrorList {
+	var allErrs field.ErrorList
+
+	// bytes.Compare() return values:
+	//   if a < b => -1
+	//   if a = b =>  0
+	//   if a > b =>  1
+	switch x := bytes.Compare(a.start, b.start); x {
+	case -1: // a.Start < b.Start -> CHECK: a.End < b.Start
+		switch x := bytes.Compare(a.end, b.start); x {
+		case -1: // a.End < b.Start :: OK
+			return allErrs
+		case 0, 1: // a.Start < b.Start && a.End >= b.Start :: FORBIDDEN
+		    aRange := fmt.Sprintf("%v->%v", a.start.String(), a.end.String())
+		    bRange := fmt.Sprintf("%v->%v", b.start.String(), b.end.String())
+			allErrs = append(
+				allErrs,
+				field.Forbidden(
+					a.path,
+					fmt.Sprintf(errForbiddenAddressOverlap, aRange, b.path, bRange)),
+			)
+			return allErrs
+		}
+	case 0: // a.Start == b.Start :: FORBIDDEN
+	    aRange := fmt.Sprintf("%v->%v", a.start.String(), a.end.String())
+		bRange := fmt.Sprintf("%v->%v", b.start.String(), b.end.String())
+		allErrs = append(
+			allErrs,
+			field.Forbidden(
+				a.path,
+				fmt.Sprintf(errForbiddenAddressOverlap, aRange, b.path, bRange)),
+		)
+		return allErrs
+	case 1: // a.Start > theirStart -> CHECK: a.Start > b.End
+		switch x := bytes.Compare(a.start, b.end); x {
+		case 1: // a.Start > b.End -> OK
+			return allErrs
+		case 0, -1: // a.start > b.Start && a.Start <= b.End :: FORBIDDEN
+		    aRange := fmt.Sprintf("%v->%v", a.start.String(), a.end.String())
+			bRange := fmt.Sprintf("%v->%v", b.start.String(), b.end.String())
+			allErrs = append(
+				allErrs,
+				field.Forbidden(
+					a.path,
+					fmt.Sprintf(errForbiddenAddressOverlap, aRange, b.path, bRange)),
+			)
+			return allErrs
+		}
+	}
+
+	return allErrs
 }

--- a/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
@@ -102,6 +102,10 @@ spec:
                 items:
                   description: DHCPRange to define address range for DHCP requestes
                   properties:
+                    cidr:
+                      description: Cidr - IP address prefix (CIDR) representing an
+                        IP network.
+                      type: string
                     end:
                       description: End - End of DHCP range
                       type: string
@@ -115,21 +119,17 @@ spec:
                       description: Name - Name of the DHCPRange (used for tagging
                         in dnsmasq)
                       type: string
-                    netmask:
-                      description: Netmask - IP network netmask (network mask bits)
-                        for IPv4
-                      type: string
                     podIndex:
                       description: PodIndex - Maps the DHCPRange to a specific statefulset
                         pod index
                       type: integer
-                    prefix:
-                      description: Prefix - IP network prefix (network mask bits)
-                        for IPv6
-                      type: integer
                     start:
                       description: Start - Start of DHCP range
                       type: string
+                  required:
+                  - cidr
+                  - end
+                  - start
                   type: object
                 type: array
               networkAttachments:

--- a/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -104,6 +104,10 @@ spec:
                 items:
                   description: DHCPRange to define address range for DHCP requestes
                   properties:
+                    cidr:
+                      description: Cidr - IP address prefix (CIDR) representing an
+                        IP network.
+                      type: string
                     end:
                       description: End - End of DHCP range
                       type: string
@@ -117,21 +121,17 @@ spec:
                       description: Name - Name of the DHCPRange (used for tagging
                         in dnsmasq)
                       type: string
-                    netmask:
-                      description: Netmask - IP network netmask (network mask bits)
-                        for IPv4
-                      type: string
                     podIndex:
                       description: PodIndex - Maps the DHCPRange to a specific statefulset
                         pod index
                       type: integer
-                    prefix:
-                      description: Prefix - IP network prefix (network mask bits)
-                        for IPv6
-                      type: integer
                     start:
                       description: Start - Start of DHCP range
                       type: string
+                  required:
+                  - cidr
+                  - end
+                  - start
                   type: object
                 type: array
               inspectionNetwork:

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -294,6 +294,10 @@ spec:
                       items:
                         description: DHCPRange to define address range for DHCP requestes
                         properties:
+                          cidr:
+                            description: Cidr - IP address prefix (CIDR) representing
+                              an IP network.
+                            type: string
                           end:
                             description: End - End of DHCP range
                             type: string
@@ -307,21 +311,17 @@ spec:
                             description: Name - Name of the DHCPRange (used for tagging
                               in dnsmasq)
                             type: string
-                          netmask:
-                            description: Netmask - IP network netmask (network mask
-                              bits) for IPv4
-                            type: string
                           podIndex:
                             description: PodIndex - Maps the DHCPRange to a specific
                               statefulset pod index
                             type: integer
-                          prefix:
-                            description: Prefix - IP network prefix (network mask
-                              bits) for IPv6
-                            type: integer
                           start:
                             description: Start - Start of DHCP range
                             type: string
+                        required:
+                        - cidr
+                        - end
+                        - start
                         type: object
                       type: array
                     networkAttachments:
@@ -516,6 +516,10 @@ spec:
                     items:
                       description: DHCPRange to define address range for DHCP requestes
                       properties:
+                        cidr:
+                          description: Cidr - IP address prefix (CIDR) representing
+                            an IP network.
+                          type: string
                         end:
                           description: End - End of DHCP range
                           type: string
@@ -529,21 +533,17 @@ spec:
                           description: Name - Name of the DHCPRange (used for tagging
                             in dnsmasq)
                           type: string
-                        netmask:
-                          description: Netmask - IP network netmask (network mask
-                            bits) for IPv4
-                          type: string
                         podIndex:
                           description: PodIndex - Maps the DHCPRange to a specific
                             statefulset pod index
                           type: integer
-                        prefix:
-                          description: Prefix - IP network prefix (network mask bits)
-                            for IPv6
-                          type: integer
                         start:
                           description: Start - Start of DHCP range
                           type: string
+                      required:
+                      - cidr
+                      - end
+                      - start
                       type: object
                     type: array
                   inspectionNetwork:

--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -595,7 +595,11 @@ func (r *IronicConductorReconciler) generateServiceConfigMaps(
 		templateParameters["KeystonePublicURL"] = instance.Spec.KeystoneVars["keystonePublicURL"]
 		templateParameters["ServiceUser"] = instance.Spec.ServiceUser
 	}
-	templateParameters["DHCPRanges"] = instance.Spec.DHCPRanges
+	dhcpRanges, err := ironic.PrefixOrNetmaskFromCIDR(instance.Spec.DHCPRanges)
+	if err != nil {
+		r.Log.Error(err, "Failed to get Prefix or Netmask from IP network Prefix (CIDR)")
+	}
+	templateParameters["DHCPRanges"] = dhcpRanges
 	templateParameters["Standalone"] = instance.Spec.Standalone
 	templateParameters["ConductorGroup"] = instance.Spec.ConductorGroup
 

--- a/controllers/ironicinspector_controller.go
+++ b/controllers/ironicinspector_controller.go
@@ -1024,7 +1024,11 @@ func (r *IronicInspectorReconciler) generateServiceConfigMaps(
 		}
 		templateParameters["IronicInternalURL"] = ironicInternalURL
 	}
-	templateParameters["DHCPRanges"] = instance.Spec.DHCPRanges
+	dhcpRanges, err := ironic.PrefixOrNetmaskFromCIDR(instance.Spec.DHCPRanges)
+	if err != nil {
+		r.Log.Error(err, "unable to get Prefix or Netmask from IP network Prefix (CIDR)")
+	}
+	templateParameters["DHCPRanges"] = dhcpRanges
 	templateParameters["Standalone"] = instance.Spec.Standalone
 
 	cms := []util.Template{

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
+	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	sigs.k8s.io/controller-runtime v0.14.4
 )
 
@@ -73,7 +74,6 @@ require (
 	k8s.io/component-base v0.26.1 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
-	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect


### PR DESCRIPTION
* Validate that each DHCP Range has sane value IP addresses valid, start/end/gateway in same range
* Validates DHCP start->end ranges does not overlap

Also:
* Changes the DHCPRange struct to include a `cidr` field.
* The `netmask` and `prefix` fields changed to be hidden fields.
* `netmask` and `prefix` are set internally prior to passing the dhcpRanges to tempalteParameters, sourcing the info from the `cidr` value.
* `cidr`, `start` and `end` changed to mandatory (required)

    Example validation errors:
    ```
    The Ironic "ironic" is invalid:
    * spec.ironicConductors[0].dhcpRanges[0].gateway: Invalid value: "172.25.22.1": address not in IP address prefix (CIDR) 172.25.23.0/24
    * spec.ironicInspector.dhcpRanges[0].end: Invalid value: "172.25.23.777": not an IP address
    ```
    ```
    The Ironic "ironic" is invalid:
    * spec.ironicConductors[0].dhcpRanges[0].gateway: Invalid value: "172.25.22.1": address not in IP address prefix (CIDR) 172.25.23.0/24
    * spec.ironicConductors[0].dhcpRanges[0]: Forbidden: 172.25.23.110->172.25.23.190 overlap with spec.ironicInspector.dhcpRanges[0]: 172.25.23.90->172.25.23.150
    ```


Jira: [OSP-22448](https://issues.redhat.com//browse/OSP-22448)