### PR TITLE
Add ironic-neutron-agent image to ironicDefaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,6 +323,7 @@ run-with-webhook: export IRONIC_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-
 run-with-webhook: export IRONIC_CONDUCTOR_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
 run-with-webhook: export IRONIC_INSPECTOR_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ironic-inspector:current-podified
 run-with-webhook: export IRONIC_PXE_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
+run-with-webhook: export IRONIC_NEUTRON_AGENT_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ironic-neutron-agent:current-podified
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/configure_local_webhook.sh
 	go run ./main.go

--- a/api/bases/ironic.openstack.org_ironicneutronagents.yaml
+++ b/api/bases/ironic.openstack.org_ironicneutronagents.yaml
@@ -158,6 +158,7 @@ spec:
                   to register in ironic
                 type: string
             required:
+            - containerImage
             - secret
             type: object
           status:

--- a/api/bases/ironic.openstack.org_ironics.yaml
+++ b/api/bases/ironic.openstack.org_ironics.yaml
@@ -860,6 +860,7 @@ spec:
                       to register in ironic
                     type: string
                 required:
+                - containerImage
                 - secret
                 type: object
               nodeSelector:

--- a/api/v1beta1/ironic_webhook.go
+++ b/api/v1beta1/ironic_webhook.go
@@ -50,6 +50,7 @@ type IronicDefaults struct {
 	ConductorContainerImageURL string
 	InspectorContainerImageURL string
 	PXEContainerImageURL       string
+	INAContainerImageURL       string
 }
 
 var ironicDefaults IronicDefaults
@@ -562,6 +563,10 @@ func defaultIronicInspector(spec *IronicSpec) {
 // defaultIronicNeutronAgent - implements defaulter for IronicNeutronAgent Spec
 func defaultIronicNeutronAgent(spec *IronicSpec) {
 	ironiclog.Info("webhool - calling IronicNeutronAgent defaulter")
+	// ContainerImage
+	if spec.IronicAPI.ContainerImage == "" {
+		spec.IronicNeutronAgent.ContainerImage = ironicDefaults.INAContainerImageURL
+	}
 	// Secret
 	if spec.IronicNeutronAgent.Secret == "" {
 		spec.IronicNeutronAgent.Secret = spec.Secret

--- a/api/v1beta1/ironicneutronagent_types.go
+++ b/api/v1beta1/ironicneutronagent_types.go
@@ -45,9 +45,9 @@ type IronicNeutronAgentSpec struct {
 	// ServiceUser - optional username used for this service to register in ironic
 	ServiceUser string `json:"serviceUser"`
 
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// ContainerImage - ML2 baremtal - Ironic Neutron Agent Image URL
-	ContainerImage string `json:"containerImage,omitempty"`
+	ContainerImage string `json:"containerImage"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=1

--- a/config/crd/bases/ironic.openstack.org_ironicneutronagents.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicneutronagents.yaml
@@ -158,6 +158,7 @@ spec:
                   to register in ironic
                 type: string
             required:
+            - containerImage
             - secret
             type: object
           status:

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -860,6 +860,7 @@ spec:
                       to register in ironic
                     type: string
                 required:
+                - containerImage
                 - secret
                 type: object
               nodeSelector:

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -19,3 +19,5 @@ spec:
           value: quay.io/podified-antelope-centos9/openstack-ironic-inspector:current-podified
         - name: IRONIC_PXE_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
+        - name: IRONIC_NEUTRON_AGENT_IMAGE_URL_DEFAULT
+          value: quay.io/podified-antelope-centos9/openstack-ironic-neutron-agent:current-podified

--- a/main.go
+++ b/main.go
@@ -168,6 +168,7 @@ func main() {
 		ConductorContainerImageURL: os.Getenv("IRONIC_CONDUCTOR_IMAGE_URL_DEFAULT"),
 		InspectorContainerImageURL: os.Getenv("IRONIC_INSPECTOR_IMAGE_URL_DEFAULT"),
 		PXEContainerImageURL:       os.Getenv("IRONIC_PXE_IMAGE_URL_DEFAULT"),
+		INAContainerImageURL:       os.Getenv("IRONIC_NEUTRON_AGENT_IMAGE_URL_DEFAULT"),
 	}
 
 	ironicv1.SetupIronicDefaults(ironicDefaults)


### PR DESCRIPTION
Set up the ironic webhook to default the image for ironic neutron agent the same way it works for the other container images.

Jira: [osp-24276](https://issues.redhat.com//browse/osp-24276)