### PR TITLE
Make services and routes owned by Statufulset Pods

### DIFF
--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -295,7 +295,7 @@ func (r *IronicConductorReconciler) reconcileServices(
 			err = r.Get(
 				ctx,
 				k8s_types.NamespacedName{
-					Name: conductorService.Name,
+					Name:      conductorService.Name,
 					Namespace: conductorService.Namespace,
 				},
 				conductorService,
@@ -338,7 +338,7 @@ func (r *IronicConductorReconciler) reconcileServices(
 			err = r.Get(
 				ctx,
 				k8s_types.NamespacedName{
-					Name: conductorRoute.Name,
+					Name:      conductorRoute.Name,
 					Namespace: conductorRoute.Namespace,
 				},
 				conductorRoute,


### PR DESCRIPTION
Set owner reference for conductor services and routes to the Statufulset Pod. This ensures that garbage collection will delete Services and Routes when the Statefulset is scaled down.
    
Unfortunately the the route and service packages in lib-common does not allow this level of control.

Jira: [OSP-22519](https://issues.redhat.com//browse/OSP-22519)
