### PR TITLE
Fix defaulting of RPCTransport and ServiceUser

### DIFF
--- a/api/v1beta1/ironic_webhook.go
+++ b/api/v1beta1/ironic_webhook.go
@@ -511,13 +511,9 @@ func defaultIronicConductors(spec *IronicSpec) {
 			spec.IronicConductors[idx].Standalone = true
 		}
 		// ServiceUser
-		if c.ServiceUser == "" {
-			spec.IronicConductors[idx].ServiceUser = spec.ServiceUser
-		}
+		spec.IronicConductors[idx].ServiceUser = spec.ServiceUser
 		// RPCTransport
-		if c.RPCTransport == "" {
-			spec.IronicConductors[idx].RPCTransport = spec.RPCTransport
-		}
+		spec.IronicConductors[idx].RPCTransport = spec.RPCTransport
 		// Secret
 		if c.Secret == "" {
 			spec.IronicConductors[idx].Secret = spec.Secret
@@ -550,9 +546,7 @@ func defaultIronicInspector(spec *IronicSpec) {
 		spec.IronicInspector.DatabaseInstance = spec.DatabaseInstance
 	}
 	// RPCTransport
-	if spec.IronicInspector.RPCTransport == "" {
-		spec.IronicInspector.RPCTransport = spec.RPCTransport
-	}
+	spec.IronicInspector.RPCTransport = spec.RPCTransport
 	// Secret
 	if spec.IronicInspector.Secret == "" {
 		spec.IronicInspector.Secret = spec.Secret


### PR DESCRIPTION
ironic conductor and inspector types set a default for these, e.g they are never "" so the value defined fir the ironic parent never applies.

Remove the condition, and always set to what is defined for the parent.