### PR TITLE
Fix INA transport URL - RabbitMqClusterName

### DIFF
--- a/api/v1beta1/ironicneutronagent_types.go
+++ b/api/v1beta1/ironicneutronagent_types.go
@@ -25,12 +25,6 @@ import (
 type IronicNeutronAgentTemplate struct {
 	// Common input parameters for all Ironic services
 	IronicServiceTemplate `json:",inline"`
-
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=rabbitmq
-	// RabbitMQ instance name
-	// Needed to request a transportURL that is created and used in Ironic
-	RabbitMqClusterName string `json:"rabbitMqClusterName"`
 }
 
 // IronicNeutronAgentSpec defines the desired state of ML2 baremetal - ironic-neutron-agent agents
@@ -56,6 +50,11 @@ type IronicNeutronAgentSpec struct {
 	// PasswordSelectors - Selectors to identify the ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=rabbitmq
+	// RabbitMQ instance name
+	// Needed to request a transportURL that is created and used in Ironic
+	RabbitMqClusterName string `json:"rabbitMqClusterName"`
 }
 
 // IronicNeutronAgentStatus defines the observed state of ML2 baremetal - ironic-neutron-agent

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -651,11 +651,6 @@ spec:
                       this service. Setting here overrides any global NodeSelector
                       settings within the Ironic CR
                     type: object
-                  rabbitMqClusterName:
-                    default: rabbitmq
-                    description: RabbitMQ instance name Needed to request a transportURL
-                      that is created and used in Ironic
-                    type: string
                   replicas:
                     default: 1
                     description: Replicas -

--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -967,6 +967,7 @@ func (r *IronicReconciler) ironicNeutronAgentDeploymentCreateOrUpdate(
 		Secret:                     instance.Spec.Secret,
 		PasswordSelectors:          instance.Spec.PasswordSelectors,
 		ServiceUser:                instance.Spec.ServiceUser,
+		RabbitMqClusterName:        instance.Spec.RabbitMqClusterName,
 	}
 	deployment := &ironicv1.IronicNeutronAgent{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Ironic Neutron Agent was broken because the transport URL was created without setting the RabbitMqClusterName - causing the transport secret to never reconcile successfully.

Add RabbitMqClusterName back to IronicNeutronAgentSpec and set it in ironic controller the same way it is done for inspector.