### PR TITLE
Skip redundant update when removing a finalizer

### DIFF
--- a/controllers/ironicapi_controller.go
+++ b/controllers/ironicapi_controller.go
@@ -55,26 +55,6 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 )
 
-// GetClient -
-func (r *IronicAPIReconciler) GetClient() client.Client {
-	return r.Client
-}
-
-// GetKClient -
-func (r *IronicAPIReconciler) GetKClient() kubernetes.Interface {
-	return r.Kclient
-}
-
-// GetLogger -
-func (r *IronicAPIReconciler) GetLogger() logr.Logger {
-	return r.Log
-}
-
-// GetScheme -
-func (r *IronicAPIReconciler) GetScheme() *runtime.Scheme {
-	return r.Scheme
-}
-
 // IronicAPIReconciler reconciles a IronicAPI object
 type IronicAPIReconciler struct {
 	client.Client
@@ -284,11 +264,13 @@ func (r *IronicAPIReconciler) reconcileDelete(ctx context.Context, instance *iro
 		}
 
 		if err == nil {
-			controllerutil.RemoveFinalizer(keystoneEndpoint, helper.GetFinalizer())
-			if err = helper.GetClient().Update(ctx, keystoneEndpoint); err != nil && !k8s_errors.IsNotFound(err) {
-				return ctrl.Result{}, err
+			if controllerutil.RemoveFinalizer(keystoneEndpoint, helper.GetFinalizer()) {
+				err = r.Update(ctx, keystoneEndpoint)
+				if err != nil && !k8s_errors.IsNotFound(err) {
+					return ctrl.Result{}, err
+				}
+				util.LogForObject(helper, "Removed finalizer from our KeystoneEndpoint", instance)
 			}
-			util.LogForObject(helper, "Removed finalizer from our KeystoneEndpoint", instance)
 		}
 
 		// Remove the finalizer from our KeystoneService CR
@@ -298,11 +280,13 @@ func (r *IronicAPIReconciler) reconcileDelete(ctx context.Context, instance *iro
 		}
 
 		if err == nil {
-			controllerutil.RemoveFinalizer(keystoneService, helper.GetFinalizer())
-			if err = helper.GetClient().Update(ctx, keystoneService); err != nil && !k8s_errors.IsNotFound(err) {
-				return ctrl.Result{}, err
+			if controllerutil.RemoveFinalizer(keystoneService, helper.GetFinalizer()) {
+				err = r.Update(ctx, keystoneService)
+				if err != nil && !k8s_errors.IsNotFound(err) {
+					return ctrl.Result{}, err
+				}
+				util.LogForObject(helper, "Removed finalizer from our KeystoneService", instance)
 			}
-			util.LogForObject(helper, "Removed finalizer from our KeystoneService", instance)
 		}
 	}
 

--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -58,26 +58,6 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 )
 
-// GetClient -
-func (r *IronicConductorReconciler) GetClient() client.Client {
-	return r.Client
-}
-
-// GetKClient -
-func (r *IronicConductorReconciler) GetKClient() kubernetes.Interface {
-	return r.Kclient
-}
-
-// GetLogger -
-func (r *IronicConductorReconciler) GetLogger() logr.Logger {
-	return r.Log
-}
-
-// GetScheme -
-func (r *IronicConductorReconciler) GetScheme() *runtime.Scheme {
-	return r.Scheme
-}
-
 // IronicConductorReconciler reconciles a IronicConductor object
 type IronicConductorReconciler struct {
 	client.Client

--- a/controllers/ironicinspector_controller.go
+++ b/controllers/ironicinspector_controller.go
@@ -692,11 +692,13 @@ func (r *IronicInspectorReconciler) reconcileDeleteKeystoneServices(
 		}
 
 		if err == nil {
-			controllerutil.RemoveFinalizer(keystoneEndpoint, helper.GetFinalizer())
-			if err = helper.GetClient().Update(ctx, keystoneEndpoint); err != nil && !k8s_errors.IsNotFound(err) {
-				return ctrl.Result{}, err
+			if controllerutil.RemoveFinalizer(keystoneEndpoint, helper.GetFinalizer()) {
+				err = r.Update(ctx, keystoneEndpoint)
+				if err != nil && !k8s_errors.IsNotFound(err) {
+					return ctrl.Result{}, err
+				}
+				util.LogForObject(helper, "Removed finalizer from our KeystoneEndpoint", instance)
 			}
-			util.LogForObject(helper, "Removed finalizer from our KeystoneEndpoint", instance)
 		}
 
 		// Remove the finalizer from our KeystoneService CR
@@ -706,11 +708,13 @@ func (r *IronicInspectorReconciler) reconcileDeleteKeystoneServices(
 		}
 
 		if err == nil {
-			controllerutil.RemoveFinalizer(keystoneService, helper.GetFinalizer())
-			if err = helper.GetClient().Update(ctx, keystoneService); err != nil && !k8s_errors.IsNotFound(err) {
-				return ctrl.Result{}, err
+			if controllerutil.RemoveFinalizer(keystoneService, helper.GetFinalizer()) {
+				err = r.Update(ctx, keystoneService)
+				if err != nil && !k8s_errors.IsNotFound(err) {
+					return ctrl.Result{}, err
+				}
+				util.LogForObject(helper, "Removed finalizer from our KeystoneService", instance)
 			}
-			util.LogForObject(helper, "Removed finalizer from our KeystoneService", instance)
 		}
 	}
 	return ctrl.Result{}, nil

--- a/controllers/ironicneutronagent_controller.go
+++ b/controllers/ironicneutronagent_controller.go
@@ -53,26 +53,6 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 )
 
-// GetClient -
-func (r *IronicNeutronAgentReconciler) GetClient() client.Client {
-	return r.Client
-}
-
-// GetKClient -
-func (r *IronicNeutronAgentReconciler) GetKClient() kubernetes.Interface {
-	return r.Kclient
-}
-
-// GetLogger -
-func (r *IronicNeutronAgentReconciler) GetLogger() logr.Logger {
-	return r.Log
-}
-
-// GetScheme -
-func (r *IronicNeutronAgentReconciler) GetScheme() *runtime.Scheme {
-	return r.Scheme
-}
-
 // IronicNeutronAgentReconciler reconciles a IronicNeutronAgent object
 type IronicNeutronAgentReconciler struct {
 	client.Client


### PR DESCRIPTION
We don't have to update a CR when the CR does not contain the finalizer being removed. This also removes some unused/redundant function from the Reconciler struct.