### PR TITLE
Use constant to define restart policy

### DIFF
--- a/pkg/ironic/dbsync.go
+++ b/pkg/ironic/dbsync.go
@@ -58,7 +58,7 @@ func DbSyncJob(
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy:      "OnFailure",
+					RestartPolicy:      corev1.RestartPolicyOnFailure,
 					ServiceAccountName: ServiceAccount,
 					Containers: []corev1.Container{
 						{

--- a/pkg/ironicinspector/dbsync.go
+++ b/pkg/ironicinspector/dbsync.go
@@ -59,7 +59,7 @@ func DbSyncJob(
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy:      "OnFailure",
+					RestartPolicy:      corev1.RestartPolicyOnFailure,
 					ServiceAccountName: ServiceAccount,
 					Containers: []corev1.Container{
 						{


### PR DESCRIPTION
... instead hard-coding the string in our own logic.