### PR TITLE
Set IronicPublicURL to empty string in ironic controller

### DIFF
--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -841,16 +841,7 @@ func (r *IronicReconciler) generateServiceConfigMaps(
 		templateParameters["KeystonePublicURL"] = keystoneVars["keystonePublicURL"]
 		templateParameters["ServiceUser"] = instance.Spec.ServiceUser
 	} else {
-		ironicAPI, err := ironicv1.GetIronicAPI(
-			ctx, h, instance.Namespace, map[string]string{})
-		if err != nil {
-			return err
-		}
-		ironicPublicURL, err := ironicAPI.GetEndpoint(endpoint.EndpointPublic)
-		if err != nil {
-			return err
-		}
-		templateParameters["IronicPublicURL"] = ironicPublicURL
+		templateParameters["IronicPublicURL"] = ""
 	}
 	templateParameters["Standalone"] = instance.Spec.Standalone
 


### PR DESCRIPTION
Only the conductor config actually needs this in standalone mode, and that is already handled in the conductor controller.

Not discovering the actual endpoint saves an extra reconcile cycle, since this config is generated before IronicAPI is reconciled.