### PR TITLE
Remove DatabaseHostname from inspector SPEC

### DIFF
--- a/api/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/api/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -59,9 +59,6 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
-              databaseHostname:
-                description: DatabaseHostname - Ironic Database Hostname
-                type: string
               databaseInstance:
                 description: MariaDB instance name. Right now required by the maridb-operator
                   to get the credentials from the instance to create the DB. Might

--- a/api/bases/ironic.openstack.org_ironics.yaml
+++ b/api/bases/ironic.openstack.org_ironics.yaml
@@ -471,9 +471,6 @@ spec:
                       content gets added to to /etc/<service>/<service>.conf.d directory
                       as custom.conf file.
                     type: string
-                  databaseHostname:
-                    description: DatabaseHostname - Ironic Database Hostname
-                    type: string
                   databaseInstance:
                     description: MariaDB instance name. Right now required by the
                       maridb-operator to get the credentials from the instance to

--- a/api/v1beta1/ironicinspector_types.go
+++ b/api/v1beta1/ironicinspector_types.go
@@ -49,10 +49,6 @@ type IronicInspectorSpec struct {
 	Replicas int32 `json:"replicas"`
 
 	// +kubebuilder:validation:Optional
-	// DatabaseHostname - Ironic Database Hostname
-	DatabaseHostname string `json:"databaseHostname,omitempty"`
-
-	// +kubebuilder:validation:Optional
 	// MariaDB instance name.
 	// Right now required by the maridb-operator to get the credentials from the instance to create the DB.
 	// Might not be required in future.

--- a/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -59,9 +59,6 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
-              databaseHostname:
-                description: DatabaseHostname - Ironic Database Hostname
-                type: string
               databaseInstance:
                 description: MariaDB instance name. Right now required by the maridb-operator
                   to get the credentials from the instance to create the DB. Might

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -471,9 +471,6 @@ spec:
                       content gets added to to /etc/<service>/<service>.conf.d directory
                       as custom.conf file.
                     type: string
-                  databaseHostname:
-                    description: DatabaseHostname - Ironic Database Hostname
-                    type: string
                   databaseInstance:
                     description: MariaDB instance name. Right now required by the
                       maridb-operator to get the credentials from the instance to

--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -809,7 +809,6 @@ func (r *IronicReconciler) inspectorDeploymentCreateOrUpdate(
 			// Add in transfers from umbrella Ironic (this instance) spec
 			// TODO: Add logic to determine when to set/overwrite, etc
 			deployment.Spec.Standalone = instance.Spec.Standalone
-			deployment.Spec.DatabaseHostname = instance.Status.DatabaseHostname
 			// TODO: Revist DatabaseUser - It is currently implemented in lib-common,
 			//       but not in mariadb-operator. mariadb-operator always creates
 			//       database user with name == .DatabaseName

--- a/pkg/ironicinspector/statefulset.go
+++ b/pkg/ironicinspector/statefulset.go
@@ -279,7 +279,7 @@ func StatefulSet(
 	initContainerDetails := APIDetails{
 		ContainerImage:       instance.Spec.ContainerImage,
 		PxeContainerImage:    instance.Spec.PxeContainerImage,
-		DatabaseHost:         instance.Spec.DatabaseHostname,
+		DatabaseHost:         instance.Status.DatabaseHostname,
 		DatabaseUser:         instance.Spec.DatabaseUser,
 		DatabaseName:         DatabaseName,
 		OSPSecret:            instance.Spec.Secret,


### PR DESCRIPTION
Inspector creates it's own database and derives the hostname from the results we should get `DatabaseHostname` from Status when setting `initContainerDetails`.