### PR TITLE
Ironic inspector scaling - Maximum 1 replica

### DIFF
--- a/api/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/api/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -187,6 +187,7 @@ spec:
                 default: 1
                 description: Replicas - Ironic Inspector Replicas
                 format: int32
+                maximum: 1
                 type: integer
               resources:
                 description: Resources - Compute Resources required by this service

--- a/api/bases/ironic.openstack.org_ironics.yaml
+++ b/api/bases/ironic.openstack.org_ironics.yaml
@@ -600,6 +600,7 @@ spec:
                     default: 1
                     description: Replicas - Ironic Inspector Replicas
                     format: int32
+                    maximum: 1
                     type: integer
                   resources:
                     description: Resources - Compute Resources required by this service

--- a/api/v1beta1/ironic_types.go
+++ b/api/v1beta1/ironic_types.go
@@ -161,7 +161,6 @@ type DHCPRange struct {
 	// MTU - Maximum Transmission Unit
 	MTU int `json:"mtu,omitempty"`
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:
 	// PodIndex - Maps the DHCPRange to a specific statefulset pod index
 	PodIndex int `json:"podIndex,omitempty"`
 	// Prefix - (Hidden) Internal use only, prefix (mask bits) for IPv6 is autopopulated from Cidr

--- a/api/v1beta1/ironicinspector_types.go
+++ b/api/v1beta1/ironicinspector_types.go
@@ -44,6 +44,7 @@ type IronicInspectorSpec struct {
 	ServiceUser string `json:"serviceUser"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Maximum=1
 	// +kubebuilder:default=1
 	// Replicas - Ironic Inspector Replicas
 	Replicas int32 `json:"replicas"`

--- a/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -187,6 +187,7 @@ spec:
                 default: 1
                 description: Replicas - Ironic Inspector Replicas
                 format: int32
+                maximum: 1
                 type: integer
               resources:
                 description: Resources - Compute Resources required by this service

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -600,6 +600,7 @@ spec:
                     default: 1
                     description: Replicas - Ironic Inspector Replicas
                     format: int32
+                    maximum: 1
                     type: integer
                   resources:
                     description: Resources - Compute Resources required by this service


### PR DESCRIPTION
* Set validation to Maximum=1 for replicas 
   We have decided not to support HA/Scaling for the inspector service.
   In other words - rely on kubernets to service availability.
* Don't create inspector deployment if replicas count is 0.
* Delete the inspector deployment if scaled to 0.

Jira: [OSP-22518](https://issues.redhat.com//browse/OSP-22518)