### PR TITLE
Replace TripleO images by TCIB images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,10 +319,10 @@ operator-lint: gowork ## Runs operator-lint
 # $oc delete -n openstack mutatingwebhookconfiguration/mironic.kb.io
 SKIP_CERT ?=false
 .PHONY: run-with-webhook
-run-with-webhook: export IRONIC_API_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-ironic-api:current-tripleo
-run-with-webhook: export IRONIC_CONDUCTOR_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
-run-with-webhook: export IRONIC_INSPECTOR_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-ironic-inspector:current-tripleo
-run-with-webhook: export IRONIC_PXE_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+run-with-webhook: export IRONIC_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ironic-api:current-podified
+run-with-webhook: export IRONIC_CONDUCTOR_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
+run-with-webhook: export IRONIC_INSPECTOR_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ironic-inspector:current-podified
+run-with-webhook: export IRONIC_PXE_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/configure_local_webhook.sh
 	go run ./main.go

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ spec:
   databaseInstance: openstack
   ironicAPI:
     replicas: 1
-    containerImage: quay.io/tripleomastercentos9/openstack-ironic-api:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-ironic-api:current-podified
   ironicConductors:
   - replicas: 1
-    containerImage: quay.io/tripleomastercentos9/openstack-ironic-conductor:current-tripleo
-    pxeContainerImage: quay.io/tripleomastercentos9/openstack-ironic-pxe:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
+    pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
     provisionNetwork: provision-net
   secret: ironic-secret
 ```

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -12,10 +12,10 @@ spec:
       - name: manager
         env:
         - name: IRONIC_API_IMAGE_URL_DEFAULT
-          value: quay.io/tripleozedcentos9/openstack-ironic-api:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-ironic-api:current-podified
         - name: IRONIC_CONDUCTOR_IMAGE_URL_DEFAULT
-          value: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
         - name: IRONIC_INSPECTOR_IMAGE_URL_DEFAULT
-          value: quay.io/tripleozedcentos9/openstack-ironic-inspector:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-ironic-inspector:current-podified
         - name: IRONIC_PXE_IMAGE_URL_DEFAULT
-          value: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified

--- a/config/samples/ironic_v1beta1_ironic.yaml
+++ b/config/samples/ironic_v1beta1_ironic.yaml
@@ -12,14 +12,14 @@ spec:
   storageClass: local-storage
   ironicAPI:
     replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-ironic-api:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-ironic-api:current-podified
   ironicConductors:
   - replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
-    pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
+    pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
     storageRequest: 10G
   ironicInspector:
     replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-ironic-inspector:current-tripleo
-    pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-ironic-inspector:current-podified
+    pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
   secret: osp-secret

--- a/config/samples/ironic_v1beta1_ironic_conductor_groups.yaml
+++ b/config/samples/ironic_v1beta1_ironic_conductor_groups.yaml
@@ -12,24 +12,24 @@ spec:
   storageClass: local-storage
   ironicAPI:
     replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-ironic-api:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-ironic-api:current-podified
   ironicConductors:
   - replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
-    pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
+    pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
     storageRequest: 10G
   - conductorGroup: auckland
     replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
-    pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
+    pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
     storageRequest: 10G
   - conductorGroup: stockholm
     replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
-    pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
+    pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
     storageRequest: 10G
   ironicInspector:
     replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-ironic-inspector:current-tripleo
-    pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-ironic-inspector:current-podified
+    pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
   secret: osp-secret

--- a/config/samples/ironic_v1beta1_ironic_standalone.yaml
+++ b/config/samples/ironic_v1beta1_ironic_standalone.yaml
@@ -13,14 +13,14 @@ spec:
   storageClass: local-storage
   ironicAPI:
     replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-ironic-api:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-ironic-api:current-podified
   ironicConductors:
   - replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
-    pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
+    pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
     storageRequest: 10G
   ironicInspector:
     replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-ironic-inspector:current-tripleo
-    pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-ironic-inspector:current-podified
+    pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
   secret: ironic-secret

--- a/config/samples/ironic_v1beta1_ironicneutronagent.yaml
+++ b/config/samples/ironic_v1beta1_ironicneutronagent.yaml
@@ -4,6 +4,6 @@ metadata:
   name: ironic-neutron-agent
   namespace: openstack
 spec:
-  containerImage: quay.io/tripleomastercentos9/openstack-ironic-neutron-agent:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-ironic-neutron-agent:current-podified
   replicas: 1
   secret: osp-secret

--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -22,7 +22,7 @@ spec:
     debug = true
   databaseInstance: openstack
   ironicAPI:
-    containerImage: quay.io/tripleozedcentos9/openstack-ironic-api:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-ironic-api:current-podified
     passwordSelectors:
       database: IronicDatabasePassword
       service: IronicPassword
@@ -31,24 +31,24 @@ spec:
     serviceUser: ironic
     standalone: false
   ironicConductors:
-  - containerImage: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
+  - containerImage: quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
     passwordSelectors:
       database: IronicDatabasePassword
       service: IronicPassword
-    pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+    pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
     replicas: 1
     rpcTransport: json-rpc
     serviceUser: ironic
     standalone: false
     storageRequest: 10G
   ironicInspector:
-    containerImage: quay.io/tripleozedcentos9/openstack-ironic-inspector:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-ironic-inspector:current-podified
     customServiceConfig: '# add your customization here'
     passwordSelectors:
       database: IronicInspectorDatabasePassword
       service: IronicInspectorPassword
     preserveJobs: true
-    pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+    pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
     rabbitMqClusterName: rabbitmq
     replicas: 1
     rpcTransport: json-rpc
@@ -83,7 +83,7 @@ metadata:
     kind: Ironic
     name: ironic
 spec:
-  containerImage: quay.io/tripleozedcentos9/openstack-ironic-api:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-ironic-api:current-podified
   customServiceConfig: '# add your customization here'
   databaseHostname: openstack
   debug:
@@ -116,7 +116,7 @@ metadata:
     name: ironic
 spec:
   conductorGroup: ""
-  containerImage: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
   customServiceConfig: '# add your customization here'
   databaseHostname: openstack
   debug:
@@ -125,7 +125,7 @@ spec:
   passwordSelectors:
     database: IronicDatabasePassword
     service: IronicPassword
-  pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+  pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
   replicas: 1
   resources: {}
   rpcTransport: json-rpc
@@ -150,7 +150,7 @@ metadata:
     kind: Ironic
     name: ironic
 spec:
-  containerImage: quay.io/tripleozedcentos9/openstack-ironic-inspector:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-ironic-inspector:current-podified
   customServiceConfig: '# add your customization here'
   databaseInstance: openstack
   debug:
@@ -160,7 +160,7 @@ spec:
     database: IronicInspectorDatabasePassword
     service: IronicInspectorPassword
   preserveJobs: true
-  pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+  pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
   rabbitMqClusterName: rabbitmq
   replicas: 1
   resources: {}

--- a/tests/kuttl/tests/deployments/02-assert-deploy-ironic-conductor-groups.yaml
+++ b/tests/kuttl/tests/deployments/02-assert-deploy-ironic-conductor-groups.yaml
@@ -11,26 +11,26 @@ spec:
   databaseInstance: openstack
   ironicAPI:
     replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-ironic-api:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-ironic-api:current-podified
   ironicConductors:
   - replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
-    pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
+    pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
     storageRequest: 10G
   - conductorGroup: auckland
     replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
-    pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
+    pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
     storageRequest: 10G
   - conductorGroup: stockholm
     replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-ironic-conductor:current-tripleo
-    pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
+    pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
     storageRequest: 10G
   ironicInspector:
     replicas: 1
-    containerImage: quay.io/tripleozedcentos9/openstack-ironic-inspector:current-tripleo
-    pxeContainerImage: quay.io/tripleozedcentos9/openstack-ironic-pxe:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-ironic-inspector:current-podified
+    pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
   secret: osp-secret
 status:
   databaseHostname: openstack


### PR DESCRIPTION
We imported container build tools from TripleO as TCIB[1]. Now we are retiring TripleO and should complete the migration.

[1] https://github.com/openstack-k8s-operators/tcib