### PR TITLE
Initialize templateParameters["ConductorGroup"]

### DIFF
--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -833,6 +833,9 @@ func (r *IronicReconciler) generateServiceConfigMaps(
 	}
 
 	templateParameters := make(map[string]interface{})
+	// Initialize ConductorGroup key to ensure template rendering does not fail
+	templateParameters["ConductorGroup"] = nil
+
 	if !instance.Spec.Standalone {
 		templateParameters["KeystoneInternalURL"] = keystoneVars["keystoneInternalURL"]
 		templateParameters["KeystonePublicURL"] = keystoneVars["keystonePublicURL"]


### PR DESCRIPTION
Initialize templateParameters["ConductorGroup"] with nil value in ironic controller. The ironic.conf template is shared between ironic controller and ironcconductor controller. Only the conductor controller uses ConductorGroup.