### PR TITLE
Omit empty value for RPCTransport and RabbitMqClusterName

### DIFF
--- a/api/v1beta1/ironic_types.go
+++ b/api/v1beta1/ironic_types.go
@@ -124,15 +124,16 @@ type IronicSpec struct {
 	// +kubebuilder:default=rabbitmq
 	// RabbitMQ instance name
 	// Needed to request a transportURL that is created and used in Ironic
-	RabbitMqClusterName string `json:"rabbitMqClusterName"`
+	RabbitMqClusterName string `json:"rabbitMqClusterName,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum:=oslo;json-rpc
 	// +kubebuilder:default=json-rpc
 	// RPC transport type - Which RPC transport implementation to use between
 	// conductor and API services. 'oslo' to use oslo.messaging transport
 	// or 'json-rpc' to use JSON RPC transport. NOTE -> ironic and ironic-inspector
 	// require oslo.messaging transport when not in standalone mode.
-	RPCTransport string `json:"rpcTransport"`
+	RPCTransport string `json:"rpcTransport,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service. Setting

--- a/api/v1beta1/ironicapi_types.go
+++ b/api/v1beta1/ironicapi_types.go
@@ -75,12 +75,13 @@ type IronicAPISpec struct {
 	TransportURLSecret string `json:"transportURLSecret,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum:=oslo;json-rpc
 	// +kubebuilder:default=json-rpc
 	// RPC transport type - Which RPC transport implementation to use between
 	// conductor and API services. 'oslo' to use oslo.messaging transport
 	// or 'json-rpc' to use JSON RPC transport. NOTE -> ironic requires
 	// oslo.messaging transport when not in standalone mode.
-	RPCTransport string `json:"rpcTransport"`
+	RPCTransport string `json:"rpcTransport,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// keystoneVars - Internally used map of Keystone API endpoints

--- a/api/v1beta1/ironicconductor_types.go
+++ b/api/v1beta1/ironicconductor_types.go
@@ -99,12 +99,13 @@ type IronicConductorSpec struct {
 	TransportURLSecret string `json:"transportURLSecret,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum:=oslo;json-rpc
 	// +kubebuilder:default=json-rpc
 	// RPC transport type - Which RPC transport implementation to use between
 	// conductor and API services. 'oslo' to use oslo.messaging transport
 	// or 'json-rpc' to use JSON RPC transport. NOTE -> ironic requires
 	// oslo.messaging transport when not in standalone mode.
-	RPCTransport string `json:"rpcTransport"`
+	RPCTransport string `json:"rpcTransport,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// keystoneVars - Internally used map of Keystone API endpoints

--- a/api/v1beta1/ironicinspector_types.go
+++ b/api/v1beta1/ironicinspector_types.go
@@ -148,12 +148,13 @@ type IronicInspectorSpec struct {
 	RabbitMqClusterName string `json:"rabbitMqClusterName"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum:=oslo;json-rpc
 	// +kubebuilder:default=json-rpc
 	// RPC transport type - Which RPC transport implementation to use between
 	// conductor and API services. 'oslo' to use oslo.messaging transport
 	// or 'json-rpc' to use JSON RPC transport. NOTE -> ironic-inspector
 	// requires oslo.messaging transport when not in standalone mode.
-	RPCTransport string `json:"rpcTransport"`
+	RPCTransport string `json:"rpcTransport,omitempty"`
 }
 
 // IronicInspectorStatus defines the observed state of IronicInspector

--- a/api/v1beta1/ironicneutronagent_types.go
+++ b/api/v1beta1/ironicneutronagent_types.go
@@ -30,7 +30,7 @@ type IronicNeutronAgentTemplate struct {
 	// +kubebuilder:default=rabbitmq
 	// RabbitMQ instance name
 	// Needed to request a transportURL that is created and used in Ironic
-	RabbitMqClusterName string `json:"rabbitMqClusterName"`
+	RabbitMqClusterName string `json:"rabbitMqClusterName,omitempty"`
 }
 
 // IronicNeutronAgentSpec defines the desired state of ML2 baremetal - ironic-neutron-agent agents

--- a/config/crd/bases/ironic.openstack.org_ironicapis.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicapis.yaml
@@ -219,6 +219,9 @@ spec:
                   to use between conductor and API services. 'oslo' to use oslo.messaging
                   transport or 'json-rpc' to use JSON RPC transport. NOTE -> ironic
                   requires oslo.messaging transport when not in standalone mode.
+                enum:
+                - oslo
+                - json-rpc
                 type: string
               secret:
                 description: Secret containing OpenStack password information for

--- a/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
@@ -226,6 +226,9 @@ spec:
                   to use between conductor and API services. 'oslo' to use oslo.messaging
                   transport or 'json-rpc' to use JSON RPC transport. NOTE -> ironic
                   requires oslo.messaging transport when not in standalone mode.
+                enum:
+                - oslo
+                - json-rpc
                 type: string
               secret:
                 description: Secret containing OpenStack password information for

--- a/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -278,6 +278,9 @@ spec:
                   to use between conductor and API services. 'oslo' to use oslo.messaging
                   transport or 'json-rpc' to use JSON RPC transport. NOTE -> ironic-inspector
                   requires oslo.messaging transport when not in standalone mode.
+                enum:
+                - oslo
+                - json-rpc
                 type: string
               secret:
                 description: Secret containing OpenStack password information for

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -755,6 +755,9 @@ spec:
                   transport or 'json-rpc' to use JSON RPC transport. NOTE -> ironic
                   and ironic-inspector require oslo.messaging transport when not in
                   standalone mode.
+                enum:
+                - oslo
+                - json-rpc
                 type: string
               secret:
                 description: Secret containing OpenStack password information for


### PR DESCRIPTION
These specs are optional so are allowed to be defined with omitempty. This helps us to avoid getting "" passed down to underlying CR.

This also adds validation about RPCTransport to reject any unsupported values.