### PR TITLE
Remove DatabaseUser from all resource specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,11 @@ spec:
     [DEFAULT]
     debug = true
   databaseInstance: openstack
-  databaseUser: ironic
   ironicAPI:
     replicas: 1
     containerImage: quay.io/tripleomastercentos9/openstack-ironic-api:current-tripleo
-  ironicConductor:
-    replicas: 1
+  ironicConductors:
+  - replicas: 1
     containerImage: quay.io/tripleomastercentos9/openstack-ironic-conductor:current-tripleo
     pxeContainerImage: quay.io/tripleomastercentos9/openstack-ironic-pxe:current-tripleo
     provisionNetwork: provision-net

--- a/api/bases/ironic.openstack.org_ironicapis.yaml
+++ b/api/bases/ironic.openstack.org_ironicapis.yaml
@@ -62,12 +62,6 @@ spec:
               databaseHostname:
                 description: DatabaseHostname - Ironic Database Hostname
                 type: string
-              databaseUser:
-                default: ironic
-                description: 'DatabaseUser - optional username used for ironic DB,
-                  defaults to ironic TODO: -> implement needs work in mariadb-operator,
-                  right now only ironic'
-                type: string
               debug:
                 description: Debug - enable debug for different deploy stages. If
                   an init container is used, it runs and the actual action pod gets

--- a/api/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/api/bases/ironic.openstack.org_ironicconductors.yaml
@@ -65,12 +65,6 @@ spec:
               databaseHostname:
                 description: DatabaseHostname - Ironic Database Hostname
                 type: string
-              databaseUser:
-                default: ironic
-                description: 'DatabaseUser - optional username used for ironic DB,
-                  defaults to ironic TODO: -> implement needs work in mariadb-operator,
-                  right now only ironic'
-                type: string
               debug:
                 description: Debug - enable debug for different deploy stages. If
                   an init container is used, it runs and the actual action pod gets

--- a/api/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/api/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -64,12 +64,6 @@ spec:
                   to get the credentials from the instance to create the DB. Might
                   not be required in future.
                 type: string
-              databaseUser:
-                default: ironic_inspector
-                description: 'DatabaseUser - optional username used for ironic DB,
-                  defaults to ironic TODO: -> implement needs work in mariadb-operator,
-                  right now only ironic'
-                type: string
               debug:
                 description: Debug - enable debug for different deploy stages. If
                   an init container is used, it runs and the actual action pod gets

--- a/api/bases/ironic.openstack.org_ironics.yaml
+++ b/api/bases/ironic.openstack.org_ironics.yaml
@@ -48,12 +48,6 @@ spec:
                   to get the credentials from the instance to create the DB. Might
                   not be required in future.
                 type: string
-              databaseUser:
-                default: ironic
-                description: 'DatabaseUser - optional username used for ironic DB,
-                  defaults to ironic. TODO: -> implement needs work in mariadb-operator,
-                  right now only ironic.'
-                type: string
               debug:
                 description: Debug - enable debug for different deploy stages. If
                   an init container is used, it runs and the actual action pod gets
@@ -97,12 +91,6 @@ spec:
                     type: string
                   databaseHostname:
                     description: DatabaseHostname - Ironic Database Hostname
-                    type: string
-                  databaseUser:
-                    default: ironic
-                    description: 'DatabaseUser - optional username used for ironic
-                      DB, defaults to ironic TODO: -> implement needs work in mariadb-operator,
-                      right now only ironic'
                     type: string
                   debug:
                     description: Debug - enable debug for different deploy stages.
@@ -309,12 +297,6 @@ spec:
                       type: string
                     databaseHostname:
                       description: DatabaseHostname - Ironic Database Hostname
-                      type: string
-                    databaseUser:
-                      default: ironic
-                      description: 'DatabaseUser - optional username used for ironic
-                        DB, defaults to ironic TODO: -> implement needs work in mariadb-operator,
-                        right now only ironic'
                       type: string
                     debug:
                       description: Debug - enable debug for different deploy stages.
@@ -530,12 +512,6 @@ spec:
                     description: MariaDB instance name. Right now required by the
                       maridb-operator to get the credentials from the instance to
                       create the DB. Might not be required in future.
-                    type: string
-                  databaseUser:
-                    default: ironic_inspector
-                    description: 'DatabaseUser - optional username used for ironic
-                      DB, defaults to ironic TODO: -> implement needs work in mariadb-operator,
-                      right now only ironic'
                     type: string
                   debug:
                     description: Debug - enable debug for different deploy stages.

--- a/api/v1beta1/ironic_types.go
+++ b/api/v1beta1/ironic_types.go
@@ -50,12 +50,6 @@ type IronicSpec struct {
 	// Might not be required in future.
 	DatabaseInstance string `json:"databaseInstance"`
 
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=ironic
-	// DatabaseUser - optional username used for ironic DB, defaults to ironic.
-	// TODO: -> implement needs work in mariadb-operator, right now only ironic.
-	DatabaseUser string `json:"databaseUser"`
-
 	// +kubebuilder:validation:Required
 	// Secret containing OpenStack password information for ironic IronicDatabasePassword, AdminPassword
 	Secret string `json:"secret"`

--- a/api/v1beta1/ironic_webhook.go
+++ b/api/v1beta1/ironic_webhook.go
@@ -480,10 +480,6 @@ func defaultIronicAPI(spec *IronicSpec) {
 	if spec.IronicAPI.ServiceUser == "" {
 		spec.IronicAPI.ServiceUser = spec.ServiceUser
 	}
-	// DatabaseUser
-	if spec.IronicAPI.DatabaseUser == "" {
-		spec.IronicAPI.DatabaseUser = spec.DatabaseUser
-	}
 	// Secret
 	if spec.IronicAPI.Secret == "" {
 		spec.IronicAPI.Secret = spec.Secret
@@ -519,10 +515,6 @@ func defaultIronicConductors(spec *IronicSpec) {
 		// ServiceUser
 		if c.ServiceUser == "" {
 			spec.IronicConductors[idx].ServiceUser = spec.ServiceUser
-		}
-		// DatabaseUser
-		if c.DatabaseUser == "" {
-			spec.IronicConductors[idx].DatabaseUser = spec.DatabaseUser
 		}
 		// RPCTransport
 		if c.RPCTransport == "" {

--- a/api/v1beta1/ironicapi_types.go
+++ b/api/v1beta1/ironicapi_types.go
@@ -51,12 +51,6 @@ type IronicAPISpec struct {
 	DatabaseHostname string `json:"databaseHostname,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=ironic
-	// DatabaseUser - optional username used for ironic DB, defaults to ironic
-	// TODO: -> implement needs work in mariadb-operator, right now only ironic
-	DatabaseUser string `json:"databaseUser"`
-
-	// +kubebuilder:validation:Optional
 	// Secret containing OpenStack password information for IronicDatabasePassword, AdminPassword
 	Secret string `json:"secret,omitempty"`
 

--- a/api/v1beta1/ironicconductor_types.go
+++ b/api/v1beta1/ironicconductor_types.go
@@ -68,12 +68,6 @@ type IronicConductorSpec struct {
 	DatabaseHostname string `json:"databaseHostname,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=ironic
-	// DatabaseUser - optional username used for ironic DB, defaults to ironic
-	// TODO: -> implement needs work in mariadb-operator, right now only ironic
-	DatabaseUser string `json:"databaseUser"`
-
-	// +kubebuilder:validation:Optional
 	// Secret containing OpenStack password information for IronicDatabasePassword, AdminPassword
 	Secret string `json:"secret,omitempty"`
 

--- a/api/v1beta1/ironicinspector_types.go
+++ b/api/v1beta1/ironicinspector_types.go
@@ -56,12 +56,6 @@ type IronicInspectorSpec struct {
 	DatabaseInstance string `json:"databaseInstance"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=ironic_inspector
-	// DatabaseUser - optional username used for ironic DB, defaults to ironic
-	// TODO: -> implement needs work in mariadb-operator, right now only ironic
-	DatabaseUser string `json:"databaseUser"`
-
-	// +kubebuilder:validation:Optional
 	// Secret containing OpenStack password information for IronicInspectorDatabasePassword, AdminPassword
 	Secret string `json:"secret,omitempty"`
 

--- a/config/crd/bases/ironic.openstack.org_ironicapis.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicapis.yaml
@@ -62,12 +62,6 @@ spec:
               databaseHostname:
                 description: DatabaseHostname - Ironic Database Hostname
                 type: string
-              databaseUser:
-                default: ironic
-                description: 'DatabaseUser - optional username used for ironic DB,
-                  defaults to ironic TODO: -> implement needs work in mariadb-operator,
-                  right now only ironic'
-                type: string
               debug:
                 description: Debug - enable debug for different deploy stages. If
                   an init container is used, it runs and the actual action pod gets

--- a/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
@@ -65,12 +65,6 @@ spec:
               databaseHostname:
                 description: DatabaseHostname - Ironic Database Hostname
                 type: string
-              databaseUser:
-                default: ironic
-                description: 'DatabaseUser - optional username used for ironic DB,
-                  defaults to ironic TODO: -> implement needs work in mariadb-operator,
-                  right now only ironic'
-                type: string
               debug:
                 description: Debug - enable debug for different deploy stages. If
                   an init container is used, it runs and the actual action pod gets

--- a/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -64,12 +64,6 @@ spec:
                   to get the credentials from the instance to create the DB. Might
                   not be required in future.
                 type: string
-              databaseUser:
-                default: ironic_inspector
-                description: 'DatabaseUser - optional username used for ironic DB,
-                  defaults to ironic TODO: -> implement needs work in mariadb-operator,
-                  right now only ironic'
-                type: string
               debug:
                 description: Debug - enable debug for different deploy stages. If
                   an init container is used, it runs and the actual action pod gets

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -48,12 +48,6 @@ spec:
                   to get the credentials from the instance to create the DB. Might
                   not be required in future.
                 type: string
-              databaseUser:
-                default: ironic
-                description: 'DatabaseUser - optional username used for ironic DB,
-                  defaults to ironic. TODO: -> implement needs work in mariadb-operator,
-                  right now only ironic.'
-                type: string
               debug:
                 description: Debug - enable debug for different deploy stages. If
                   an init container is used, it runs and the actual action pod gets
@@ -97,12 +91,6 @@ spec:
                     type: string
                   databaseHostname:
                     description: DatabaseHostname - Ironic Database Hostname
-                    type: string
-                  databaseUser:
-                    default: ironic
-                    description: 'DatabaseUser - optional username used for ironic
-                      DB, defaults to ironic TODO: -> implement needs work in mariadb-operator,
-                      right now only ironic'
                     type: string
                   debug:
                     description: Debug - enable debug for different deploy stages.
@@ -309,12 +297,6 @@ spec:
                       type: string
                     databaseHostname:
                       description: DatabaseHostname - Ironic Database Hostname
-                      type: string
-                    databaseUser:
-                      default: ironic
-                      description: 'DatabaseUser - optional username used for ironic
-                        DB, defaults to ironic TODO: -> implement needs work in mariadb-operator,
-                        right now only ironic'
                       type: string
                     debug:
                       description: Debug - enable debug for different deploy stages.
@@ -530,12 +512,6 @@ spec:
                     description: MariaDB instance name. Right now required by the
                       maridb-operator to get the credentials from the instance to
                       create the DB. Might not be required in future.
-                    type: string
-                  databaseUser:
-                    default: ironic_inspector
-                    description: 'DatabaseUser - optional username used for ironic
-                      DB, defaults to ironic TODO: -> implement needs work in mariadb-operator,
-                      right now only ironic'
                     type: string
                   debug:
                     description: Debug - enable debug for different deploy stages.

--- a/config/samples/ironic_v1beta1_ironic.yaml
+++ b/config/samples/ironic_v1beta1_ironic.yaml
@@ -9,7 +9,6 @@ spec:
     [DEFAULT]
     debug = true
   databaseInstance: openstack
-  databaseUser: ironic
   storageClass: local-storage
   ironicAPI:
     replicas: 1

--- a/config/samples/ironic_v1beta1_ironic_conductor_groups.yaml
+++ b/config/samples/ironic_v1beta1_ironic_conductor_groups.yaml
@@ -9,7 +9,6 @@ spec:
     [DEFAULT]
     debug = true
   databaseInstance: openstack
-  databaseUser: ironic
   storageClass: standard-csi
   ironicAPI:
     replicas: 1

--- a/config/samples/ironic_v1beta1_ironic_standalone.yaml
+++ b/config/samples/ironic_v1beta1_ironic_standalone.yaml
@@ -10,7 +10,6 @@ spec:
     [DEFAULT]
     debug = true
   databaseInstance: openstack
-  databaseUser: ironic
   storageClass: local-storage
   ironicAPI:
     replicas: 1

--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -551,7 +551,7 @@ func (r *IronicReconciler) reconcileInit(
 	//
 	db := database.NewDatabase(
 		instance.Name,
-		instance.Spec.DatabaseUser,
+		instance.Name,
 		instance.Spec.Secret,
 		map[string]string{
 			"dbName": instance.Spec.DatabaseInstance,
@@ -834,13 +834,6 @@ func (r *IronicReconciler) inspectorDeploymentCreateOrUpdate(
 	op, err := controllerutil.CreateOrUpdate(
 		context.TODO(), r.Client, deployment, func() error {
 			deployment.Spec = instance.Spec.IronicInspector
-			// Add in transfers from umbrella Ironic (this instance) spec
-			// TODO: Add logic to determine when to set/overwrite, etc
-			// TODO: Revist DatabaseUser - It is currently implemented in lib-common,
-			//       but not in mariadb-operator. mariadb-operator always creates
-			//       database user with name == .DatabaseName
-			//       See: https://raw.githubusercontent.com/openstack-k8s-operators/mariadb-operator/master/templates/database.sh
-			// deployment.Spec.DatabaseUser = instance.Spec.DatabaseUser
 			err := controllerutil.SetControllerReference(
 				instance, deployment, r.Scheme)
 			if err != nil {

--- a/controllers/ironicinspector_controller.go
+++ b/controllers/ironicinspector_controller.go
@@ -714,7 +714,7 @@ func (r *IronicInspectorReconciler) reconcileServiceDBinstance(
 	databaseName := strings.Replace(instance.Name, "-", "_", -1)
 	db := database.NewDatabase(
 		databaseName,
-		instance.Spec.DatabaseUser,
+		databaseName,
 		instance.Spec.Secret,
 		map[string]string{
 			"dbName": instance.Spec.DatabaseInstance,

--- a/pkg/ironic/dbsync.go
+++ b/pkg/ironic/dbsync.go
@@ -85,7 +85,6 @@ func DbSyncJob(
 	initContainerDetails := APIDetails{
 		ContainerImage:       instance.Spec.IronicAPI.ContainerImage,
 		DatabaseHost:         instance.Status.DatabaseHostname,
-		DatabaseUser:         instance.Spec.DatabaseUser,
 		DatabaseName:         DatabaseName,
 		OSPSecret:            instance.Spec.Secret,
 		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,

--- a/pkg/ironic/initcontainer.go
+++ b/pkg/ironic/initcontainer.go
@@ -26,7 +26,6 @@ type APIDetails struct {
 	ContainerImage       string
 	PxeContainerImage    string
 	DatabaseHost         string
-	DatabaseUser         string
 	DatabaseName         string
 	TransportURLSecret   string
 	OSPSecret            string
@@ -58,7 +57,6 @@ func InitContainer(init APIDetails) []corev1.Container {
 
 	envVars := map[string]env.Setter{}
 	envVars["DatabaseHost"] = env.SetValue(init.DatabaseHost)
-	envVars["DatabaseUser"] = env.SetValue(init.DatabaseUser)
 	envVars["DatabaseName"] = env.SetValue(init.DatabaseName)
 	envVars["DeployHTTPURL"] = env.SetValue(init.DeployHTTPURL)
 	envVars["IngressDomain"] = env.SetValue(init.IngressDomain)

--- a/pkg/ironicapi/deployment.go
+++ b/pkg/ironicapi/deployment.go
@@ -149,7 +149,6 @@ func Deployment(
 	initContainerDetails := ironic.APIDetails{
 		ContainerImage:       instance.Spec.ContainerImage,
 		DatabaseHost:         instance.Spec.DatabaseHostname,
-		DatabaseUser:         instance.Spec.DatabaseUser,
 		DatabaseName:         ironic.DatabaseName,
 		OSPSecret:            instance.Spec.Secret,
 		TransportURLSecret:   instance.Spec.TransportURLSecret,

--- a/pkg/ironicconductor/statefulset.go
+++ b/pkg/ironicconductor/statefulset.go
@@ -306,7 +306,6 @@ func StatefulSet(
 		ContainerImage:       instance.Spec.ContainerImage,
 		PxeContainerImage:    instance.Spec.PxeContainerImage,
 		DatabaseHost:         instance.Spec.DatabaseHostname,
-		DatabaseUser:         instance.Spec.DatabaseUser,
 		DatabaseName:         ironic.DatabaseName,
 		OSPSecret:            instance.Spec.Secret,
 		TransportURLSecret:   instance.Spec.TransportURLSecret,

--- a/pkg/ironicinspector/dbsync.go
+++ b/pkg/ironicinspector/dbsync.go
@@ -86,7 +86,6 @@ func DbSyncJob(
 	initContainerDetails := APIDetails{
 		ContainerImage:       instance.Spec.ContainerImage,
 		DatabaseHost:         instance.Status.DatabaseHostname,
-		DatabaseUser:         instance.Spec.DatabaseUser,
 		DatabaseName:         DatabaseName,
 		OSPSecret:            instance.Spec.Secret,
 		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,

--- a/pkg/ironicinspector/initcontainer.go
+++ b/pkg/ironicinspector/initcontainer.go
@@ -27,7 +27,6 @@ type APIDetails struct {
 	PxeInit              bool
 	PxeContainerImage    string
 	DatabaseHost         string
-	DatabaseUser         string
 	DatabaseName         string
 	TransportURLSecret   string
 	OSPSecret            string
@@ -54,7 +53,6 @@ func InitContainer(init APIDetails) []corev1.Container {
 
 	envVars := map[string]env.Setter{}
 	envVars["DatabaseHost"] = env.SetValue(init.DatabaseHost)
-	envVars["DatabaseUser"] = env.SetValue(init.DatabaseUser)
 	envVars["DatabaseName"] = env.SetValue(init.DatabaseName)
 	envVars["InspectorHTTPURL"] = env.SetValue(init.InspectorHTTPURL)
 	envVars["IngressDomain"] = env.SetValue(init.IngressDomain)

--- a/pkg/ironicinspector/statefulset.go
+++ b/pkg/ironicinspector/statefulset.go
@@ -270,7 +270,6 @@ func StatefulSet(
 		ContainerImage:       instance.Spec.ContainerImage,
 		PxeContainerImage:    instance.Spec.PxeContainerImage,
 		DatabaseHost:         instance.Status.DatabaseHostname,
-		DatabaseUser:         instance.Spec.DatabaseUser,
 		DatabaseName:         DatabaseName,
 		OSPSecret:            instance.Spec.Secret,
 		TransportURLSecret:   instance.Status.TransportURLSecret,

--- a/templates/ironic/bin/init.sh
+++ b/templates/ironic/bin/init.sh
@@ -18,7 +18,7 @@ set -ex
 # Secrets are obtained from ENV variables.
 export DB=${DatabaseName:-"ironic"}
 export DBHOST=${DatabaseHost:?"Please specify a DatabaseHost variable."}
-export DBUSER=${DatabaseUser:-"ironic"}
+export DBUSER=${DatabaseName:-"ironic"}
 export DBPASSWORD=${DatabasePassword:?"Please specify a DatabasePassword variable."}
 export IRONICPASSWORD=${IronicPassword:?"Please specify a IronicPassword variable."}
 export TRANSPORTURL=${TransportURL:-""}

--- a/templates/ironicinspector/bin/init.sh
+++ b/templates/ironicinspector/bin/init.sh
@@ -17,7 +17,7 @@
 # Secrets are obtained from ENV variables.
 export DB=${DatabaseName:-"ironic_inspector"}
 export DBHOST=${DatabaseHost:?"Please specify a DatabaseHost variable."}
-export DBUSER=${DatabaseUser:-"ironic_inspector"}
+export DBUSER=${DatabaseName:-"ironic_inspector"}
 export DBPASSWORD=${DatabasePassword:?"Please specify a DatabasePassword variable."}
 export INSPECTORPASSWORD=${IronicInspectorPassword:?"Please specify a IronicInspectorPassword variable."}
 export TRANSPORTURL=${TransportURL:-""}

--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -21,10 +21,8 @@ spec:
     [DEFAULT]
     debug = true
   databaseInstance: openstack
-  databaseUser: ironic
   ironicAPI:
     containerImage: quay.io/tripleozedcentos9/openstack-ironic-api:current-tripleo
-    databaseUser: ironic
     passwordSelectors:
       database: IronicDatabasePassword
       service: IronicPassword
@@ -34,7 +32,6 @@ spec:
     standalone: false
   ironicConductors:
   - containerImage: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
-    databaseUser: ironic
     passwordSelectors:
       database: IronicDatabasePassword
       service: IronicPassword
@@ -47,7 +44,6 @@ spec:
   ironicInspector:
     containerImage: quay.io/tripleozedcentos9/openstack-ironic-inspector:current-tripleo
     customServiceConfig: '# add your customization here'
-    databaseUser: ironic_inspector
     passwordSelectors:
       database: IronicInspectorDatabasePassword
       service: IronicInspectorPassword
@@ -90,7 +86,6 @@ spec:
   containerImage: quay.io/tripleozedcentos9/openstack-ironic-api:current-tripleo
   customServiceConfig: '# add your customization here'
   databaseHostname: openstack
-  databaseUser: ironic
   debug:
     bootstrap: false
     dbSync: false
@@ -125,7 +120,6 @@ spec:
   containerImage: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
   customServiceConfig: '# add your customization here'
   databaseHostname: openstack
-  databaseUser: ironic
   debug:
     bootstrap: false
     dbSync: false
@@ -161,7 +155,6 @@ spec:
   containerImage: quay.io/tripleozedcentos9/openstack-ironic-inspector:current-tripleo
   customServiceConfig: '# add your customization here'
   databaseInstance: openstack
-  databaseUser: ironic_inspector
   debug:
     bootstrap: false
     dbSync: false


### PR DESCRIPTION
It is currently implemented in lib-common, but not in mariadb-operator. mariadb-operator always creates database user with name == .DatabaseName.

Whith this change we pass the same value (the database name) to lib-common's NewDatabase function.

See: https://raw.githubusercontent.com/openstack-k8s-operators/mariadb-operator/master/templates/database.sh