### PR TITLE
fix typo in golangci-lint name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ vet: gowork ## Run go vet against code.
 
 .PHONY: golangci-lint
 golangci-lint:
-	test -s $(LOCALBIN)/tolangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.2
+	test -s $(LOCALBIN)/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.2
 	$(LOCALBIN)/golangci-lint run --fix
 
 .PHONY: test


### PR DESCRIPTION
Cross checked in keystone-operator, it should be golangci-lint and not tolangci-lint.

[1] https://github.com/openstack-k8s-operators/keystone-operator/blob/master/Makefile#L116 
test -s $(LOCALBIN)/golangci-lint
