### PR TITLE
Remove generation field from deployment assertion

### DIFF
--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -14,7 +14,6 @@ kind: Ironic
 metadata:
   finalizers:
   - Ironic
-  generation: 1
   name: ironic
   namespace: openstack
 spec:
@@ -88,7 +87,6 @@ kind: IronicAPI
 metadata:
   finalizers:
   - IronicAPI
-  generation: 1
   name: ironic-api
   namespace: openstack
   ownerReferences:
@@ -128,7 +126,6 @@ kind: IronicConductor
 metadata:
   finalizers:
   - IronicConductor
-  generation: 1
   name: ironic-conductor
   namespace: openstack
   ownerReferences:
@@ -166,7 +163,6 @@ kind: IronicInspector
 metadata:
   finalizers:
   - IronicInspector
-  generation: 1
   name: ironic-inspector
   namespace: openstack
   ownerReferences:


### PR DESCRIPTION
The generation field will update everytime the resource is updated so we cannot and should not validate the value of this field

Change-Id: I413df4623289a6a69afa61c3d0f190434e155ee4