### PR TITLE
Unhide KeystoneVars

### DIFF
--- a/api/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/api/bases/ironic.openstack.org_ironicconductors.yaml
@@ -127,6 +127,11 @@ spec:
                   - start
                   type: object
                 type: array
+              keystoneVars:
+                additionalProperties:
+                  type: string
+                description: keystoneVars - Internally used map of Keystone API endpoints
+                type: object
               networkAttachments:
                 description: NetworkAttachments is a list of NetworkAttachment resource
                   names to expose the services to the given network

--- a/api/bases/ironic.openstack.org_ironics.yaml
+++ b/api/bases/ironic.openstack.org_ironics.yaml
@@ -360,6 +360,12 @@ spec:
                         - start
                         type: object
                       type: array
+                    keystoneVars:
+                      additionalProperties:
+                        type: string
+                      description: keystoneVars - Internally used map of Keystone
+                        API endpoints
+                      type: object
                     networkAttachments:
                       description: NetworkAttachments is a list of NetworkAttachment
                         resource names to expose the services to the given network

--- a/api/v1beta1/ironicconductor_types.go
+++ b/api/v1beta1/ironicconductor_types.go
@@ -126,8 +126,8 @@ type IronicConductorSpec struct {
 	RPCTransport string `json:"rpcTransport"`
 
 	// +kubebuilder:validation:Optional
-	// keystoneVars - (Hidden) Internally used map of Keystone API endpoints
-	KeystoneVars map[string]string `json:"-"`
+	// keystoneVars - Internally used map of Keystone API endpoints
+	KeystoneVars map[string]string `json:"keystoneVars,omitempty"`
 }
 
 // IronicConductorStatus defines the observed state of IronicConductor

--- a/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
@@ -127,6 +127,11 @@ spec:
                   - start
                   type: object
                 type: array
+              keystoneVars:
+                additionalProperties:
+                  type: string
+                description: keystoneVars - Internally used map of Keystone API endpoints
+                type: object
               networkAttachments:
                 description: NetworkAttachments is a list of NetworkAttachment resource
                   names to expose the services to the given network

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -360,6 +360,12 @@ spec:
                         - start
                         type: object
                       type: array
+                    keystoneVars:
+                      additionalProperties:
+                        type: string
+                      description: keystoneVars - Internally used map of Keystone
+                        API endpoints
+                      type: object
                     networkAttachments:
                       description: NetworkAttachments is a list of NetworkAttachment
                         resource names to expose the services to the given network


### PR DESCRIPTION
Using the `json:"-" to "hide" the property cause issues, the generated config map using the values in the map end up with empty values. This might be caused by the json serialisation in the webhooks.

Let's just unhide the property, it may come in handy to expose them if we ever want to run conductor in a separate OCP cluster.

Jira: [osp-23942](https://issues.redhat.com//browse/osp-23942)