### PR TITLE
Add Deployment of ironic-neutron-agent

### DIFF
--- a/api/bases/ironic.openstack.org_ironics.yaml
+++ b/api/bases/ironic.openstack.org_ironics.yaml
@@ -489,7 +489,7 @@ spec:
                   type: object
                 type: array
               ironicInspector:
-                description: IronicInspector - Spec definition for the conductor service
+                description: IronicInspector - Spec definition for the inspector service
                   of this Ironic deployment
                 properties:
                   containerImage:
@@ -747,6 +747,121 @@ spec:
                 - containerImage
                 - pxeContainerImage
                 type: object
+              ironicNeutronAgent:
+                description: IronicNeutronAgent - Spec definition for the ML2 baremetal
+                  ironic-neutron-agent service of this Ironic deployment
+                properties:
+                  containerImage:
+                    description: ContainerImage - ML2 baremtal - Ironic Neutron Agent
+                      Image URL
+                    type: string
+                  customServiceConfig:
+                    default: '# add your customization here'
+                    description: CustomServiceConfig - customize the service config
+                      using this parameter to change service defaults, or overwrite
+                      rendered information using raw OpenStack config format. The
+                      content gets added to to /etc/<service>/<service>.conf.d directory
+                      as custom.conf file.
+                    type: string
+                  debug:
+                    description: Debug - enable debug for different deploy stages.
+                      If an init container is used, it runs and the actual action
+                      pod gets started with sleep infinity
+                    properties:
+                      service:
+                        default: false
+                        description: Service enable debug
+                        type: boolean
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector to target subset of worker nodes running
+                      this service.
+                    type: object
+                  passwordSelectors:
+                    default:
+                      service: IronicPassword
+                    description: PasswordSelectors - Selectors to identify the ServiceUser
+                      password from the Secret
+                    properties:
+                      service:
+                        default: IronicPassword
+                        description: Service - Selector to get the ironic service
+                          password from the Secret
+                        type: string
+                    type: object
+                  rabbitMqClusterName:
+                    default: rabbitmq
+                    description: RabbitMQ instance name Needed to request a transportURL
+                      that is created and used in Ironic
+                    type: string
+                  replicas:
+                    default: 1
+                    description: Replicas - ML2 baremetal - Ironic Neutron Agent Replicas
+                    format: int32
+                    type: integer
+                  resources:
+                    description: Resources - Compute Resources required by this service
+                      (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: Name must match the name of one entry in
+                                pod.spec.resourceClaims of the Pod where this field
+                                is used. It makes that resource available inside a
+                                container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  secret:
+                    description: Secret containing OpenStack password information
+                      for IronicPassword
+                    type: string
+                  serviceUser:
+                    default: ironic
+                    description: ServiceUser - optional username used for this service
+                      to register in ironic
+                    type: string
+                required:
+                - secret
+                type: object
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -812,6 +927,7 @@ spec:
             - ironicAPI
             - ironicConductors
             - ironicInspector
+            - ironicNeutronAgent
             - secret
             - storageClass
             type: object
@@ -888,6 +1004,10 @@ spec:
                 type: object
               ironicInspectorReadyCount:
                 description: ReadyCount of Ironic Inspector instance
+                format: int32
+                type: integer
+              ironicNeutronAgentReadyCount:
+                description: ReadyCount of Ironic Neutron Agent instance
                 format: int32
                 type: integer
               serviceIDs:

--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -30,8 +30,11 @@ const (
 	// IronicRabbitMqTransportURLReady Status=True condition which indicates if the RabbitMQ TransportURLUrl is ready
 	IronicRabbitMqTransportURLReadyCondition condition.Type = "IronicRabbitMqTransportURLReady"
 
-	// IronicInspectorReadyCondition Status=True condition which indicates if the IronicConductor is configured and operational
+	// IronicInspectorReadyCondition Status=True condition which indicates if the Inspector is configured and operational
 	IronicInspectorReadyCondition condition.Type = "IronicInspectorReady"
+
+	// IronicNeutronAgentReadyCondition Status=True condition which indicates if the ML2 baremetal Ironic Neutron Agent is configured and operational
+	IronicNeutronAgentReadyCondition condition.Type = "IronicNeutronAgentReady"
 )
 
 // Ironic Reasons used by API objects.
@@ -77,4 +80,7 @@ const (
 
 	// IronicInspectorReadyErrorMessage
 	IronicInspectorReadyErrorMessage = "IronicInspector error occured %s"
+
+	// IronicNeutronAgentReadyErrorMessage
+	IronicNeutronAgentReadyErrorMessage = "IronicNeutronAgent error occured %s"
 )

--- a/api/v1beta1/ironic_types.go
+++ b/api/v1beta1/ironic_types.go
@@ -91,8 +91,13 @@ type IronicSpec struct {
 	IronicConductors []IronicConductorSpec `json:"ironicConductors"`
 
 	// +kubebuilder:validation:Required
-	// IronicInspector - Spec definition for the conductor service of this Ironic deployment
+	// IronicInspector - Spec definition for the inspector service of this Ironic deployment
 	IronicInspector IronicInspectorSpec `json:"ironicInspector"`
+
+	// +kubebuilder:validation:Required
+	// IronicNeutronAgent - Spec definition for the ML2 baremetal ironic-neutron-agent
+	// service of this Ironic deployment
+	IronicNeutronAgent IronicNeutronAgentSpec `json:"ironicNeutronAgent"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=rabbitmq
@@ -200,6 +205,9 @@ type IronicStatus struct {
 
 	// ReadyCount of Ironic Inspector instance
 	InspectorReadyCount int32 `json:"ironicInspectorReadyCount,omitempty"`
+
+	// ReadyCount of Ironic Neutron Agent instance
+	IronicNeutronAgentReadyCount int32 `json:"ironicNeutronAgentReadyCount,omitempty"`
 
 	// TransportURLSecret - Secret containing RabbitMQ transportURL
 	TransportURLSecret string `json:"transportURLSecret,omitempty"`

--- a/api/v1beta1/ironic_webhook.go
+++ b/api/v1beta1/ironic_webhook.go
@@ -461,6 +461,7 @@ func (spec *IronicSpec) Default() {
 	defaultIronicAPI(spec)
 	defaultIronicConductors(spec)
 	defaultIronicInspector(spec)
+	defaultIronicNeutronAgent(spec)
 }
 
 // defaultIronicAPI - implements defaulter for IronicAPI spec
@@ -556,4 +557,14 @@ func defaultIronicInspector(spec *IronicSpec) {
 		spec.IronicInspector.NodeSelector = spec.NodeSelector
 	}
 	ironiclog.Info("webhook - IronicInspector defaulter called")
+}
+
+// defaultIronicNeutronAgent - implements defaulter for IronicNeutronAgent Spec
+func defaultIronicNeutronAgent(spec *IronicSpec) {
+	ironiclog.Info("webhool - calling IronicNeutronAgent defaulter")
+	// Secret
+	if spec.IronicNeutronAgent.Secret == "" {
+		spec.IronicNeutronAgent.Secret = spec.Secret
+	}
+	ironiclog.Info("webhook - IronicNeutronAgent defaulter called")
 }

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -800,6 +800,7 @@ func (in *IronicSpec) DeepCopyInto(out *IronicSpec) {
 		}
 	}
 	in.IronicInspector.DeepCopyInto(&out.IronicInspector)
+	in.IronicNeutronAgent.DeepCopyInto(&out.IronicNeutronAgent)
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
 		*out = make(map[string]string, len(*in))

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -489,7 +489,7 @@ spec:
                   type: object
                 type: array
               ironicInspector:
-                description: IronicInspector - Spec definition for the conductor service
+                description: IronicInspector - Spec definition for the inspector service
                   of this Ironic deployment
                 properties:
                   containerImage:
@@ -747,6 +747,121 @@ spec:
                 - containerImage
                 - pxeContainerImage
                 type: object
+              ironicNeutronAgent:
+                description: IronicNeutronAgent - Spec definition for the ML2 baremetal
+                  ironic-neutron-agent service of this Ironic deployment
+                properties:
+                  containerImage:
+                    description: ContainerImage - ML2 baremtal - Ironic Neutron Agent
+                      Image URL
+                    type: string
+                  customServiceConfig:
+                    default: '# add your customization here'
+                    description: CustomServiceConfig - customize the service config
+                      using this parameter to change service defaults, or overwrite
+                      rendered information using raw OpenStack config format. The
+                      content gets added to to /etc/<service>/<service>.conf.d directory
+                      as custom.conf file.
+                    type: string
+                  debug:
+                    description: Debug - enable debug for different deploy stages.
+                      If an init container is used, it runs and the actual action
+                      pod gets started with sleep infinity
+                    properties:
+                      service:
+                        default: false
+                        description: Service enable debug
+                        type: boolean
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector to target subset of worker nodes running
+                      this service.
+                    type: object
+                  passwordSelectors:
+                    default:
+                      service: IronicPassword
+                    description: PasswordSelectors - Selectors to identify the ServiceUser
+                      password from the Secret
+                    properties:
+                      service:
+                        default: IronicPassword
+                        description: Service - Selector to get the ironic service
+                          password from the Secret
+                        type: string
+                    type: object
+                  rabbitMqClusterName:
+                    default: rabbitmq
+                    description: RabbitMQ instance name Needed to request a transportURL
+                      that is created and used in Ironic
+                    type: string
+                  replicas:
+                    default: 1
+                    description: Replicas - ML2 baremetal - Ironic Neutron Agent Replicas
+                    format: int32
+                    type: integer
+                  resources:
+                    description: Resources - Compute Resources required by this service
+                      (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: Name must match the name of one entry in
+                                pod.spec.resourceClaims of the Pod where this field
+                                is used. It makes that resource available inside a
+                                container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  secret:
+                    description: Secret containing OpenStack password information
+                      for IronicPassword
+                    type: string
+                  serviceUser:
+                    default: ironic
+                    description: ServiceUser - optional username used for this service
+                      to register in ironic
+                    type: string
+                required:
+                - secret
+                type: object
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -812,6 +927,7 @@ spec:
             - ironicAPI
             - ironicConductors
             - ironicInspector
+            - ironicNeutronAgent
             - secret
             - storageClass
             type: object
@@ -888,6 +1004,10 @@ spec:
                 type: object
               ironicInspectorReadyCount:
                 description: ReadyCount of Ironic Inspector instance
+                format: int32
+                type: integer
+              ironicNeutronAgentReadyCount:
+                description: ReadyCount of Ironic Neutron Agent instance
                 format: int32
                 type: integer
               serviceIDs:

--- a/config/samples/ironic_v1beta1_ironic.yaml
+++ b/config/samples/ironic_v1beta1_ironic.yaml
@@ -22,4 +22,7 @@ spec:
     replicas: 1
     containerImage: quay.io/podified-antelope-centos9/openstack-ironic-inspector:current-podified
     pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
+  ironicNeutronAgent:
+    replicas: 1
+    containerImage: quay.io/podified-antelope-centos9/openstack-ironic-neutron-agent:current-podified
   secret: osp-secret

--- a/config/samples/ironic_v1beta1_ironicneutronagent.yaml
+++ b/config/samples/ironic_v1beta1_ironicneutronagent.yaml
@@ -4,6 +4,6 @@ metadata:
   name: ironic-neutron-agent
   namespace: openstack
 spec:
-  containerImage: quay.io/podified-antelope-centos9/openstack-ironic-neutron-agent:current-podified
   replicas: 1
+  containerImage: quay.io/podified-antelope-centos9/openstack-ironic-neutron-agent:current-podified
   secret: osp-secret


### PR DESCRIPTION
In ironic controller add deployment of ironic neutron agent. When replicas is ! > 0 the ironic neutron agent will not be deployed, setting replicas = 0 will also delete any running deployment.

Also:
* Update sample files to use zed container images for ironic neutron agent ... match the other components.
* Update description string for inspector

Jira: [OSP-24274](https://issues.redhat.com//browse/OSP-24274)