### PR TITLE
Remove duplicate IronicInspector CR from csv

### DIFF
--- a/config/manifests/bases/ironic-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ironic-operator.clusterserviceversion.yaml
@@ -16,11 +16,6 @@ spec:
       kind: IronicInspector
       name: ironicinspectors.ironic.openstack.org
       version: v1beta1
-    - description: IronicInspector is the Schema for the ironicinspectors
-      displayName: Ironic Inspector
-      kind: IronicInspector
-      name: ironicinspectors.ironic.openstack.org
-      version: ""
     - description: IronicNeutronAgent is the Schema for the ML2 networking-baremetal's
         agent
       displayName: Ironic Neutron Agent


### PR DESCRIPTION
There are two IronicInspector CR now. We should keep the one with API version and the other one can be removed.