### PR TITLE
Remove depedency on install_yaml for resource creation

### DIFF
--- a/tests/kuttl/tests/deployments/01-deploy-ironic.yaml
+++ b/tests/kuttl/tests/deployments/01-deploy-ironic.yaml
@@ -2,5 +2,5 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      PWD=$INSTALL_YAMLS
-      make -C $INSTALL_YAMLS ironic_deploy
+      cp ../../../../config/samples/ironic_v1beta1_ironic.yaml deploy
+      oc kustomize deploy | oc apply -n openstack -f -

--- a/tests/kuttl/tests/deployments/03-cleanup-ironic.yaml
+++ b/tests/kuttl/tests/deployments/03-cleanup-ironic.yaml
@@ -1,6 +1,7 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-commands:
-  - script: |
-      PWD=$INSTALL_YAMLS
-      make -C $INSTALL_YAMLS ironic_deploy_cleanup
+delete:
+- apiVersion: ironic.openstack.org/v1beta1
+  kind: Ironic
+  name: ironic
+  namespace: openstack

--- a/tests/kuttl/tests/deployments/deploy/ironic_v1beta1_ironic.yaml
+++ b/tests/kuttl/tests/deployments/deploy/ironic_v1beta1_ironic.yaml
@@ -1,0 +1,25 @@
+apiVersion: ironic.openstack.org/v1beta1
+kind: Ironic
+metadata:
+  name: ironic
+  namespace: openstack
+spec:
+  serviceUser: ironic
+  customServiceConfig: |
+    [DEFAULT]
+    debug = true
+  databaseInstance: openstack
+  storageClass: local-storage
+  ironicAPI:
+    replicas: 1
+    containerImage: quay.io/tripleozedcentos9/openstack-ironic-api:current-tripleo
+  ironicConductors:
+  - replicas: 1
+    containerImage: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
+    pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+    storageRequest: 10G
+  ironicInspector:
+    replicas: 1
+    containerImage: quay.io/tripleozedcentos9/openstack-ironic-inspector:current-tripleo
+    pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+  secret: ironic-secret

--- a/tests/kuttl/tests/deployments/deploy/kustomization.yaml
+++ b/tests/kuttl/tests/deployments/deploy/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./ironic_v1beta1_ironic.yaml
+patches:
+- patch: |-
+    - op: replace
+      path: /spec/secret
+      value: osp-secret
+  target:
+    kind: Ironic


### PR DESCRIPTION
Following patterns established in https://github.com/openstack-k8s-operators/keystone-operator/pull/224

Change-Id: I65ca5347bfd3f04b3f4d17e7f59e6a7cb158299b