### PR TITLE
Drop hard-coded replicas from samples

### DIFF
--- a/config/samples/ironic_v1beta1_ironic_conductor_groups.yaml
+++ b/config/samples/ironic_v1beta1_ironic_conductor_groups.yaml
@@ -9,19 +9,13 @@ spec:
     debug = true
   databaseInstance: openstack
   storageClass: local-storage
-  ironicAPI:
-    replicas: 1
+  ironicAPI: {}
   ironicConductors:
-  - replicas: 1
-    storageRequest: 10G
+  - storageRequest: 10G
   - conductorGroup: auckland
-    replicas: 1
     storageRequest: 10G
   - conductorGroup: stockholm
-    replicas: 1
     storageRequest: 10G
-  ironicInspector:
-    replicas: 1
-  ironicNeutronAgent:
-    replicas: 1
+  ironicInspector: {}
+  ironicNeutronAgent: {}
   secret: osp-secret

--- a/config/samples/ironic_v1beta1_ironic_standalone.yaml
+++ b/config/samples/ironic_v1beta1_ironic_standalone.yaml
@@ -10,13 +10,10 @@ spec:
     debug = true
   databaseInstance: openstack
   storageClass: local-storage
-  ironicAPI:
-    replicas: 1
+  ironicAPI: {}
   ironicConductors:
-  - replicas: 1
-    storageRequest: 10G
-  ironicInspector:
-    replicas: 1
+  - storageRequest: 10G
+  ironicInspector: {}
   ironicNeutronAgent:
     replicas: 0  # Neutron agent replicas is zero, i.e disabled for standalone.
   secret: osp-secret

--- a/config/samples/ironic_v1beta1_ironicapi.yaml
+++ b/config/samples/ironic_v1beta1_ironicapi.yaml
@@ -2,5 +2,4 @@ apiVersion: ironic.openstack.org/v1beta1
 kind: IronicAPI
 metadata:
   name: ironicapi-sample
-spec:
-  replicas: 1
+spec: {}

--- a/config/samples/ironic_v1beta1_ironicconductor.yaml
+++ b/config/samples/ironic_v1beta1_ironicconductor.yaml
@@ -3,5 +3,4 @@ kind: IronicConductor
 metadata:
   name: ironicconductor-sample
 spec:
-  replicas: 1
   storageRequest: 10G

--- a/config/samples/ironic_v1beta1_ironicinspector.yaml
+++ b/config/samples/ironic_v1beta1_ironicinspector.yaml
@@ -3,5 +3,4 @@ kind: IronicInspector
 metadata:
   name: ironicinspector-sample
 spec:
-  replicas: 1
   secret: osp-secret

--- a/config/samples/ironic_v1beta1_ironicneutronagent.yaml
+++ b/config/samples/ironic_v1beta1_ironicneutronagent.yaml
@@ -4,5 +4,4 @@ metadata:
   name: ironic-neutron-agent-sample
   namespace: openstack
 spec:
-  replicas: 1
   secret: osp-secret


### PR DESCRIPTION
The issue with default Replicas spec has been resolved by [1], thus the replicas spec can be removed from samples now.

[1] c285e25b410a0ca7f81664072c33f0edb958d161