### PR TITLE
Use golang 1.19 in lint jobs

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Checkout project code
         uses: actions/checkout@v2
       - name: Checkout openstack-k8s-operators-ci project
@@ -32,7 +32,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Checkout project code
         uses: actions/checkout@v2
       - name: Run golangci lint
@@ -48,7 +48,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Checkout project code
         uses: actions/checkout@v2
       - name: Run operator-lint


### PR DESCRIPTION
Now this operator is developed with golang 1.19 instead of 1.18, so we should use the correct version.