### PR TITLE
Remove Keystone service IDs from status fields

### DIFF
--- a/api/bases/ironic.openstack.org_ironicapis.yaml
+++ b/api/bases/ironic.openstack.org_ironicapis.yaml
@@ -309,11 +309,6 @@ spec:
                 description: ReadyCount of ironic API instances
                 format: int32
                 type: integer
-              serviceIDs:
-                additionalProperties:
-                  type: string
-                description: ServiceIDs
-                type: object
             type: object
         type: object
     served: true

--- a/api/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/api/bases/ironic.openstack.org_ironicconductors.yaml
@@ -319,11 +319,6 @@ spec:
                 description: ReadyCount of ironic Conductor instances
                 format: int32
                 type: integer
-              serviceIDs:
-                additionalProperties:
-                  type: string
-                description: ServiceIDs
-                type: object
             type: object
         type: object
     served: true

--- a/api/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/api/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -371,11 +371,6 @@ spec:
                 description: ReadyCount of Ironic Inspector instances
                 format: int32
                 type: integer
-              serviceIDs:
-                additionalProperties:
-                  type: string
-                description: ServiceIDs
-                type: object
               transportURLSecret:
                 description: TransportURLSecret - Secret containing RabbitMQ transportURL
                 type: string

--- a/api/bases/ironic.openstack.org_ironics.yaml
+++ b/api/bases/ironic.openstack.org_ironics.yaml
@@ -1045,11 +1045,6 @@ spec:
                 description: ReadyCount of Ironic Neutron Agent instance
                 format: int32
                 type: integer
-              serviceIDs:
-                additionalProperties:
-                  type: string
-                description: ServiceIDs
-                type: object
               transportURLSecret:
                 description: TransportURLSecret - Secret containing RabbitMQ transportURL
                 type: string

--- a/api/v1beta1/ironic_types.go
+++ b/api/v1beta1/ironic_types.go
@@ -236,9 +236,6 @@ type IronicStatus struct {
 	// API endpoint
 	APIEndpoints map[string]map[string]string `json:"apiEndpoints,omitempty"`
 
-	// ServiceIDs
-	ServiceIDs map[string]string `json:"serviceIDs,omitempty"`
-
 	// ReadyCount of Ironic API instance
 	IronicAPIReadyCount int32 `json:"ironicAPIReadyCount,omitempty"`
 

--- a/api/v1beta1/ironicapi_types.go
+++ b/api/v1beta1/ironicapi_types.go
@@ -155,9 +155,6 @@ type IronicAPIStatus struct {
 	// ReadyCount of ironic API instances
 	ReadyCount int32 `json:"readyCount,omitempty"`
 
-	// ServiceIDs
-	ServiceIDs map[string]string `json:"serviceIDs,omitempty"`
-
 	// NetworkAttachments status of the deployment pods
 	NetworkAttachments map[string][]string `json:"networkAttachments,omitempty"`
 }

--- a/api/v1beta1/ironicconductor_types.go
+++ b/api/v1beta1/ironicconductor_types.go
@@ -145,9 +145,6 @@ type IronicConductorStatus struct {
 	// ReadyCount of ironic Conductor instances
 	ReadyCount int32 `json:"readyCount,omitempty"`
 
-	// ServiceIDs
-	ServiceIDs map[string]string `json:"serviceIDs,omitempty"`
-
 	// NetworkAttachments status of the deployment pods
 	NetworkAttachments map[string][]string `json:"networkAttachments,omitempty"`
 }

--- a/api/v1beta1/ironicinspector_types.go
+++ b/api/v1beta1/ironicinspector_types.go
@@ -157,9 +157,6 @@ type IronicInspectorStatus struct {
 	// ReadyCount of Ironic Inspector instances
 	ReadyCount int32 `json:"readyCount,omitempty"`
 
-	// ServiceIDs
-	ServiceIDs map[string]string `json:"serviceIDs,omitempty"`
-
 	// TransportURLSecret - Secret containing RabbitMQ transportURL
 	TransportURLSecret string `json:"transportURLSecret,omitempty"`
 

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -205,13 +205,6 @@ func (in *IronicAPIStatus) DeepCopyInto(out *IronicAPIStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.ServiceIDs != nil {
-		in, out := &in.ServiceIDs, &out.ServiceIDs
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	}
 	if in.NetworkAttachments != nil {
 		in, out := &in.NetworkAttachments, &out.NetworkAttachments
 		*out = make(map[string][]string, len(*in))
@@ -362,13 +355,6 @@ func (in *IronicConductorStatus) DeepCopyInto(out *IronicConductorStatus) {
 		*out = make(condition.Conditions, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
-	if in.ServiceIDs != nil {
-		in, out := &in.ServiceIDs, &out.ServiceIDs
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
 		}
 	}
 	if in.NetworkAttachments != nil {
@@ -583,13 +569,6 @@ func (in *IronicInspectorStatus) DeepCopyInto(out *IronicInspectorStatus) {
 		*out = make(condition.Conditions, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
-	if in.ServiceIDs != nil {
-		in, out := &in.ServiceIDs, &out.ServiceIDs
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
 		}
 	}
 	if in.NetworkAttachments != nil {
@@ -868,13 +847,6 @@ func (in *IronicStatus) DeepCopyInto(out *IronicStatus) {
 				}
 			}
 			(*out)[key] = outVal
-		}
-	}
-	if in.ServiceIDs != nil {
-		in, out := &in.ServiceIDs, &out.ServiceIDs
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
 		}
 	}
 	if in.IronicConductorReadyCount != nil {

--- a/config/crd/bases/ironic.openstack.org_ironicapis.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicapis.yaml
@@ -309,11 +309,6 @@ spec:
                 description: ReadyCount of ironic API instances
                 format: int32
                 type: integer
-              serviceIDs:
-                additionalProperties:
-                  type: string
-                description: ServiceIDs
-                type: object
             type: object
         type: object
     served: true

--- a/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
@@ -319,11 +319,6 @@ spec:
                 description: ReadyCount of ironic Conductor instances
                 format: int32
                 type: integer
-              serviceIDs:
-                additionalProperties:
-                  type: string
-                description: ServiceIDs
-                type: object
             type: object
         type: object
     served: true

--- a/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -371,11 +371,6 @@ spec:
                 description: ReadyCount of Ironic Inspector instances
                 format: int32
                 type: integer
-              serviceIDs:
-                additionalProperties:
-                  type: string
-                description: ServiceIDs
-                type: object
               transportURLSecret:
                 description: TransportURLSecret - Secret containing RabbitMQ transportURL
                 type: string

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -1045,11 +1045,6 @@ spec:
                 description: ReadyCount of Ironic Neutron Agent instance
                 format: int32
                 type: integer
-              serviceIDs:
-                additionalProperties:
-                  type: string
-                description: ServiceIDs
-                type: object
               transportURLSecret:
                 description: TransportURLSecret - Secret containing RabbitMQ transportURL
                 type: string

--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -187,9 +187,6 @@ func (r *IronicReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	if instance.Status.APIEndpoints == nil {
 		instance.Status.APIEndpoints = make(map[string]map[string]string)
 	}
-	if instance.Status.ServiceIDs == nil {
-		instance.Status.ServiceIDs = make(map[string]string)
-	}
 
 	// Handle service delete
 	if !instance.DeletionTimestamp.IsZero() {
@@ -459,7 +456,6 @@ func (r *IronicReconciler) reconcileNormal(ctx context.Context, instance *ironic
 			r.Log.Info(fmt.Sprintf("Conductor deployment %s successfully reconciled - operation: %s", ironicConductor.Name, string(op)))
 		}
 		// Mirror IronicConductor status' ReadyCount to this parent CR
-		// instance.Status.ServiceIDs = ironicConductor.Status.ServiceIDs
 		condGrp := conductorSpec.ConductorGroup
 		if conductorSpec.ConductorGroup == "" {
 			condGrp = ironicv1.ConductorGroupNull
@@ -497,9 +493,6 @@ func (r *IronicReconciler) reconcileNormal(ctx context.Context, instance *ironic
 	for k, v := range ironicAPI.Status.APIEndpoints {
 		instance.Status.APIEndpoints[k] = v
 	}
-	for k, v := range ironicAPI.Status.ServiceIDs {
-		instance.Status.ServiceIDs[k] = v
-	}
 	instance.Status.IronicAPIReadyCount = ironicAPI.Status.ReadyCount
 
 	// Mirror IronicAPI's condition status
@@ -531,9 +524,6 @@ func (r *IronicReconciler) reconcileNormal(ctx context.Context, instance *ironic
 		// Mirror IronicInspector status APIEndpoints and ReadyCount to this parent CR
 		for k, v := range ironicInspector.Status.APIEndpoints {
 			instance.Status.APIEndpoints[k] = v
-		}
-		for k, v := range ironicInspector.Status.ServiceIDs {
-			instance.Status.ServiceIDs[k] = v
 		}
 		instance.Status.InspectorReadyCount = ironicInspector.Status.ReadyCount
 
@@ -959,7 +949,6 @@ func (r *IronicReconciler) inspectorDeploymentDelete(
 	}
 	// Remove inspector APIEndpoints, Services and set ReadyCount 0
 	delete(instance.Status.APIEndpoints, "ironic-inspector")
-	delete(instance.Status.ServiceIDs, "ironic-inspector")
 	instance.Status.InspectorReadyCount = 0
 	// Remove IronicInspectorReadyCondition
 	instance.Status.Conditions.Remove(ironicv1.IronicInspectorReadyCondition)

--- a/controllers/ironicapi_controller.go
+++ b/controllers/ironicapi_controller.go
@@ -191,9 +191,6 @@ func (r *IronicAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if instance.Status.APIEndpoints == nil {
 		instance.Status.APIEndpoints = make(map[string]map[string]string)
 	}
-	if instance.Status.ServiceIDs == nil {
-		instance.Status.ServiceIDs = make(map[string]string)
-	}
 	if instance.Status.NetworkAttachments == nil {
 		instance.Status.NetworkAttachments = map[string][]string{}
 	}
@@ -403,8 +400,6 @@ func (r *IronicAPIReconciler) reconcileInit(
 			if (ctrlResult != ctrl.Result{}) {
 				return ctrlResult, nil
 			}
-
-			instance.Status.ServiceIDs[ksSvc["name"]] = ksSvcObj.GetServiceID()
 
 			//
 			// register endpoints

--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -174,10 +174,6 @@ func (r *IronicConductorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if instance.Status.Hash == nil {
 		instance.Status.Hash = make(map[string]string)
 	}
-	// TODO: We don't use ServiceIDs in conductor controller
-	if instance.Status.ServiceIDs == nil {
-		instance.Status.ServiceIDs = make(map[string]string)
-	}
 	if instance.Status.NetworkAttachments == nil {
 		instance.Status.NetworkAttachments = map[string][]string{}
 	}

--- a/controllers/ironicinspector_controller.go
+++ b/controllers/ironicinspector_controller.go
@@ -206,9 +206,6 @@ func (r *IronicInspectorReconciler) Reconcile(
 	if instance.Status.APIEndpoints == nil {
 		instance.Status.APIEndpoints = make(map[string]map[string]string)
 	}
-	if instance.Status.ServiceIDs == nil {
-		instance.Status.ServiceIDs = make(map[string]string)
-	}
 	if instance.Status.NetworkAttachments == nil {
 		instance.Status.NetworkAttachments = map[string][]string{}
 	}
@@ -936,8 +933,6 @@ func (r *IronicInspectorReconciler) reconcileUsersAndEndpoints(
 			if (ctrlResult != ctrl.Result{}) {
 				return ctrlResult, nil
 			}
-
-			instance.Status.ServiceIDs[ksSvc["name"]] = ksSvcObj.GetServiceID()
 
 			//
 			// register endpoints


### PR DESCRIPTION
... because these fields are not really useful.