### PR TITLE
Bump the timeout for kuttl tests

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -19,7 +19,7 @@ kind: TestSuite
 reportFormat: JSON
 reportName: kuttl-test-ironic
 namespace: openstack
-timeout: 750
+timeout: 900
 parallel: 1
 suppress:
   - events                     # Remove spammy event logs


### PR DESCRIPTION
We have seen many retest runs required. The tests
pass consistently in my local env. Let's see if it just needs a bit more time.