### PR TITLE
Ignoere undef .ConductorGroup in ironic.conf template

### DIFF
--- a/templates/common/config/ironic.conf
+++ b/templates/common/config/ironic.conf
@@ -110,7 +110,7 @@ heartbeat_timeout=120
 force_power_state_during_sync=false
 automated_clean=false
 allow_provisioning_in_maintenance=false
-{{ if .ConductorGroup }}conductor_group={{ .ConductorGroup }}{{ end }}
+{{ if (or .ConductorGroup false) }}conductor_group={{ .ConductorGroup }}{{ end }}
 
 [cors]
 allowed_origin=*


### PR DESCRIPTION
The ironic.conf template is common for ironic API and ironic Conductors. `.ConductorGroup` is only defined for when ironic conductor controller.

Use `or` to default to `false` when ConductorGroup is not set.