### PR TITLE
Add null_conductor_group ReadyCount check

### DIFF
--- a/tests/kuttl/tests/deployments/02-assert-deploy-ironic-conductor-groups.yaml
+++ b/tests/kuttl/tests/deployments/02-assert-deploy-ironic-conductor-groups.yaml
@@ -36,5 +36,6 @@ status:
   databaseHostname: openstack
   ironicAPIReadyCount: 1
   ironicConductorReadyCount:
+    null_conductor_group_null: 1
     auckland: 1
     stockholm: 1


### PR DESCRIPTION
This was a carry over from the last PR.  The check for the null conductor group is valid because there is one deployed with no name.

Change-Id: I9bf98194744215b3d0642cc304a6b908b72511f0