### PR TITLE
Don't use su with dbsync

### DIFF
--- a/pkg/ironic/dbsync.go
+++ b/pkg/ironic/dbsync.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// DBSyncCommand -
-	DBSyncCommand = "/usr/local/bin/kolla_set_configs && su ironic -s /bin/bash -c 'ironic-dbsync --config-file /etc/ironic/ironic.conf'"
+	DBSyncCommand = "/usr/local/bin/kolla_set_configs && /bin/bash -c 'ironic-dbsync --config-file /etc/ironic/ironic.conf'"
 )
 
 // DbSyncJob func

--- a/pkg/ironicinspector/dbsync.go
+++ b/pkg/ironicinspector/dbsync.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	// DBSyncCommand -
-	DBSyncCommand = "/usr/local/bin/kolla_set_configs && su ironic-inspector -s /bin/bash -c 'ironic-inspector-dbsync --config-file /etc/ironic-inspector/inspector.conf upgrade'"
+	DBSyncCommand = "/usr/local/bin/kolla_set_configs && /bin/bash -c 'ironic-inspector-dbsync --config-file /etc/ironic-inspector/inspector.conf upgrade'"
 )
 
 // DbSyncJob func


### PR DESCRIPTION
This is triggering a bug with Openshift 4.13 resulting in "Permission denied" when writing to /dev/stdout.