### PR TITLE
Extend dbsync to handle full update/upgrade

### DIFF
--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -668,7 +668,7 @@ func (r *IronicReconciler) reconcileUpgrade(
 		jobDef,
 		ironicv1.DbSyncHash,
 		instance.Spec.PreserveJobs,
-		5,
+		time.Second*5,
 		dbSyncHash,
 	)
 	ctrlResult, err := dbSyncjob.DoJob(

--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -413,7 +413,7 @@ func (r *IronicReconciler) reconcileNormal(ctx context.Context, instance *ironic
 	}
 
 	// Handle service upgrade
-	ctrlResult, err = r.reconcileUpgrade(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpgrade(ctx, instance, helper, serviceLabels)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -640,6 +640,25 @@ func (r *IronicReconciler) reconcileInit(
 
 	// create service DB - end
 
+	r.Log.Info("Reconciled Ironic init successfully")
+	return ctrl.Result{}, nil
+}
+
+func (r *IronicReconciler) reconcileUpdate(ctx context.Context, instance *ironicv1.Ironic, helper *helper.Helper) (ctrl.Result, error) {
+	// r.Log.Info("Reconciling Ironic update")
+
+	// r.Log.Info("Reconciled Ironic update successfully")
+	return ctrl.Result{}, nil
+}
+
+func (r *IronicReconciler) reconcileUpgrade(
+	ctx context.Context,
+	instance *ironicv1.Ironic,
+	helper *helper.Helper,
+	serviceLabels map[string]string,
+) (ctrl.Result, error) {
+	r.Log.Info("Reconciling Ironic upgrade")
+
 	//
 	// run ironic db sync
 	//
@@ -652,7 +671,7 @@ func (r *IronicReconciler) reconcileInit(
 		5,
 		dbSyncHash,
 	)
-	ctrlResult, err = dbSyncjob.DoJob(
+	ctrlResult, err := dbSyncjob.DoJob(
 		ctx,
 		helper,
 	)
@@ -680,26 +699,6 @@ func (r *IronicReconciler) reconcileInit(
 	instance.Status.Conditions.MarkTrue(condition.DBSyncReadyCondition, condition.DBSyncReadyMessage)
 
 	// run ironic db sync - end
-
-	r.Log.Info("Reconciled Ironic init successfully")
-	return ctrl.Result{}, nil
-}
-
-func (r *IronicReconciler) reconcileUpdate(ctx context.Context, instance *ironicv1.Ironic, helper *helper.Helper) (ctrl.Result, error) {
-	r.Log.Info("Reconciling Ironic update")
-
-	// TODO: should have minor update tasks if required
-	// - delete dbsync hash from status to rerun it?
-
-	r.Log.Info("Reconciled Ironic update successfully")
-	return ctrl.Result{}, nil
-}
-
-func (r *IronicReconciler) reconcileUpgrade(ctx context.Context, instance *ironicv1.Ironic, helper *helper.Helper) (ctrl.Result, error) {
-	r.Log.Info("Reconciling Ironic upgrade")
-
-	// TODO: should have major version upgrade tasks
-	// -delete dbsync hash from status to rerun it?
 
 	r.Log.Info("Reconciled Ironic upgrade successfully")
 	return ctrl.Result{}, nil

--- a/controllers/ironicapi_controller.go
+++ b/controllers/ironicapi_controller.go
@@ -723,22 +723,16 @@ func (r *IronicAPIReconciler) reconcileNormal(ctx context.Context, instance *iro
 }
 
 func (r *IronicAPIReconciler) reconcileUpdate(ctx context.Context, instance *ironicv1.IronicAPI, helper *helper.Helper) (ctrl.Result, error) {
-	r.Log.Info("Reconciling API update")
+	// r.Log.Info("Reconciling API update")
 
-	// TODO: should have minor update tasks if required
-	// - delete dbsync hash from status to rerun it?
-
-	r.Log.Info("Reconciled API update successfully")
+	// r.Log.Info("Reconciled API update successfully")
 	return ctrl.Result{}, nil
 }
 
 func (r *IronicAPIReconciler) reconcileUpgrade(ctx context.Context, instance *ironicv1.IronicAPI, helper *helper.Helper) (ctrl.Result, error) {
-	r.Log.Info("Reconciling API upgrade")
+	// r.Log.Info("Reconciling API upgrade")
 
-	// TODO: should have major version upgrade tasks
-	// -delete dbsync hash from status to rerun it?
-
-	r.Log.Info("Reconciled API upgrade successfully")
+	// r.Log.Info("Reconciled API upgrade successfully")
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -672,18 +672,12 @@ func (r *IronicConductorReconciler) reconcileNormal(ctx context.Context, instanc
 func (r *IronicConductorReconciler) reconcileUpdate(ctx context.Context, instance *ironicv1.IronicConductor, helper *helper.Helper) (ctrl.Result, error) {
 	// r.Log.Info("Reconciling Service update")
 
-	// TODO: should have minor update tasks if required
-	// - delete dbsync hash from status to rerun it?
-
 	// r.Log.Info("Reconciled Service update successfully")
 	return ctrl.Result{}, nil
 }
 
 func (r *IronicConductorReconciler) reconcileUpgrade(ctx context.Context, instance *ironicv1.IronicConductor, helper *helper.Helper) (ctrl.Result, error) {
 	// r.Log.Info("Reconciling Service upgrade")
-
-	// TODO: should have major version upgrade tasks
-	// -delete dbsync hash from status to rerun it?
 
 	// r.Log.Info("Reconciled Service upgrade successfully")
 	return ctrl.Result{}, nil

--- a/pkg/ironic/dbsync.go
+++ b/pkg/ironic/dbsync.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// DBSyncCommand -
-	DBSyncCommand = "/usr/local/bin/kolla_set_configs && /bin/bash -c 'ironic-dbsync --config-file /etc/ironic/ironic.conf'"
+	DBSyncCommand = "/usr/local/bin/container-scripts/dbsync.sh"
 )
 
 // DbSyncJob func

--- a/pkg/ironic/dbsync.go
+++ b/pkg/ironic/dbsync.go
@@ -83,7 +83,7 @@ func DbSyncJob(
 	job.Spec.Template.Spec.Volumes = GetVolumes(ServiceName)
 
 	initContainerDetails := APIDetails{
-		ContainerImage:       instance.Spec.Images.API,
+		ContainerImage:       instance.Spec.Images.Conductor,
 		DatabaseHost:         instance.Status.DatabaseHostname,
 		DatabaseName:         DatabaseName,
 		OSPSecret:            instance.Spec.Secret,

--- a/templates/ironic/bin/dbsync.sh
+++ b/templates/ironic/bin/dbsync.sh
@@ -31,3 +31,5 @@ if [ $ret_val -gt 1 ] ; then
     fi
 fi
 ironic-dbsync --config-file /etc/ironic/ironic.conf
+
+ironic-dbsync --config-file /etc/ironic/ironic.conf online_data_migrations

--- a/templates/ironic/bin/dbsync.sh
+++ b/templates/ironic/bin/dbsync.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Copyright 2023 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+/usr/local/bin/kolla_set_configs
+ironic-dbsync --config-file /etc/ironic/ironic.conf


### PR DESCRIPTION
- Move dbsync to reconcileUpgrade
- Move dbsync to a dedicated script
- Run upgrade check before dbsync
- Use conductor container image for dbsync
- Wait 5 seconds between dbsync reconciles
- Run online_data_migrations after default dbsync

Jira: [OSP-22712](https://issues.redhat.com//browse/OSP-22712)