### PR TITLE
Accept only supported values for RPCTransport

### DIFF
--- a/api/v1beta1/ironic_types.go
+++ b/api/v1beta1/ironic_types.go
@@ -127,6 +127,7 @@ type IronicSpec struct {
 	RabbitMqClusterName string `json:"rabbitMqClusterName"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum:=oslo;json-rpc
 	// +kubebuilder:default=json-rpc
 	// RPC transport type - Which RPC transport implementation to use between
 	// conductor and API services. 'oslo' to use oslo.messaging transport

--- a/api/v1beta1/ironicapi_types.go
+++ b/api/v1beta1/ironicapi_types.go
@@ -75,6 +75,7 @@ type IronicAPISpec struct {
 	TransportURLSecret string `json:"transportURLSecret,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum:=oslo;json-rpc
 	// +kubebuilder:default=json-rpc
 	// RPC transport type - Which RPC transport implementation to use between
 	// conductor and API services. 'oslo' to use oslo.messaging transport

--- a/api/v1beta1/ironicconductor_types.go
+++ b/api/v1beta1/ironicconductor_types.go
@@ -99,6 +99,7 @@ type IronicConductorSpec struct {
 	TransportURLSecret string `json:"transportURLSecret,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum:=oslo;json-rpc
 	// +kubebuilder:default=json-rpc
 	// RPC transport type - Which RPC transport implementation to use between
 	// conductor and API services. 'oslo' to use oslo.messaging transport

--- a/api/v1beta1/ironicinspector_types.go
+++ b/api/v1beta1/ironicinspector_types.go
@@ -148,6 +148,7 @@ type IronicInspectorSpec struct {
 	RabbitMqClusterName string `json:"rabbitMqClusterName"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum:=oslo;json-rpc
 	// +kubebuilder:default=json-rpc
 	// RPC transport type - Which RPC transport implementation to use between
 	// conductor and API services. 'oslo' to use oslo.messaging transport

--- a/config/crd/bases/ironic.openstack.org_ironicapis.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicapis.yaml
@@ -219,6 +219,9 @@ spec:
                   to use between conductor and API services. 'oslo' to use oslo.messaging
                   transport or 'json-rpc' to use JSON RPC transport. NOTE -> ironic
                   requires oslo.messaging transport when not in standalone mode.
+                enum:
+                - oslo
+                - json-rpc
                 type: string
               secret:
                 description: Secret containing OpenStack password information for

--- a/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
@@ -226,6 +226,9 @@ spec:
                   to use between conductor and API services. 'oslo' to use oslo.messaging
                   transport or 'json-rpc' to use JSON RPC transport. NOTE -> ironic
                   requires oslo.messaging transport when not in standalone mode.
+                enum:
+                - oslo
+                - json-rpc
                 type: string
               secret:
                 description: Secret containing OpenStack password information for

--- a/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -278,6 +278,9 @@ spec:
                   to use between conductor and API services. 'oslo' to use oslo.messaging
                   transport or 'json-rpc' to use JSON RPC transport. NOTE -> ironic-inspector
                   requires oslo.messaging transport when not in standalone mode.
+                enum:
+                - oslo
+                - json-rpc
                 type: string
               secret:
                 description: Secret containing OpenStack password information for

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -755,6 +755,9 @@ spec:
                   transport or 'json-rpc' to use JSON RPC transport. NOTE -> ironic
                   and ironic-inspector require oslo.messaging transport when not in
                   standalone mode.
+                enum:
+                - oslo
+                - json-rpc
                 type: string
               secret:
                 description: Secret containing OpenStack password information for


### PR DESCRIPTION
This adds the validation annotation so that the RPCTransport spec accepts a supported value.