### PR TITLE
Fix deploy URLs for standalone

### DIFF
--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -45,6 +45,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/endpoint"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/labels"
@@ -678,6 +679,17 @@ func (r *IronicConductorReconciler) generateServiceConfigMaps(
 		templateParameters["KeystoneInternalURL"] = instance.Spec.KeystoneVars["keystoneInternalURL"]
 		templateParameters["KeystonePublicURL"] = instance.Spec.KeystoneVars["keystonePublicURL"]
 		templateParameters["ServiceUser"] = instance.Spec.ServiceUser
+	} else {
+		ironicAPI, err := ironicv1.GetIronicAPI(
+			ctx, h, instance.Namespace, map[string]string{})
+		if err != nil {
+			return err
+		}
+		ironicPublicURL, err := ironicAPI.GetEndpoint(endpoint.EndpointPublic)
+		if err != nil {
+			return err
+		}
+		templateParameters["IronicPublicURL"] = ironicPublicURL
 	}
 	dhcpRanges, err := ironic.PrefixOrNetmaskFromCIDR(instance.Spec.DHCPRanges)
 	if err != nil {

--- a/pkg/ironicconductor/statefulset.go
+++ b/pkg/ironicconductor/statefulset.go
@@ -299,7 +299,7 @@ func StatefulSet(
 	deployHTTPURL := "http://%(ProvisionNetworkIP)s:8088/"
 	if instance.Spec.ProvisionNetwork == "" {
 		// Build what the fully qualified Route hostname will be when the Route exists
-		deployHTTPURL = "http://%(PodName)s-%(PodNamespace)s.apps.%(IngressDomain)s/"
+		deployHTTPURL = "http://%(PodName)s-%(PodNamespace)s.%(IngressDomain)s/"
 	}
 
 	initContainerDetails := ironic.APIDetails{

--- a/templates/common/config/ironic.conf
+++ b/templates/common/config/ironic.conf
@@ -32,7 +32,11 @@ auth_strategy={{if .Standalone}}noauth{{else}}keystone{{end}}
 grub_config_path=EFI/BOOT/grub.cfg
 isolinux_bin=/usr/share/syslinux/isolinux.bin
 
-{{if not .Standalone}}
+{{if .Standalone}}
+[service_catalog]
+auth_type=none
+endpoint_override={{ .IronicPublicURL }}
+{{else}}
 [keystone_authtoken]
 project_domain_name=Default
 user_domain_name=Default


### PR DESCRIPTION
Fix deployHTTPURL:
This aligns with what inspector does now, ".apps" is already in
PodNamespace so it is not required here.

Standalone: set ironic API endpoint override:
This is required for deployment for heartbeat, etc.
This has been confirmed to work when there is no provisioning network.
To get this working when there is a provisioning network might require
more changes, since the ironic API needs to serve requests on the
provisioning network.