### PR TITLE
Reorganize config samples

### DIFF
--- a/config/samples/ironic_v1beta1_images.yaml
+++ b/config/samples/ironic_v1beta1_images.yaml
@@ -1,0 +1,8 @@
+- op: replace
+  path: /spec/images
+  value:
+    api: quay.io/podified-antelope-centos9/openstack-ironic-api:current-podified
+    conductor: quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
+    pxe: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
+    inspector: quay.io/podified-antelope-centos9/openstack-ironic-inspector:current-podified
+    neutronAgent: quay.io/podified-antelope-centos9/openstack-ironic-neutron-agent:current-podified

--- a/config/samples/ironic_v1beta1_ironic.yaml
+++ b/config/samples/ironic_v1beta1_ironic.yaml
@@ -2,15 +2,8 @@ apiVersion: ironic.openstack.org/v1beta1
 kind: Ironic
 metadata:
   name: ironic
-  namespace: openstack
 spec:
   serviceUser: ironic
-  images:
-    api: quay.io/podified-antelope-centos9/openstack-ironic-api:current-podified
-    conductor: quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
-    inspector: quay.io/podified-antelope-centos9/openstack-ironic-inspector:current-podified
-    pxe: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
-    neutronAgent: quay.io/podified-antelope-centos9/openstack-ironic-neutron-agent:current-podified
   customServiceConfig: |
     [DEFAULT]
     debug = true

--- a/config/samples/ironic_v1beta1_ironic_conductor_groups.yaml
+++ b/config/samples/ironic_v1beta1_ironic_conductor_groups.yaml
@@ -2,13 +2,7 @@ apiVersion: ironic.openstack.org/v1beta1
 kind: Ironic
 metadata:
   name: ironic
-  namespace: openstack
 spec:
-  images:
-    api: quay.io/podified-antelope-centos9/openstack-ironic-api:current-podified
-    conductor: quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
-    inspector: quay.io/podified-antelope-centos9/openstack-ironic-inspector:current-podified
-    pxe: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
   serviceUser: ironic
   customServiceConfig: |
     [DEFAULT]

--- a/config/samples/ironic_v1beta1_ironic_standalone.yaml
+++ b/config/samples/ironic_v1beta1_ironic_standalone.yaml
@@ -2,14 +2,8 @@ apiVersion: ironic.openstack.org/v1beta1
 kind: Ironic
 metadata:
   name: ironic
-  namespace: openstack
 spec:
   standalone: true
-  images:
-    api: quay.io/podified-antelope-centos9/openstack-ironic-api:current-podified
-    conductor: quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
-    inspector: quay.io/podified-antelope-centos9/openstack-ironic-inspector:current-podified
-    pxe: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
   serviceUser: ironic
   customServiceConfig: |
     [DEFAULT]

--- a/config/samples/ironic_v1beta1_ironicapi.yaml
+++ b/config/samples/ironic_v1beta1_ironicapi.yaml
@@ -3,4 +3,4 @@ kind: IronicAPI
 metadata:
   name: ironicapi-sample
 spec:
-  # TODO(user): Add fields here
+  replicas: 1

--- a/config/samples/ironic_v1beta1_ironicconductor.yaml
+++ b/config/samples/ironic_v1beta1_ironicconductor.yaml
@@ -3,4 +3,5 @@ kind: IronicConductor
 metadata:
   name: ironicconductor-sample
 spec:
-  # TODO(user): Add fields here
+  replicas: 1
+  storageRequest: 10G

--- a/config/samples/ironic_v1beta1_ironicinspector.yaml
+++ b/config/samples/ironic_v1beta1_ironicinspector.yaml
@@ -3,4 +3,4 @@ kind: IronicInspector
 metadata:
   name: ironicinspector-sample
 spec:
-  # TODO(user): Add fields here
+  replicas: 1

--- a/config/samples/ironic_v1beta1_ironicneutronagent.yaml
+++ b/config/samples/ironic_v1beta1_ironicneutronagent.yaml
@@ -1,9 +1,8 @@
 apiVersion: ironic.openstack.org/v1beta1
 kind: IronicNeutronAgent
 metadata:
-  name: ironic-neutron-agent
+  name: ironic-neutron-agent-sample
   namespace: openstack
 spec:
   replicas: 1
-  containerImage: quay.io/podified-antelope-centos9/openstack-ironic-neutron-agent:current-podified
   secret: osp-secret

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -3,4 +3,10 @@ resources:
 - ironic_v1beta1_ironic.yaml
 - ironic_v1beta1_ironicapi.yaml
 - ironic_v1beta1_ironicconductor.yaml
+- ironic_v1beta1_ironicinspector.yaml
+- ironic_v1beta1_ironicneutronagent.yaml
+patches:
+- target:
+    kind: Ironic
+  path: ironic_v1beta1_images.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples


### PR DESCRIPTION
- Remove namespace openstack, to align with other operators
- Ensure standalone and conductor groups samples have unique metadata
  names so that kustomize will process them
- Remove image tags from all samples, defaults now come from the
  operator environment
- Add a JSON6902 patch file which restates the image defaults.
  It is provided as an example and for tooling to use it as a template
  to convert to versioned tags.
- Add the image patch to kustomization.yaml, just for validation -
  these samples are not bundled with the operator.
- Set the replicas attribute on the single service samples. They still
  won't work but at least there is something valid.