### PR TITLE
Change ironic-api logging to using a sidecar container

### DIFF
--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -830,6 +830,7 @@ func (r *IronicReconciler) generateServiceConfigMaps(
 		templateParameters["IronicPublicURL"] = ""
 	}
 	templateParameters["Standalone"] = instance.Spec.Standalone
+	templateParameters["LogPath"] = ironic.LogPath
 
 	cms := []util.Template{
 		// ScriptsConfigMap

--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -739,6 +739,7 @@ func (r *IronicConductorReconciler) generateServiceConfigMaps(
 	templateParameters["DHCPRanges"] = dhcpRanges
 	templateParameters["Standalone"] = instance.Spec.Standalone
 	templateParameters["ConductorGroup"] = instance.Spec.ConductorGroup
+	templateParameters["LogPath"] = ironicconductor.LogPath
 
 	cms := []util.Template{
 		// Custom ConfigMap

--- a/pkg/ironic/const.go
+++ b/pkg/ironic/const.go
@@ -44,4 +44,6 @@ const (
 	ConductorGroupSelector = "conductorGroup"
 	// ImageDirectory -
 	ImageDirectory = "/var/lib/ironic/httpboot"
+	// LogPath - Log path for Ironc API
+	LogPath = "/var/log/ironic/ironic-api.log"
 )

--- a/pkg/ironicapi/deployment.go
+++ b/pkg/ironicapi/deployment.go
@@ -109,6 +109,22 @@ func Deployment(
 				Spec: corev1.PodSpec{
 					ServiceAccountName: instance.RbacResourceName(),
 					Containers: []corev1.Container{
+						// the first container in a pod is the default selected
+						// by oc log so define the log stream container first.
+						{
+							Name: ironic.ServiceName + "-" + ironic.APIComponent + "-log",
+							Command: []string{
+								"/bin/bash",
+							},
+							Args:  []string{"-c", "tail -n+1 -F " + ironic.LogPath},
+							Image: instance.Spec.ContainerImage,
+							SecurityContext: &corev1.SecurityContext{
+								RunAsUser: &runAsUser,
+							},
+							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
+							VolumeMounts: []corev1.VolumeMount{GetLogVolumeMount()},
+							Resources:    instance.Spec.Resources,
+						},
 						{
 							Name: ironic.ServiceName + "-" + ironic.APIComponent,
 							Command: []string{

--- a/pkg/ironicapi/volumes.go
+++ b/pkg/ironicapi/volumes.go
@@ -9,7 +9,7 @@ import (
 func GetVolumes(parentName string, name string) []corev1.Volume {
 	var config0640AccessMode int32 = 0640
 
-	backupVolumes := []corev1.Volume{
+	apiVolumes := []corev1.Volume{
 		{
 			Name: "config-data-custom",
 			VolumeSource: corev1.VolumeSource{
@@ -21,9 +21,24 @@ func GetVolumes(parentName string, name string) []corev1.Volume {
 				},
 			},
 		},
+		{
+			Name: "logs",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{Medium: ""},
+			},
+		},
 	}
 
-	return append(ironic.GetVolumes(parentName), backupVolumes...)
+	return append(ironic.GetVolumes(parentName), apiVolumes...)
+}
+
+// GetLogVolumeMount - Ironic API LogVolumeMount
+func GetLogVolumeMount() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      "logs",
+		MountPath: "/var/log/ironic",
+		ReadOnly:  false,
+	}
 }
 
 // GetInitVolumeMounts - Ironic API init task VolumeMounts
@@ -40,5 +55,5 @@ func GetInitVolumeMounts() []corev1.VolumeMount {
 
 // GetVolumeMounts - Ironic API VolumeMounts
 func GetVolumeMounts() []corev1.VolumeMount {
-	return ironic.GetVolumeMounts()
+	return append(ironic.GetVolumeMounts(), GetLogVolumeMount())
 }

--- a/pkg/ironicconductor/const.go
+++ b/pkg/ironicconductor/const.go
@@ -22,4 +22,6 @@ const (
 	DnsmasqKollaConfig = "/var/lib/config-data/merged/dnsmasq-config.json"
 	// HttpbootKollaConfig -
 	HttpbootKollaConfig = "/var/lib/config-data/merged/httpboot-config.json"
+	// LogPath
+	LogPath = "/dev/stdout"
 )

--- a/templates/common/config/ironic.conf
+++ b/templates/common/config/ironic.conf
@@ -24,7 +24,7 @@ hash_ring_algorithm=sha256
 rpc_transport=json-rpc
 
 use_stderr=false
-log_file=/dev/stdout
+log_file={{ .LogPath }}
 tempdir=/var/lib/ironic/tmp
 
 auth_strategy={{if .Standalone}}noauth{{else}}keystone{{end}}


### PR DESCRIPTION
This avoids permissions error when writing to /dev/stdout from a non-root user, which is an issue affecting OCP-4.13.x. Sidecar containers for API logging is the recommended pattern, has been done for some time by the nova-operator, and has just been implemented by cinder-operator[1]

[1] https://github.com/openstack-k8s-operators/cinder-operator/pull/238

Jira: [OSP-26868](https://issues.redhat.com//browse/OSP-26868)