### PR TITLE
Remove unused boostrap debug flag

### DIFF
--- a/api/bases/ironic.openstack.org_ironicapis.yaml
+++ b/api/bases/ironic.openstack.org_ironicapis.yaml
@@ -68,10 +68,6 @@ spec:
                   an init container is used, it runs and the actual action pod gets
                   started with sleep infinity
                 properties:
-                  bootstrap:
-                    default: false
-                    description: ReadyCount enable debug
-                    type: boolean
                   dbSync:
                     default: false
                     description: DBSync enable debug

--- a/api/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/api/bases/ironic.openstack.org_ironicconductors.yaml
@@ -71,10 +71,6 @@ spec:
                   an init container is used, it runs and the actual action pod gets
                   started with sleep infinity
                 properties:
-                  bootstrap:
-                    default: false
-                    description: ReadyCount enable debug
-                    type: boolean
                   dbSync:
                     default: false
                     description: DBSync enable debug

--- a/api/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/api/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -70,10 +70,6 @@ spec:
                   an init container is used, it runs and the actual action pod gets
                   started with sleep infinity
                 properties:
-                  bootstrap:
-                    default: false
-                    description: ReadyCount enable debug
-                    type: boolean
                   dbSync:
                     default: false
                     description: DBSync enable debug

--- a/api/bases/ironic.openstack.org_ironicneutronagents.yaml
+++ b/api/bases/ironic.openstack.org_ironicneutronagents.yaml
@@ -67,10 +67,6 @@ spec:
                   an init container is used, it runs and the actual action pod gets
                   started with sleep infinity
                 properties:
-                  bootstrap:
-                    default: false
-                    description: ReadyCount enable debug
-                    type: boolean
                   service:
                     default: false
                     description: Service enable debug

--- a/api/bases/ironic.openstack.org_ironics.yaml
+++ b/api/bases/ironic.openstack.org_ironics.yaml
@@ -53,10 +53,6 @@ spec:
                   an init container is used, it runs and the actual action pod gets
                   started with sleep infinity
                 properties:
-                  bootstrap:
-                    default: false
-                    description: ReadyCount enable debug
-                    type: boolean
                   dbSync:
                     default: false
                     description: DBSync enable debug
@@ -98,10 +94,6 @@ spec:
                       If an init container is used, it runs and the actual action
                       pod gets started with sleep infinity
                     properties:
-                      bootstrap:
-                        default: false
-                        description: ReadyCount enable debug
-                        type: boolean
                       dbSync:
                         default: false
                         description: DBSync enable debug
@@ -304,10 +296,6 @@ spec:
                         If an init container is used, it runs and the actual action
                         pod gets started with sleep infinity
                       properties:
-                        bootstrap:
-                          default: false
-                          description: ReadyCount enable debug
-                          type: boolean
                         dbSync:
                           default: false
                           description: DBSync enable debug
@@ -526,10 +514,6 @@ spec:
                       If an init container is used, it runs and the actual action
                       pod gets started with sleep infinity
                     properties:
-                      bootstrap:
-                        default: false
-                        description: ReadyCount enable debug
-                        type: boolean
                       dbSync:
                         default: false
                         description: DBSync enable debug

--- a/api/v1beta1/ironic_types.go
+++ b/api/v1beta1/ironic_types.go
@@ -171,10 +171,6 @@ type IronicDebug struct {
 	DBSync bool `json:"dbSync"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
-	// ReadyCount enable debug
-	Bootstrap bool `json:"bootstrap"`
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=false
 	// Service enable debug
 	Service bool `json:"service"`
 }

--- a/api/v1beta1/ironicneutronagent_types.go
+++ b/api/v1beta1/ironicneutronagent_types.go
@@ -34,10 +34,6 @@ type IronicNeutronAgentPasswordSelector struct {
 type IronicNeutronAgentDebug struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
-	// ReadyCount enable debug
-	Bootstrap bool `json:"bootstrap"`
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=false
 	// Service enable debug
 	Service bool `json:"service"`
 }

--- a/config/crd/bases/ironic.openstack.org_ironicapis.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicapis.yaml
@@ -68,10 +68,6 @@ spec:
                   an init container is used, it runs and the actual action pod gets
                   started with sleep infinity
                 properties:
-                  bootstrap:
-                    default: false
-                    description: ReadyCount enable debug
-                    type: boolean
                   dbSync:
                     default: false
                     description: DBSync enable debug

--- a/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
@@ -71,10 +71,6 @@ spec:
                   an init container is used, it runs and the actual action pod gets
                   started with sleep infinity
                 properties:
-                  bootstrap:
-                    default: false
-                    description: ReadyCount enable debug
-                    type: boolean
                   dbSync:
                     default: false
                     description: DBSync enable debug

--- a/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -70,10 +70,6 @@ spec:
                   an init container is used, it runs and the actual action pod gets
                   started with sleep infinity
                 properties:
-                  bootstrap:
-                    default: false
-                    description: ReadyCount enable debug
-                    type: boolean
                   dbSync:
                     default: false
                     description: DBSync enable debug

--- a/config/crd/bases/ironic.openstack.org_ironicneutronagents.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicneutronagents.yaml
@@ -67,10 +67,6 @@ spec:
                   an init container is used, it runs and the actual action pod gets
                   started with sleep infinity
                 properties:
-                  bootstrap:
-                    default: false
-                    description: ReadyCount enable debug
-                    type: boolean
                   service:
                     default: false
                     description: Service enable debug

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -53,10 +53,6 @@ spec:
                   an init container is used, it runs and the actual action pod gets
                   started with sleep infinity
                 properties:
-                  bootstrap:
-                    default: false
-                    description: ReadyCount enable debug
-                    type: boolean
                   dbSync:
                     default: false
                     description: DBSync enable debug
@@ -98,10 +94,6 @@ spec:
                       If an init container is used, it runs and the actual action
                       pod gets started with sleep infinity
                     properties:
-                      bootstrap:
-                        default: false
-                        description: ReadyCount enable debug
-                        type: boolean
                       dbSync:
                         default: false
                         description: DBSync enable debug
@@ -304,10 +296,6 @@ spec:
                         If an init container is used, it runs and the actual action
                         pod gets started with sleep infinity
                       properties:
-                        bootstrap:
-                          default: false
-                          description: ReadyCount enable debug
-                          type: boolean
                         dbSync:
                           default: false
                           description: DBSync enable debug
@@ -526,10 +514,6 @@ spec:
                       If an init container is used, it runs and the actual action
                       pod gets started with sleep infinity
                     properties:
-                      bootstrap:
-                        default: false
-                        description: ReadyCount enable debug
-                        type: boolean
                       dbSync:
                         default: false
                         description: DBSync enable debug

--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -87,7 +87,6 @@ spec:
   customServiceConfig: '# add your customization here'
   databaseHostname: openstack
   debug:
-    bootstrap: false
     dbSync: false
     service: false
   passwordSelectors:
@@ -121,7 +120,6 @@ spec:
   customServiceConfig: '# add your customization here'
   databaseHostname: openstack
   debug:
-    bootstrap: false
     dbSync: false
     service: false
   passwordSelectors:
@@ -156,7 +154,6 @@ spec:
   customServiceConfig: '# add your customization here'
   databaseInstance: openstack
   debug:
-    bootstrap: false
     dbSync: false
     service: false
   passwordSelectors:


### PR DESCRIPTION
Ironic does not have separate bootstrap step and this flag is not actually used.