### PR TITLE
Change references of networks-status to network-status

### DIFF
--- a/pkg/ironic/initcontainer.go
+++ b/pkg/ironic/initcontainer.go
@@ -110,7 +110,7 @@ func InitContainer(init APIDetails) []corev1.Container {
 			Name: "PodNetworksStatus",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "metadata.annotations['k8s.v1.cni.cncf.io/networks-status']",
+					FieldPath: "metadata.annotations['k8s.v1.cni.cncf.io/network-status']",
 				},
 			},
 		},

--- a/pkg/ironicinspector/initcontainer.go
+++ b/pkg/ironicinspector/initcontainer.go
@@ -103,7 +103,7 @@ func InitContainer(init APIDetails) []corev1.Container {
 			Name: "PodNetworksStatus",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "metadata.annotations['k8s.v1.cni.cncf.io/networks-status']",
+					FieldPath: "metadata.annotations['k8s.v1.cni.cncf.io/network-status']",
 				},
 			},
 		},

--- a/templates/common/bin/get_net_ip
+++ b/templates/common/bin/get_net_ip
@@ -19,7 +19,7 @@ import json
 import sys
 
 # Uses network status from pod:
-#   metadata.annotations['k8s.v1.cni.cncf.io/networks-status']
+#   metadata.annotations['k8s.v1.cni.cncf.io/network-status']
 #
 # Example network status json string:
 #


### PR DESCRIPTION
Annotation `k8s.v1.cni.cncf.io/networks-status` has been changed to `k8s.v1.cni.cncf.io/network-status` and the former is no longer supported [1]

[1] https://github.com/k8snetworkplumbingwg/network-attachment-definition-client/pull/45