### PR TITLE
Use volume for DownwardAPI - network-status

### DIFF
--- a/pkg/ironic/initcontainer.go
+++ b/pkg/ironic/initcontainer.go
@@ -106,14 +106,6 @@ func InitContainer(init APIDetails) []corev1.Container {
 			Name:  "ProvisionNetwork",
 			Value: init.ProvisionNetwork,
 		},
-		{
-			Name: "PodNetworksStatus",
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "metadata.annotations['k8s.v1.cni.cncf.io/network-status']",
-				},
-			},
-		},
 	}
 	if init.TransportURLSecret != "" {
 		envTransport := corev1.EnvVar{

--- a/pkg/ironic/volumes.go
+++ b/pkg/ironic/volumes.go
@@ -38,6 +38,21 @@ func GetVolumes(name string) []corev1.Volume {
 				EmptyDir: &corev1.EmptyDirVolumeSource{Medium: ""},
 			},
 		},
+		{
+			Name: "etc-podinfo",
+			VolumeSource: corev1.VolumeSource{
+				DownwardAPI: &corev1.DownwardAPIVolumeSource{
+					Items: []corev1.DownwardAPIVolumeFile{
+						{
+							Path: "network-status",
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: "metadata.annotations['k8s.v1.cni.cncf.io/network-status']",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 }
@@ -60,6 +75,11 @@ func GetInitVolumeMounts() []corev1.VolumeMount {
 			MountPath: "/var/lib/config-data/merged",
 			ReadOnly:  false,
 		},
+		{
+			Name:      "etc-podinfo",
+			MountPath: "/etc/podinfo",
+			ReadOnly:  false,
+		},
 	}
 
 }
@@ -75,6 +95,11 @@ func GetVolumeMounts() []corev1.VolumeMount {
 		{
 			Name:      "config-data-merged",
 			MountPath: "/var/lib/config-data/merged",
+			ReadOnly:  false,
+		},
+		{
+			Name:      "etc-podinfo",
+			MountPath: "/etc/podinfo",
 			ReadOnly:  false,
 		},
 	}

--- a/pkg/ironicinspector/initcontainer.go
+++ b/pkg/ironicinspector/initcontainer.go
@@ -99,14 +99,6 @@ func InitContainer(init APIDetails) []corev1.Container {
 				},
 			},
 		},
-		{
-			Name: "PodNetworksStatus",
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "metadata.annotations['k8s.v1.cni.cncf.io/network-status']",
-				},
-			},
-		},
 	}
 	if init.TransportURLSecret != "" {
 		envTransport := corev1.EnvVar{

--- a/pkg/ironicinspector/volumes.go
+++ b/pkg/ironicinspector/volumes.go
@@ -50,6 +50,21 @@ func GetVolumes(name string) []corev1.Volume {
 				EmptyDir: &corev1.EmptyDirVolumeSource{Medium: ""},
 			},
 		},
+		{
+			Name: "etc-podinfo",
+			VolumeSource: corev1.VolumeSource{
+				DownwardAPI: &corev1.DownwardAPIVolumeSource{
+					Items: []corev1.DownwardAPIVolumeFile{
+						{
+							Path: "network-status",
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: "metadata.annotations['k8s.v1.cni.cncf.io/network-status']",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 }
@@ -78,6 +93,11 @@ func GetInitVolumeMounts() []corev1.VolumeMount {
 			MountPath: "/var/lib/ironic",
 			ReadOnly:  false,
 		},
+		{
+			Name:      "etc-podinfo",
+			MountPath: "/etc/podinfo",
+			ReadOnly:  false,
+		},
 	}
 
 }
@@ -103,6 +123,11 @@ func GetVolumeMounts() []corev1.VolumeMount {
 		{
 			Name:      "var-lib-ironic-inspector-dhcp-hostsdir",
 			MountPath: "/var/lib/ironic-inspector/dhcp-hostsdir",
+			ReadOnly:  false,
+		},
+		{
+			Name:      "etc-podinfo",
+			MountPath: "/etc/podinfo",
 			ReadOnly:  false,
 		},
 	}

--- a/templates/common/bin/get_net_ip
+++ b/templates/common/bin/get_net_ip
@@ -18,6 +18,8 @@ import os
 import json
 import sys
 
+from tenacity import Retrying, RetryError, stop_after_attempt, wait_exponential
+
 # Uses network status from pod:
 #   metadata.annotations['k8s.v1.cni.cncf.io/network-status']
 #
@@ -40,7 +42,20 @@ import sys
 
 def get_ip_from_network_status():
     namespace = os.environ.get('PodNamespace')
-    net_status = json.loads(os.environ.get('PodNetworksStatus'))
+    network_status_content = None
+    try:
+        for attempt in Retrying(
+            stop=stop_after_attempt(5),
+            wait=wait_exponential(multiplier=1, min=2, max=10)):
+            with attempt:
+                with open('/etc/podinfo/network-status') as f:
+                    network_status_content = f.read()
+                    net_status = json.loads(network_status_content)
+    except RetryError:
+        raise Exception(
+            f"Unable to load pod network status - /etc/podinfo/network-status contains: "
+            f"{network_status_content}")
+
     net_attachment_name = sys.argv[1]
 
     for net in net_status:


### PR DESCRIPTION
In some cases the annotations are not ready.
By using a volume we can add retrying logic in `get_net_ip` script.

Jira: [OSP-23573](https://issues.redhat.com//browse/OSP-23573)