### PR TITLE
Fix keystoneVars for conductor

### DIFF
--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -727,6 +727,7 @@ func (r *IronicReconciler) conductorDeploymentCreateOrUpdate(
 		ServiceUser:             instance.Spec.ServiceUser,
 		DatabaseHostname:        instance.Status.DatabaseHostname,
 		TransportURLSecret:      instance.Status.TransportURLSecret,
+		KeystoneVars:            keystoneVars,
 	}
 	deployment := &ironicv1.IronicConductor{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This was missed in:
 https://github.com/openstack-k8s-operators/ironic-operator/pull/276