### PR TITLE
Service account - conditionally reconcile in all controllers

### DIFF
--- a/api/v1beta1/funcs.go
+++ b/api/v1beta1/funcs.go
@@ -1,0 +1,32 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetOwningIronicName - Given a IronicAPI, IronicConductor
+// object, returning the parent Ironic object that created it (if any)
+func GetOwningIronicName(instance client.Object) string {
+	for _, ownerRef := range instance.GetOwnerReferences() {
+		if ownerRef.Kind == "Ironic" {
+			return ownerRef.Name
+		}
+	}
+
+	return ""
+}

--- a/api/v1beta1/ironic_types.go
+++ b/api/v1beta1/ironic_types.go
@@ -300,18 +300,3 @@ func SetupDefaults() {
 
 	SetupIronicImageDefaults(imageDefaults)
 }
-
-// RbacConditionsSet - set the conditions for the rbac object
-func (instance Ironic) RbacConditionsSet(c *condition.Condition) {
-	instance.Status.Conditions.Set(c)
-}
-
-// RbacNamespace - return the namespace
-func (instance Ironic) RbacNamespace() string {
-	return instance.Namespace
-}
-
-// RbacResourceName - return the name to be used for rbac objects (serviceaccount, role, rolebinding)
-func (instance Ironic) RbacResourceName() string {
-	return "ironic-" + instance.Name
-}

--- a/api/v1beta1/ironic_types.go
+++ b/api/v1beta1/ironic_types.go
@@ -300,3 +300,18 @@ func SetupDefaults() {
 
 	SetupIronicImageDefaults(imageDefaults)
 }
+
+// RbacConditionsSet - set the conditions for the rbac object
+func (instance Ironic) RbacConditionsSet(c *condition.Condition) {
+	instance.Status.Conditions.Set(c)
+}
+
+// RbacNamespace - return the namespace
+func (instance Ironic) RbacNamespace() string {
+	return instance.Namespace
+}
+
+// RbacResourceName - return the name to be used for rbac objects (serviceaccount, role, rolebinding)
+func (instance Ironic) RbacResourceName() string {
+	return "ironic-" + instance.Name
+}

--- a/api/v1beta1/ironicapi_types.go
+++ b/api/v1beta1/ironicapi_types.go
@@ -81,10 +81,6 @@ type IronicAPISpec struct {
 	// or 'json-rpc' to use JSON RPC transport. NOTE -> ironic-inspector
 	// requires oslo.messaging transport when not in standalone mode.
 	RPCTransport string `json:"rpcTransport"`
-
-	// +kubebuilder:validation:Required
-	// ServiceAccount - service account name used internally to provide the default SA name
-	ServiceAccount string `json:"serviceAccount"`
 }
 
 // MetalLBConfig to configure the MetalLB loadbalancer service
@@ -175,4 +171,23 @@ func (instance IronicAPI) GetEndpoint(endpointType endpoint.Endpoint) (string, e
 		}
 	}
 	return "", fmt.Errorf("%s endpoint not found", string(endpointType))
+}
+
+// RbacConditionsSet - set the conditions for the rbac object
+func (instance IronicAPI) RbacConditionsSet(c *condition.Condition) {
+	instance.Status.Conditions.Set(c)
+}
+
+// RbacNamespace - return the namespace
+func (instance IronicAPI) RbacNamespace() string {
+	return instance.Namespace
+}
+
+// RbacResourceName - return the name to be used for rbac objects (serviceaccount, role, rolebinding)
+func (instance IronicAPI) RbacResourceName() string {
+	owningIronicName := GetOwningIronicName(&instance)
+	if owningIronicName != "" {
+		return "ironic-" + owningIronicName
+	}
+	return "ironicapi-" + instance.Name
 }

--- a/api/v1beta1/ironicconductor_types.go
+++ b/api/v1beta1/ironicconductor_types.go
@@ -110,9 +110,6 @@ type IronicConductorSpec struct {
 	// keystoneVars - Internally used map of Keystone API endpoints
 	KeystoneVars map[string]string `json:"keystoneVars,omitempty"`
 
-	// +kubebuilder:validation:Required
-	// ServiceAccount - service account name used internally to provide the default SA name
-	ServiceAccount string `json:"serviceAccount"`
 }
 
 // IronicConductorStatus defines the observed state of IronicConductor
@@ -161,4 +158,23 @@ func init() {
 // IsReady - returns true if IronicConductor is reconciled successfully
 func (instance IronicConductor) IsReady() bool {
 	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
+}
+
+// RbacConditionsSet - set the conditions for the rbac object
+func (instance IronicConductor) RbacConditionsSet(c *condition.Condition) {
+	instance.Status.Conditions.Set(c)
+}
+
+// RbacNamespace - return the namespace
+func (instance IronicConductor) RbacNamespace() string {
+	return instance.Namespace
+}
+
+// RbacResourceName - return the name to be used for rbac objects (serviceaccount, role, rolebinding)
+func (instance IronicConductor) RbacResourceName() string {
+	owningIronicName := GetOwningIronicName(&instance)
+	if owningIronicName != "" {
+		return "ironic-" + owningIronicName
+	}
+	return "ironicconductor-" + instance.Name
 }

--- a/api/v1beta1/ironicinspector_types.go
+++ b/api/v1beta1/ironicinspector_types.go
@@ -153,10 +153,6 @@ type IronicInspectorSpec struct {
 	// or 'json-rpc' to use JSON RPC transport. NOTE -> ironic-inspector
 	// requires oslo.messaging transport when not in standalone mode.
 	RPCTransport string `json:"rpcTransport"`
-
-	// +kubebuilder:validation:Required
-	// ServiceAccount - service account name used internally to provide the default SA name
-	ServiceAccount string `json:"serviceAccount"`
 }
 
 // IronicInspectorStatus defines the observed state of IronicInspector
@@ -214,4 +210,23 @@ func init() {
 // IsReady - returns true if IronicInspector is reconciled successfully
 func (instance IronicInspector) IsReady() bool {
 	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
+}
+
+// RbacConditionsSet - set the conditions for the rbac object
+func (instance IronicInspector) RbacConditionsSet(c *condition.Condition) {
+	instance.Status.Conditions.Set(c)
+}
+
+// RbacNamespace - return the namespace
+func (instance IronicInspector) RbacNamespace() string {
+	return instance.Namespace
+}
+
+// RbacResourceName - return the name to be used for rbac objects (serviceaccount, role, rolebinding)
+func (instance IronicInspector) RbacResourceName() string {
+	owningIronicName := GetOwningIronicName(&instance)
+	if owningIronicName != "" {
+		return "ironic-" + owningIronicName
+	}
+	return "ironicinspector-" + instance.Name
 }

--- a/api/v1beta1/ironicneutronagent_types.go
+++ b/api/v1beta1/ironicneutronagent_types.go
@@ -56,9 +56,6 @@ type IronicNeutronAgentSpec struct {
 	// PasswordSelectors - Selectors to identify the ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
-	// +kubebuilder:validation:Required
-	// ServiceAccount - service account name used internally to provide the default SA name
-	ServiceAccount string `json:"serviceAccount"`
 }
 
 // IronicNeutronAgentStatus defines the observed state of ML2 baremetal - ironic-neutron-agent
@@ -110,4 +107,23 @@ func init() {
 // IsReady - returns true if IronicNeutronAgent is reconciled successfully
 func (instance IronicNeutronAgent) IsReady() bool {
 	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
+}
+
+// RbacConditionsSet - set the conditions for the rbac object
+func (instance IronicNeutronAgent) RbacConditionsSet(c *condition.Condition) {
+	instance.Status.Conditions.Set(c)
+}
+
+// RbacNamespace - return the namespace
+func (instance IronicNeutronAgent) RbacNamespace() string {
+	return instance.Namespace
+}
+
+// RbacResourceName - return the name to be used for rbac objects (serviceaccount, role, rolebinding)
+func (instance IronicNeutronAgent) RbacResourceName() string {
+	owningIronicName := GetOwningIronicName(&instance)
+	if owningIronicName != "" {
+		return "ironic-" + owningIronicName
+	}
+	return "ironicneutronagent-" + instance.Name
 }

--- a/config/crd/bases/ironic.openstack.org_ironicapis.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicapis.yaml
@@ -217,10 +217,6 @@ spec:
                 description: Secret containing OpenStack password information for
                   IronicDatabasePassword, AdminPassword
                 type: string
-              serviceAccount:
-                description: ServiceAccount - service account name used internally
-                  to provide the default SA name
-                type: string
               serviceUser:
                 default: ironic
                 description: ServiceUser - optional username used for this service
@@ -233,8 +229,6 @@ spec:
               transportURLSecret:
                 description: Secret containing RabbitMq transport URL
                 type: string
-            required:
-            - serviceAccount
             type: object
           status:
             description: IronicAPIStatus defines the observed state of IronicAPI

--- a/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
@@ -229,10 +229,6 @@ spec:
                 description: Secret containing OpenStack password information for
                   IronicDatabasePassword, AdminPassword
                 type: string
-              serviceAccount:
-                description: ServiceAccount - service account name used internally
-                  to provide the default SA name
-                type: string
               serviceUser:
                 default: ironic
                 description: ServiceUser - optional username used for this service
@@ -253,7 +249,6 @@ spec:
                 description: TransportURLSecret - Secret containing RabbitMQ transportURL
                 type: string
             required:
-            - serviceAccount
             - storageClass
             - storageRequest
             type: object

--- a/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -282,10 +282,6 @@ spec:
                 description: Secret containing OpenStack password information for
                   IronicInspectorDatabasePassword, AdminPassword
                 type: string
-              serviceAccount:
-                description: ServiceAccount - service account name used internally
-                  to provide the default SA name
-                type: string
               serviceUser:
                 default: ironic-inspector
                 description: ServiceUser - optional username used for this service
@@ -298,8 +294,6 @@ spec:
               storageClass:
                 description: StorageClass
                 type: string
-            required:
-            - serviceAccount
             type: object
           status:
             description: IronicInspectorStatus defines the observed state of IronicInspector

--- a/config/crd/bases/ironic.openstack.org_ironicneutronagents.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicneutronagents.yaml
@@ -166,17 +166,11 @@ spec:
                 description: Secret containing OpenStack password information for
                   IronicPassword
                 type: string
-              serviceAccount:
-                description: ServiceAccount - service account name used internally
-                  to provide the default SA name
-                type: string
               serviceUser:
                 default: ironic
                 description: ServiceUser - optional username used for this service
                   to register in ironic
                 type: string
-            required:
-            - serviceAccount
             type: object
           status:
             description: IronicNeutronAgentStatus defines the observed state of ML2

--- a/controllers/funcs.go
+++ b/controllers/funcs.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2022 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func getCommonRbacRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups:     []string{"security.openshift.io"},
+			ResourceNames: []string{"anyuid", "privileged"},
+			Resources:     []string{"securitycontextconstraints"},
+			Verbs:         []string{"use"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+			Verbs:     []string{"create", "get", "list", "watch", "update", "patch", "delete"},
+		},
+	}
+}

--- a/pkg/ironic/funcs.go
+++ b/pkg/ironic/funcs.go
@@ -18,18 +18,6 @@ import (
 	k8snet "k8s.io/utils/net"
 )
 
-// GetOwningIronicName - Given a IronicAPI, IronicConductor
-// object, returning the parent Ironic object that created it (if any)
-func GetOwningIronicName(instance client.Object) string {
-	for _, ownerRef := range instance.GetOwnerReferences() {
-		if ownerRef.Kind == "Ironic" {
-			return ownerRef.Name
-		}
-	}
-
-	return ""
-}
-
 // GetIngressDomain - Get the Ingress Domain of cluster
 func GetIngressDomain(
 	ctx context.Context,

--- a/pkg/ironicapi/deployment.go
+++ b/pkg/ironicapi/deployment.go
@@ -107,7 +107,7 @@ func Deployment(
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.Spec.ServiceAccount,
+					ServiceAccountName: instance.RbacResourceName(),
 					Containers: []corev1.Container{
 						{
 							Name: ironic.ServiceName + "-" + ironic.APIComponent,

--- a/pkg/ironicconductor/statefulset.go
+++ b/pkg/ironicconductor/statefulset.go
@@ -267,7 +267,7 @@ func StatefulSet(
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName:            instance.Spec.ServiceAccount,
+					ServiceAccountName:            instance.RbacResourceName(),
 					Containers:                    containers,
 					TerminationGracePeriodSeconds: &terminationGracePeriod,
 				},

--- a/pkg/ironicinspector/dbsync.go
+++ b/pkg/ironicinspector/dbsync.go
@@ -60,7 +60,7 @@ func DbSyncJob(
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ServiceAccountName: instance.Spec.ServiceAccount,
+					ServiceAccountName: instance.RbacResourceName(),
 					Containers: []corev1.Container{
 						{
 							Name: ironic.ServiceName + "-" + ironic.InspectorComponent + "-db-sync",

--- a/pkg/ironicinspector/statefulset.go
+++ b/pkg/ironicinspector/statefulset.go
@@ -237,7 +237,7 @@ func StatefulSet(
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName:            instance.Spec.ServiceAccount,
+					ServiceAccountName:            instance.RbacResourceName(),
 					Containers:                    containers,
 					TerminationGracePeriodSeconds: &terminationGracePeriod,
 				},

--- a/pkg/ironicneutronagent/deployment.go
+++ b/pkg/ironicneutronagent/deployment.go
@@ -99,7 +99,7 @@ func Deployment(
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.Spec.ServiceAccount,
+					ServiceAccountName: instance.RbacResourceName(),
 					Containers: []corev1.Container{
 						{
 							Name: ServiceName,


### PR DESCRIPTION
Instead of requiering the ServiceAccount pre-created and defined in the Spec let each controller reconcile the ServiceAccount conditioned on owning Ironic existing.

When an owning Ironic instance exists, use the ServiceAccount created by the owner.

 