### PR TITLE
IronicInspector: Remove unused spec.transportURLSecret

### DIFF
--- a/api/v1beta1/ironicinspector_types.go
+++ b/api/v1beta1/ironicinspector_types.go
@@ -108,10 +108,6 @@ type IronicInspectorSpec struct {
 	RabbitMqClusterName string `json:"rabbitMqClusterName"`
 
 	// +kubebuilder:validation:Optional
-	// TransportURLSecret - Secret containing RabbitMQ transportURL
-	TransportURLSecret string `json:"transportURLSecret,omitempty"`
-
-	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=json-rpc
 	// RPC transport type - Which RPC transport implementation to use between
 	// conductor and API services. 'oslo' to use oslo.messaging transport

--- a/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -293,9 +293,6 @@ spec:
               storageClass:
                 description: StorageClass
                 type: string
-              transportURLSecret:
-                description: TransportURLSecret - Secret containing RabbitMQ transportURL
-                type: string
             required:
             - serviceAccount
             type: object

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -771,9 +771,6 @@ spec:
                   storageClass:
                     description: StorageClass
                     type: string
-                  transportURLSecret:
-                    description: TransportURLSecret - Secret containing RabbitMQ transportURL
-                    type: string
                 required:
                 - serviceAccount
                 type: object


### PR DESCRIPTION
ironic-inspector controller is not using this value but uses the secret internally created (via TransportURL CR).