### PR TITLE
CSV: Set operator-type: non-standalone

### DIFF
--- a/config/manifests/bases/ironic-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ironic-operator.clusterserviceversion.yaml
@@ -6,6 +6,7 @@ metadata:
     capabilities: Basic Install
     operatorframework.io/suggested-namespace: openstack
     operators.openshift.io/infrastructure-features: '["disconnected"]'
+    operators.operatorframework.io/operator-type: non-standalone
   name: ironic-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
This should hide the ironic package/bundle in the OpenShift console as we only want the main OpenStack operator to show up there.

NOTE: we may eventually make the Ironic project standalone but until then this should align ironic with other operators (hidden).