### PR TITLE
Reset Ready condition when update failed

### DIFF
--- a/api/v1beta1/ironic_types.go
+++ b/api/v1beta1/ironic_types.go
@@ -288,21 +288,9 @@ func init() {
 // 	return "", fmt.Errorf("%s endpoint not found", string(endpointType))
 // }
 
-// IsReady - returns true if service is ready to server requests
+// IsReady - returns true if Ironic is reconciled successfully
 func (instance Ironic) IsReady() bool {
-	ready := instance.Status.IronicAPIReadyCount > 0
-
-	for _, conductorSpec := range instance.Spec.IronicConductors {
-		condGrp := conductorSpec.ConductorGroup
-		if conductorSpec.ConductorGroup == "" {
-			condGrp = ConductorGroupNull
-		}
-		ready = ready && instance.Status.IronicConductorReadyCount[condGrp] > 0
-	}
-
-	// ready = ready && instance.Status.IronicInspectorReadyCount > 0
-
-	return ready
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }
 
 // SetupDefaults - initializes any CRD field defaults based on environment variables (the defaulting mechanism itself is implemented via webhooks)

--- a/api/v1beta1/ironicapi_types.go
+++ b/api/v1beta1/ironicapi_types.go
@@ -190,9 +190,9 @@ func init() {
 	SchemeBuilder.Register(&IronicAPI{}, &IronicAPIList{})
 }
 
-// IsReady - returns true if service is ready to server requests
+// IsReady - returns true if IronicAPI is reconciled successfully
 func (instance IronicAPI) IsReady() bool {
-	return instance.Status.ReadyCount >= 1
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }
 
 // GetEndpoint - returns the Ironic endpoint url for type

--- a/api/v1beta1/ironicconductor_types.go
+++ b/api/v1beta1/ironicconductor_types.go
@@ -180,7 +180,7 @@ func init() {
 	SchemeBuilder.Register(&IronicConductor{}, &IronicConductorList{})
 }
 
-// IsReady - returns true if service is ready to server requests
+// IsReady - returns true if IronicConductor is reconciled successfully
 func (instance IronicConductor) IsReady() bool {
-	return instance.Status.ReadyCount >= 1
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }

--- a/api/v1beta1/ironicinspector_types.go
+++ b/api/v1beta1/ironicinspector_types.go
@@ -195,7 +195,7 @@ func init() {
 	SchemeBuilder.Register(&IronicInspector{}, &IronicInspectorList{})
 }
 
-// IsReady - returns true if service is ready to server requests
+// IsReady - returns true if IronicInspector is reconciled successfully
 func (instance IronicInspector) IsReady() bool {
-	return instance.Status.ReadyCount >= 1
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }

--- a/api/v1beta1/ironicneutronagent_types.go
+++ b/api/v1beta1/ironicneutronagent_types.go
@@ -141,7 +141,7 @@ func init() {
 	)
 }
 
-// IsReady - returns true if service is ready to server requests
+// IsReady - returns true if IronicNeutronAgent is reconciled successfully
 func (instance IronicNeutronAgent) IsReady() bool {
-	return instance.Status.ReadyCount >= 1
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }

--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -132,11 +132,18 @@ func (r *IronicReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		// update the overall status condition if service is ready
-		if instance.IsReady() {
-			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
+		// update the Ready condition based on the sub conditions
+		if instance.Status.Conditions.AllSubConditionIsTrue() {
+			instance.Status.Conditions.MarkTrue(
+				condition.ReadyCondition, condition.ReadyMessage)
+		} else {
+			// something is not ready so reset the Ready condition
+			instance.Status.Conditions.MarkUnknown(
+				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
+			// and recalculate it based on the state of the rest of the conditions
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
-
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err

--- a/controllers/ironicapi_controller.go
+++ b/controllers/ironicapi_controller.go
@@ -135,11 +135,18 @@ func (r *IronicAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		// update the overall status condition if service is ready
-		if instance.IsReady() {
-			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
+		// update the Ready condition based on the sub conditions
+		if instance.Status.Conditions.AllSubConditionIsTrue() {
+			instance.Status.Conditions.MarkTrue(
+				condition.ReadyCondition, condition.ReadyMessage)
+		} else {
+			// something is not ready so reset the Ready condition
+			instance.Status.Conditions.MarkUnknown(
+				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
+			// and recalculate it based on the state of the rest of the conditions
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
-
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err

--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -129,11 +129,18 @@ func (r *IronicConductorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		// update the overall status condition if service is ready
-		if instance.IsReady() {
-			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
+		// update the Ready condition based on the sub conditions
+		if instance.Status.Conditions.AllSubConditionIsTrue() {
+			instance.Status.Conditions.MarkTrue(
+				condition.ReadyCondition, condition.ReadyMessage)
+		} else {
+			// something is not ready so reset the Ready condition
+			instance.Status.Conditions.MarkUnknown(
+				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
+			// and recalculate it based on the state of the rest of the conditions
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
-
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err

--- a/controllers/ironicinspector_controller.go
+++ b/controllers/ironicinspector_controller.go
@@ -133,13 +133,18 @@ func (r *IronicInspectorReconciler) Reconcile(
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		// update the overall status condition if service is ready
-		if instance.IsReady() {
+		// update the Ready condition based on the sub conditions
+		if instance.Status.Conditions.AllSubConditionIsTrue() {
 			instance.Status.Conditions.MarkTrue(
-				condition.ReadyCondition,
-				condition.ReadyMessage)
+				condition.ReadyCondition, condition.ReadyMessage)
+		} else {
+			// something is not ready so reset the Ready condition
+			instance.Status.Conditions.MarkUnknown(
+				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
+			// and recalculate it based on the state of the rest of the conditions
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
-
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err

--- a/controllers/ironicneutronagent_controller.go
+++ b/controllers/ironicneutronagent_controller.go
@@ -124,14 +124,18 @@ func (r *IronicNeutronAgentReconciler) Reconcile(
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		// update the overall status condition if service is ready
-		if instance.IsReady() {
+		// update the Ready condition based on the sub conditions
+		if instance.Status.Conditions.AllSubConditionIsTrue() {
 			instance.Status.Conditions.MarkTrue(
-				condition.ReadyCondition,
-				condition.ReadyMessage,
-			)
+				condition.ReadyCondition, condition.ReadyMessage)
+		} else {
+			// something is not ready so reset the Ready condition
+			instance.Status.Conditions.MarkUnknown(
+				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
+			// and recalculate it based on the state of the rest of the conditions
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
-
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err

--- a/tests/functional/ironicneutronagent_controller_test.go
+++ b/tests/functional/ironicneutronagent_controller_test.go
@@ -114,12 +114,12 @@ var _ = Describe("IronicNeutronAgent controller", func() {
 				"Input data resources missing",
 			)
 		})
-		It("is unknown Ready", func() {
+		It("is false Ready", func() {
 			th.ExpectCondition(
 				ironicNames.INAName,
 				ConditionGetterFunc(INAConditionGetter),
 				condition.ReadyCondition,
-				corev1.ConditionUnknown,
+				corev1.ConditionFalse,
 			)
 		})
 		It("has empty Status fields", func() {
@@ -150,12 +150,12 @@ var _ = Describe("IronicNeutronAgent controller", func() {
 					"Input data resources missing",
 				)
 			})
-			It("is unknown Ready", func() {
+			It("is false Ready", func() {
 				th.ExpectCondition(
 					ironicNames.INAName,
 					ConditionGetterFunc(INAConditionGetter),
 					condition.ReadyCondition,
-					corev1.ConditionUnknown,
+					corev1.ConditionFalse,
 				)
 			})
 			It("has empty Status fields", func() {


### PR DESCRIPTION
This ensures the Ready Condition is reset when CR becomes once ready but something fails during reconfiguration.