### PR TITLE
Change kuttl tests to run in any namespace

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -16,9 +16,9 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
+namespace: ironic-kuttl-tests
 reportFormat: JSON
 reportName: kuttl-test-ironic
-namespace: openstack
 timeout: 750
 parallel: 1
 suppress:

--- a/tests/kuttl/common/assert-endpoints.yaml
+++ b/tests/kuttl/common/assert-endpoints.yaml
@@ -11,12 +11,11 @@
 # This test is for the ironic endpoints
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-namespaced: true
 commands:
   - script: |
       template='{{.status.apiEndpoints.ironic.public}}{{":"}}{{.status.apiEndpoints.ironic.internal}}{{"\n"}}'
-      regex="http:\/\/ironic-public-openstack\.apps.*:http:\/\/ironic-admin-openstack\.apps.*:http:\/\/ironic-internal-openstack\.apps.*"
-      apiEndpoints=$(oc get -n openstack ironics.ironic.openstack.org ironic -o go-template="$template")
+      regex="http:\/\/ironic-public-$NAMESPACE\.apps.*:http:\/\/ironic-admin-$NAMESPACE\.apps.*:http:\/\/ironic-internal-$NAMESPACE\.apps.*"
+      apiEndpoints=$(oc get -n $NAMESPACE ironics.ironic.openstack.org ironic -o go-template="$template")
       matches=$(echo "$apiEndpoints" | sed -e "s?$regex??")
       if [ -z "$matches" ]; then
         exit 0
@@ -30,12 +29,11 @@ commands:
 # This test is for the ironic inspector endpoints
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-namespaced: true
 commands:
   - script: |
       template='{{index .status.apiEndpoints "ironic-inspector" "public"}}{{":"}}{{index .status.apiEndpoints "ironic-inspector" "internal"}}{{"\n"}}'
-      regex="http:\/\/ironic-inspector-public-openstack\.apps.*:http:\/\/ironic-inspector-admin-openstack\.apps.*:http:\/\/ironic-inspector-internal-openstack\.apps.*"
-      apiEndpoints=$(oc get -n openstack ironics.ironic.openstack.org ironic -o go-template="$template")
+      regex="http:\/\/ironic-inspector-public-$NAMESPACE\.apps.*:http:\/\/ironic-inspector-admin-$NAMESPACE\.apps.*:http:\/\/ironic-inspector-internal-$NAMESPACE\.apps.*"
+      apiEndpoints=$(oc get -n $NAMESPACE ironics.ironic.openstack.org ironic -o go-template="$template")
       matches=$(echo "$apiEndpoints" | sed -e "s?$regex??")
       if [ -z "$matches" ]; then
         exit 0
@@ -47,12 +45,11 @@ commands:
 # This test is for ironic endpoints
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-namespaced: true
 commands:
   - script: |
       set -x
       RETURN_CODE=0
-      PUBLIC_URL=$(oc get -n openstack ironics.ironic.openstack.org ironic -o jsonpath='{.status.apiEndpoints.ironic.public}')
+      PUBLIC_URL=$(oc get -n $NAMESPACE ironics.ironic.openstack.org ironic -o jsonpath='{.status.apiEndpoints.ironic.public}')
       if [ -z "$PUBLIC_URL" ]; then
           RETURN_CODE=1
           echo "Endpoint: apiEndpoints.ironic.public not ready."
@@ -70,12 +67,11 @@ commands:
 # This test is for ironic inspector endpoints
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-namespaced: true
 commands:
   - script: |
       set -x
       RETURN_CODE=0
-      PUBLIC_URL=$(oc get -n openstack ironics.ironic.openstack.org ironic -o jsonpath='{.status.apiEndpoints.ironic-inspector.public}')
+      PUBLIC_URL=$(oc get -n $NAMESPACE ironics.ironic.openstack.org ironic -o jsonpath='{.status.apiEndpoints.ironic-inspector.public}')
       if [ -z "$PUBLIC_URL" ]; then
           RETURN_CODE=1
           echo "Endpoint: .status.apiEndpoints.ironic-inspector.public not ready."

--- a/tests/kuttl/common/cleanup-ironic.yaml
+++ b/tests/kuttl/common/cleanup-ironic.yaml
@@ -4,4 +4,3 @@ delete:
 - apiVersion: ironic.openstack.org/v1beta1
   kind: Ironic
   name: ironic
-  namespace: openstack

--- a/tests/kuttl/common/errors-cleanup-ironic.yaml
+++ b/tests/kuttl/common/errors-cleanup-ironic.yaml
@@ -13,13 +13,11 @@ metadata:
   finalizers:
   - IronicAPI
   name: ironic
-  namespace: openstack
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ironic
-  namespace: openstack
 ---
 # the openshift annotations can't be checked through the deployment above
 apiVersion: v1
@@ -37,7 +35,6 @@ metadata:
     internal: "true"
     service: ironic
   name: ironic-internal
-  namespace: openstack
 ---
 apiVersion: v1
 kind: Service
@@ -46,7 +43,6 @@ metadata:
     public: "true"
     service: ironic
   name: ironic-public
-  namespace: openstack
 ---
 apiVersion: route.openshift.io/v1
 kind: Route
@@ -55,4 +51,3 @@ metadata:
   labels:
     public: "true"
     service: ironic
-  namespace: openstack

--- a/tests/kuttl/tests/deploy/10-assert-deploy-ironic.yaml
+++ b/tests/kuttl/tests/deploy/10-assert-deploy-ironic.yaml
@@ -14,7 +14,6 @@ metadata:
   finalizers:
   - Ironic
   name: ironic
-  namespace: openstack
 spec:
   customServiceConfig: |
     [DEFAULT]
@@ -60,7 +59,6 @@ metadata:
   finalizers:
   - IronicAPI
   name: ironic-api
-  namespace: openstack
   ownerReferences:
   - apiVersion: ironic.openstack.org/v1beta1
     blockOwnerDeletion: true
@@ -91,7 +89,6 @@ metadata:
   finalizers:
   - IronicConductor
   name: ironic-conductor
-  namespace: openstack
   ownerReferences:
   - apiVersion: ironic.openstack.org/v1beta1
     blockOwnerDeletion: true
@@ -125,7 +122,6 @@ metadata:
   finalizers:
   - IronicInspector
   name: ironic-inspector
-  namespace: openstack
   ownerReferences:
   - apiVersion: ironic.openstack.org/v1beta1
     blockOwnerDeletion: true
@@ -161,7 +157,6 @@ metadata:
   finalizers:
   - IronicNeutronAgent
   name: ironic-ironic-neutron-agent
-  namespace: openstack
   ownerReferences:
   - apiVersion: ironic.openstack.org/v1beta1
     blockOwnerDeletion: true

--- a/tests/kuttl/tests/deploy/10-deploy-ironic.yaml
+++ b/tests/kuttl/tests/deploy/10-deploy-ironic.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      oc apply -n openstack -f ../../../../config/samples/ironic_v1beta1_ironic.yaml
+      oc apply -n $NAMESPACE -f ../../../../config/samples/ironic_v1beta1_ironic.yaml

--- a/tests/kuttl/tests/deploy/20-assert-deploy-ironic-conductor-groups.yaml
+++ b/tests/kuttl/tests/deploy/20-assert-deploy-ironic-conductor-groups.yaml
@@ -2,7 +2,6 @@ apiVersion: ironic.openstack.org/v1beta1
 kind: Ironic
 metadata:
   name: ironic
-  namespace: openstack
 spec:
   serviceUser: ironic
   customServiceConfig: |

--- a/tests/kuttl/tests/deploy/20-deploy-ironic-conductor-groups.yaml
+++ b/tests/kuttl/tests/deploy/20-deploy-ironic-conductor-groups.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      oc apply -n openstack -f ../../../../config/samples/ironic_v1beta1_ironic_conductor_groups.yaml
+      oc apply -n $NAMESPACE -f ../../../../config/samples/ironic_v1beta1_ironic_conductor_groups.yaml

--- a/tests/kuttl/tests/standalone/10-assert-deploy-ironic-standalone.yaml
+++ b/tests/kuttl/tests/standalone/10-assert-deploy-ironic-standalone.yaml
@@ -13,7 +13,6 @@ metadata:
   finalizers:
   - Ironic
   name: ironic
-  namespace: openstack
 spec:
   customServiceConfig: |
     [DEFAULT]
@@ -53,7 +52,6 @@ metadata:
   finalizers:
   - IronicAPI
   name: ironic-api
-  namespace: openstack
   ownerReferences:
   - apiVersion: ironic.openstack.org/v1beta1
     blockOwnerDeletion: true
@@ -84,7 +82,6 @@ metadata:
   finalizers:
   - IronicConductor
   name: ironic-conductor
-  namespace: openstack
   ownerReferences:
   - apiVersion: ironic.openstack.org/v1beta1
     blockOwnerDeletion: true
@@ -118,7 +115,6 @@ metadata:
   finalizers:
   - IronicInspector
   name: ironic-inspector
-  namespace: openstack
   ownerReferences:
   - apiVersion: ironic.openstack.org/v1beta1
     blockOwnerDeletion: true

--- a/tests/kuttl/tests/standalone/10-deploy-ironic-standalone.yaml
+++ b/tests/kuttl/tests/standalone/10-deploy-ironic-standalone.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      oc apply -n openstack -f ../../../../config/samples/ironic_v1beta1_ironic_standalone.yaml
+      oc apply -n $NAMESPACE -f ../../../../config/samples/ironic_v1beta1_ironic_standalone.yaml


### PR DESCRIPTION
Modify the kuttl tests so that they can run in any namespace, not just
in the openstack one. This requires removing any mention of the
namespace in the asserts and using the $NAMESPACE variable in scripts
instead of the namespace name.

Needs https://github.com/openstack-k8s-operators/install_yamls/pull/471 to be
merged for CI to pass.
