### PR TITLE
merge_config_dir - no crudini on ipxe scripts

### DIFF
--- a/templates/common/bin/common.sh
+++ b/templates/common/bin/common.sh
@@ -21,10 +21,10 @@ function merge_config_dir {
     for conf in $(find $1 -type f); do
         conf_base=$(basename $conf)
 
-        # If CFG already exist in ../merged and is not a json file,
+        # If CFG already exist in ../merged and is not a json or ipxe file,
         # we expect for now it can be merged using crudini.
         # Else, just copy the full file.
-        if [[ -f /var/lib/config-data/merged/${conf_base} && ${conf_base} != *.json ]]; then
+        if [[ -f /var/lib/config-data/merged/${conf_base} && ${conf_base} != *.json && ${conf_base} != *.ipxe ]]; then
             echo merging ${conf} into /var/lib/config-data/merged/${conf_base}
             crudini --merge /var/lib/config-data/merged/${conf_base} < ${conf}
         else


### PR DESCRIPTION
This bug showed up after running for couple of days, when ipxe script is already in in /var/lib/config-data/merged/. The iPXE script is copied there by function merge_config_dir after the crudini so issue seen only on re-run.

Jira: [OSP-23943](https://issues.redhat.com//browse/OSP-23943)