### PR TITLE
Reject neutron agent in standalone mode

### DIFF
--- a/api/v1beta1/ironic_webhook.go
+++ b/api/v1beta1/ironic_webhook.go
@@ -132,6 +132,10 @@ func (spec *IronicSpec) ValidateCreate(basePath *field.Path) field.ErrorList {
 		allErrs = append(allErrs, err...)
 	}
 
+	if err := validateNeutronAgentSpec(spec, basePath); err != nil {
+		allErrs = append(allErrs, err...)
+	}
+
 	return allErrs
 }
 
@@ -178,6 +182,10 @@ func (spec *IronicSpec) ValidateUpdate(old IronicSpec, basePath *field.Path) fie
 	}
 
 	if err := validateDHCPRangesOverlap(spec, basePath); err != nil {
+		allErrs = append(allErrs, err...)
+	}
+
+	if err := validateNeutronAgentSpec(spec, basePath); err != nil {
 		allErrs = append(allErrs, err...)
 	}
 
@@ -264,6 +272,21 @@ func validateConductoGroupsUnique(spec *IronicSpec, basePath *field.Path) *field
 	}
 
 	return nil
+}
+
+// validateNeutronAgentSpec
+func validateNeutronAgentSpec(spec *IronicSpec, basePath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if spec.Standalone && *spec.IronicNeutronAgent.Replicas > 0 {
+		allErrs = append(allErrs, field.Invalid(
+			basePath.Child("ironicNeutronAgent").Child("replicas"),
+			*spec.IronicNeutronAgent.Replicas,
+			"IronicNeutronAgent is not supported with standalone mode",
+		))
+	}
+
+	return allErrs
 }
 
 func validateDHCPRange(

--- a/api/v1beta1/ironic_webhook.go
+++ b/api/v1beta1/ironic_webhook.go
@@ -116,7 +116,7 @@ func (r *Ironic) ValidateCreate() error {
 func (spec *IronicSpec) ValidateCreate(basePath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	if err := validateConductoGroupsUnique(spec, basePath); err != nil {
+	if err := validateConductorGroupsUnique(spec, basePath); err != nil {
 		allErrs = append(allErrs, err)
 	}
 
@@ -169,7 +169,7 @@ func (r *Ironic) ValidateUpdate(old runtime.Object) error {
 func (spec *IronicSpec) ValidateUpdate(old IronicSpec, basePath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	if err := validateConductoGroupsUnique(spec, basePath); err != nil {
+	if err := validateConductorGroupsUnique(spec, basePath); err != nil {
 		allErrs = append(allErrs, err)
 	}
 
@@ -218,8 +218,8 @@ func validateInspectorSpec(spec *IronicSpec, basePath *field.Path) field.ErrorLi
 func validateConductorSpec(spec *IronicSpec, basePath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	// validateConductoGroupsUnique
-	if err := validateConductoGroupsUnique(spec, basePath); err != nil {
+	// validateConductorGroupsUnique
+	if err := validateConductorGroupsUnique(spec, basePath); err != nil {
 		allErrs = append(allErrs, err)
 	}
 
@@ -236,8 +236,8 @@ func validateConductorSpec(spec *IronicSpec, basePath *field.Path) field.ErrorLi
 	return allErrs
 }
 
-// validateConductoGroupsUnique implements validation of IronicConductor ConductorGroup
-func validateConductoGroupsUnique(spec *IronicSpec, basePath *field.Path) *field.Error {
+// validateConductorGroupsUnique implements validation of IronicConductor ConductorGroup
+func validateConductorGroupsUnique(spec *IronicSpec, basePath *field.Path) *field.Error {
 	fieldPath := basePath.Child("ironicConductors")
 	var groupName string
 	seenGrps := make(map[string]int)


### PR DESCRIPTION
ironic-neutron-agent should not be enabled when standalone mode is enabled. This introduces the validation at webhook.
