### PR TITLE
Align neutron-agent Secret with other types

### DIFF
--- a/api/v1beta1/ironicneutronagent_types.go
+++ b/api/v1beta1/ironicneutronagent_types.go
@@ -54,9 +54,9 @@ type IronicNeutronAgentSpec struct {
 	// Replicas - ML2 baremetal - Ironic Neutron Agent Replicas
 	Replicas int32 `json:"replicas"`
 
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	// Secret containing OpenStack password information for IronicPassword
-	Secret string `json:"secret"`
+	Secret string `json:"secret,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={service: IronicPassword}

--- a/config/crd/bases/ironic.openstack.org_ironicneutronagents.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicneutronagents.yaml
@@ -162,7 +162,6 @@ spec:
                   to register in ironic
                 type: string
             required:
-            - secret
             - serviceAccount
             type: object
           status:

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -894,7 +894,6 @@ spec:
                       to register in ironic
                     type: string
                 required:
-                - secret
                 - serviceAccount
                 type: object
               nodeSelector:


### PR DESCRIPTION
Make `Secret` optional, and set omitempty to align with the other Kinds.