### PR TITLE
Replace RabbitMqTransportURLReady by common condition

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -27,9 +27,6 @@ const (
 	// IronicConductorReadyCondition Status=True condition which indicates if the IronicConductor is configured and operational
 	IronicConductorReadyCondition condition.Type = "IronicConductorReady"
 
-	// IronicRabbitMqTransportURLReady Status=True condition which indicates if the RabbitMQ TransportURLUrl is ready
-	IronicRabbitMqTransportURLReadyCondition condition.Type = "IronicRabbitMqTransportURLReady"
-
 	// IronicInspectorReadyCondition Status=True condition which indicates if the Inspector is configured and operational
 	IronicInspectorReadyCondition condition.Type = "IronicInspectorReady"
 
@@ -42,6 +39,12 @@ const ()
 
 // Common Messages used by API objects.
 const (
+	//
+	// RabbitMqTransportURLReady condition messages
+	//
+	// RabbitMqTransportURLDisabledMessage
+	RabbitMqTransportURLDisabledMessage = "RabbitMqTransportURL disabled"
+
 	//
 	// IronicAPIReady condition messages
 	//
@@ -61,29 +64,17 @@ const (
 	IronicConductorReadyErrorMessage = "IronicConductor error occured %s"
 
 	//
-	// IronicRabbitMqTransportURLReady condition messages
+	// IronicInspectorReady condition messages
 	//
-	// IronicRabbitMqTransportURLReadyInitMessage
-	IronicRabbitMqTransportURLReadyInitMessage = "IronicRabbitMqTransportURL not started"
-
-	// IronicRabbitMqTransportURLReadyRunningMessage
-	IronicRabbitMqTransportURLReadyRunningMessage = "IronicRabbitMqTransportURL creation in progress"
-
-	// IronicRabbitMqTransportURLReadyMessage
-	IronicRabbitMqTransportURLReadyMessage = "IronicRabbitMqTransportURL successfully created"
-
-	// IronicRabbitMqTransportURLDisabledMessage
-	IronicRabbitMqTransportURLDisabledMessage = "IronicRabbitMqTransportURL disabled"
-
-	// IronicRabbitMqTransportURLReadyErrorMessage
-	IronicRabbitMqTransportURLReadyErrorMessage = "IronicRabbitMqTransportURL error occured %s"
-
 	// IronicInspectorReadyInitMessage
 	IronicInspectorReadyInitMessage = "IronicInspector not started"
 
 	// IronicInspectorReadyErrorMessage
 	IronicInspectorReadyErrorMessage = "IronicInspector error occured %s"
 
+	//
+	// IronicNeutronAgentReady condition messages
+	//
 	// IronicNeutronAgentReadyInitMessage
 	IronicNeutronAgentReadyInitMessage = "IronicNeutronAgent not started"
 

--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -171,7 +171,7 @@ func (r *IronicReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 			condition.UnknownCondition(ironicv1.IronicConductorReadyCondition, condition.InitReason, ironicv1.IronicConductorReadyInitMessage),
 			condition.UnknownCondition(ironicv1.IronicInspectorReadyCondition, condition.InitReason, ironicv1.IronicInspectorReadyInitMessage),
 			condition.UnknownCondition(ironicv1.IronicNeutronAgentReadyCondition, condition.InitReason, ironicv1.IronicNeutronAgentReadyInitMessage),
-			condition.UnknownCondition(ironicv1.IronicRabbitMqTransportURLReadyCondition, condition.InitReason, ironicv1.IronicRabbitMqTransportURLReadyInitMessage),
+			condition.UnknownCondition(condition.RabbitMqTransportURLReadyCondition, condition.InitReason, condition.RabbitMqTransportURLReadyInitMessage),
 			// service account, role, rolebinding conditions
 			condition.UnknownCondition(condition.ServiceAccountReadyCondition, condition.InitReason, condition.ServiceAccountReadyInitMessage),
 			condition.UnknownCondition(condition.RoleReadyCondition, condition.InitReason, condition.RoleReadyInitMessage),
@@ -270,10 +270,10 @@ func (r *IronicReconciler) reconcileNormal(ctx context.Context, instance *ironic
 
 		if err != nil {
 			instance.Status.Conditions.Set(condition.FalseCondition(
-				ironicv1.IronicRabbitMqTransportURLReadyCondition,
+				condition.RabbitMqTransportURLReadyCondition,
 				condition.ErrorReason,
 				condition.SeverityWarning,
-				ironicv1.IronicRabbitMqTransportURLReadyErrorMessage,
+				condition.RabbitMqTransportURLReadyErrorMessage,
 				err.Error(),
 			))
 			return ctrl.Result{}, err
@@ -288,17 +288,17 @@ func (r *IronicReconciler) reconcileNormal(ctx context.Context, instance *ironic
 		if instance.Status.TransportURLSecret == "" {
 			r.Log.Info(fmt.Sprintf("Waiting for TransportURL %s secret to be created", transportURL.Name))
 			instance.Status.Conditions.Set(condition.FalseCondition(
-				ironicv1.IronicRabbitMqTransportURLReadyCondition,
+				condition.RabbitMqTransportURLReadyCondition,
 				condition.RequestedReason,
 				condition.SeverityInfo,
-				ironicv1.IronicRabbitMqTransportURLReadyRunningMessage))
+				condition.RabbitMqTransportURLReadyRunningMessage))
 			return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 		}
 
-		instance.Status.Conditions.MarkTrue(ironicv1.IronicRabbitMqTransportURLReadyCondition, ironicv1.IronicRabbitMqTransportURLReadyMessage)
+		instance.Status.Conditions.MarkTrue(condition.RabbitMqTransportURLReadyCondition, condition.RabbitMqTransportURLReadyMessage)
 	} else {
 		instance.Status.TransportURLSecret = ""
-		instance.Status.Conditions.MarkTrue(ironicv1.IronicRabbitMqTransportURLReadyCondition, ironicv1.IronicRabbitMqTransportURLDisabledMessage)
+		instance.Status.Conditions.MarkTrue(condition.RabbitMqTransportURLReadyCondition, ironicv1.RabbitMqTransportURLDisabledMessage)
 	}
 	// end transportURL
 

--- a/controllers/ironicinspector_controller.go
+++ b/controllers/ironicinspector_controller.go
@@ -195,9 +195,9 @@ func (r *IronicInspectorReconciler) Reconcile(
 				condition.InitReason,
 				condition.NetworkAttachmentsReadyInitMessage),
 			condition.UnknownCondition(
-				ironicv1.IronicRabbitMqTransportURLReadyCondition,
+				condition.RabbitMqTransportURLReadyCondition,
 				condition.InitReason,
-				ironicv1.IronicRabbitMqTransportURLReadyInitMessage),
+				condition.RabbitMqTransportURLReadyInitMessage),
 			// service account, role, rolebinding conditions
 			condition.UnknownCondition(
 				condition.ServiceAccountReadyCondition,
@@ -336,10 +336,10 @@ func (r *IronicInspectorReconciler) reconcileTransportURL(
 
 		if err != nil {
 			instance.Status.Conditions.Set(condition.FalseCondition(
-				ironicv1.IronicRabbitMqTransportURLReadyCondition,
+				condition.RabbitMqTransportURLReadyCondition,
 				condition.ErrorReason,
 				condition.SeverityWarning,
-				ironicv1.IronicRabbitMqTransportURLReadyErrorMessage,
+				condition.RabbitMqTransportURLReadyErrorMessage,
 				err.Error(),
 			))
 			return ctrl.Result{}, err
@@ -358,21 +358,21 @@ func (r *IronicInspectorReconciler) reconcileTransportURL(
 				"Waiting for TransportURL %s secret to be created",
 				transportURL.Name))
 			instance.Status.Conditions.Set(condition.FalseCondition(
-				ironicv1.IronicRabbitMqTransportURLReadyCondition,
+				condition.RabbitMqTransportURLReadyCondition,
 				condition.RequestedReason,
 				condition.SeverityInfo,
-				ironicv1.IronicRabbitMqTransportURLReadyRunningMessage))
+				condition.RabbitMqTransportURLReadyRunningMessage))
 			return ctrl.Result{}, nil
 		}
 
 		instance.Status.Conditions.MarkTrue(
-			ironicv1.IronicRabbitMqTransportURLReadyCondition,
-			ironicv1.IronicRabbitMqTransportURLReadyMessage)
+			condition.RabbitMqTransportURLReadyCondition,
+			condition.RabbitMqTransportURLReadyMessage)
 	} else {
 		instance.Status.TransportURLSecret = ""
 		instance.Status.Conditions.MarkTrue(
-			ironicv1.IronicRabbitMqTransportURLReadyCondition,
-			ironicv1.IronicRabbitMqTransportURLDisabledMessage)
+			condition.RabbitMqTransportURLReadyCondition,
+			ironicv1.RabbitMqTransportURLDisabledMessage)
 	}
 	// transportURL - end
 

--- a/controllers/ironicneutronagent_controller.go
+++ b/controllers/ironicneutronagent_controller.go
@@ -170,9 +170,9 @@ func (r *IronicNeutronAgentReconciler) Reconcile(
 				condition.InitReason,
 				condition.InputReadyInitMessage),
 			condition.UnknownCondition(
-				ironicv1.IronicRabbitMqTransportURLReadyCondition,
+				condition.RabbitMqTransportURLReadyCondition,
 				condition.InitReason,
-				ironicv1.IronicRabbitMqTransportURLReadyInitMessage),
+				condition.RabbitMqTransportURLReadyInitMessage),
 			condition.UnknownCondition(
 				condition.ServiceConfigReadyCondition,
 				condition.InitReason,
@@ -247,10 +247,10 @@ func (r *IronicNeutronAgentReconciler) reconcileTransportURL(
 	)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
-			ironicv1.IronicRabbitMqTransportURLReadyCondition,
+			condition.RabbitMqTransportURLReadyCondition,
 			condition.ErrorReason,
 			condition.SeverityWarning,
-			ironicv1.IronicRabbitMqTransportURLReadyErrorMessage,
+			condition.RabbitMqTransportURLReadyErrorMessage,
 			err.Error(),
 		))
 		return ctrl.Result{}, err
@@ -266,15 +266,15 @@ func (r *IronicNeutronAgentReconciler) reconcileTransportURL(
 			"Waiting for TransportURL %s secret to be created",
 			transportURL.Name))
 		instance.Status.Conditions.Set(condition.FalseCondition(
-			ironicv1.IronicRabbitMqTransportURLReadyCondition,
+			condition.RabbitMqTransportURLReadyCondition,
 			condition.RequestedReason,
 			condition.SeverityInfo,
-			ironicv1.IronicRabbitMqTransportURLReadyRunningMessage))
+			condition.RabbitMqTransportURLReadyRunningMessage))
 		return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 	}
 	instance.Status.Conditions.MarkTrue(
-		ironicv1.IronicRabbitMqTransportURLReadyCondition,
-		ironicv1.IronicRabbitMqTransportURLReadyMessage)
+		condition.RabbitMqTransportURLReadyCondition,
+		condition.RabbitMqTransportURLReadyMessage)
 
 	return ctrl.Result{}, nil
 }

--- a/tests/functional/ironicinspector_controller_test.go
+++ b/tests/functional/ironicinspector_controller_test.go
@@ -22,8 +22,6 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 	corev1 "k8s.io/api/core/v1"
-
-	ironicv1 "github.com/openstack-k8s-operators/ironic-operator/api/v1beta1"
 )
 
 var _ = Describe("IronicInspector controller", func() {
@@ -108,7 +106,7 @@ var _ = Describe("IronicInspector controller", func() {
 			th.ExpectCondition(
 				ironicNames.InspectorName,
 				ConditionGetterFunc(IronicInspectorConditionGetter),
-				ironicv1.IronicRabbitMqTransportURLReadyCondition,
+				condition.RabbitMqTransportURLReadyCondition,
 				corev1.ConditionTrue,
 			)
 			instance := GetIronicInspector(ironicNames.InspectorName)

--- a/tests/functional/ironicneutronagent_controller_test.go
+++ b/tests/functional/ironicneutronagent_controller_test.go
@@ -27,8 +27,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	ironicv1 "github.com/openstack-k8s-operators/ironic-operator/api/v1beta1"
 )
 
 var _ = Describe("IronicNeutronAgent controller", func() {
@@ -54,7 +52,7 @@ var _ = Describe("IronicNeutronAgent controller", func() {
 			th.ExpectCondition(
 				ironicNames.INAName,
 				ConditionGetterFunc(INAConditionGetter),
-				ironicv1.IronicRabbitMqTransportURLReadyCondition,
+				condition.RabbitMqTransportURLReadyCondition,
 				corev1.ConditionTrue,
 			)
 			instance := GetIronicNeutronAgent(ironicNames.INAName)


### PR DESCRIPTION
We have added the common RabbitMqTransportURLReady to lib-common to reduce duplicate implementations.

Depends-on: https://github.com/openstack-k8s-operators/lib-common/pull/300