### PR TITLE
Support disconnected network environments

### DIFF
--- a/.github/create_bundle.sh
+++ b/.github/create_bundle.sh
@@ -1,69 +1,13 @@
 #!/bin/bash
 set -e
 
-CLUSTER_BUNDLE_FILE="bundle/manifests/ironic-operator.clusterserviceversion.yaml"
-
 echo "Creating ironic operator bundle"
 cd ..
 echo "${GITHUB_SHA}"
 echo "${BASE_IMAGE}"
-skopeo --version
-
-echo "Calculating image digest for docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA}"
-DIGEST=$(skopeo inspect docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} | jq '.Digest' -r)
-# Output:
-# Calculating image digest for docker://quay.io/openstack-k8s-operators/ironic-operator:d03f2c1c362c04fc5ef819f92a218f9ea59bbd0c
-# Digest: sha256:1d5b578fd212f8dbd03c0235f1913ef738721766f8c94236af5efecc6d8d8cb1
-echo "Digest: ${DIGEST}"
 
 RELEASE_VERSION=$(grep "^VERSION" Makefile | awk -F'?= ' '{ print $2 }')
-OPERATOR_IMG_WITH_DIGEST="${REGISTRY}/${BASE_IMAGE}@${DIGEST}"
-
-echo "New Operator Image with Digest: $OPERATOR_IMG_WITH_DIGEST"
 echo "Release Version: $RELEASE_VERSION"
 
 echo "Creating bundle image..."
-VERSION=$RELEASE_VERSION IMG=$OPERATOR_IMG_WITH_DIGEST make bundle
-
-echo "Bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
-
-# We do not want to exit here. Some images are in different registries, so
-# error will be reported to the console.
-set +e
-for csv_image in $(cat "${CLUSTER_BUNDLE_FILE}" | grep "image:" | sed -e "s|.*image:||" | sort -u); do
-    digest_image=""
-    echo "CSV line: ${csv_image}"
-
-    # case where @ is in the csv_image image
-    if [[ "$csv_image" =~ .*"@".* ]]; then
-        delimeter='@'
-    else
-        delimeter=':'
-    fi
-
-    base_image=$(echo $csv_image | cut -f 1 -d${delimeter})
-    tag_image=$(echo $csv_image | cut -f 2 -d${delimeter})
-
-    if [[ "$base_image:$tag_image" == "controller:latest" ]]; then
-        echo "$base_image:$tag_image becomes $OPERATOR_IMG_WITH_DIGEST"
-        sed -e "s|$base_image:$tag_image|$OPERATOR_IMG_WITH_DIGEST|g" -i "${CLUSTER_BUNDLE_FILE}"
-    else
-        digest_image=$(skopeo inspect docker://${base_image}${delimeter}${tag_image} | jq '.Digest' -r)
-        echo "Base image: $base_image"
-        if [ -n "$digest_image" ]; then
-            echo "$base_image${delimeter}$tag_image becomes $base_image@$digest_image"
-            sed -i "s|$base_image$delimeter$tag_image|$base_image@$digest_image|g" "${CLUSTER_BUNDLE_FILE}"
-        else
-            echo "$base_image${delimeter}$tag_image not changed"
-        fi
-    fi
-done
-
-echo "Resulting bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
+USE_IMAGE_DIGESTS=true VERSION=$RELEASE_VERSION IMG=${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} make bundle

--- a/.prow_ci.env
+++ b/.prow_ci.env
@@ -1,0 +1,1 @@
+export USE_IMAGE_DIGESTS=true

--- a/api/v1beta1/ironic_types.go
+++ b/api/v1beta1/ironic_types.go
@@ -291,12 +291,12 @@ func (instance Ironic) RbacResourceName() string {
 func SetupDefaults() {
 	// Acquire environmental defaults and initialize Ironic defaults with them
 	imageDefaults := IronicImages{
-		API:               util.GetEnvVar("IRONIC_API_IMAGE_URL_DEFAULT", IronicAPIContainerImage),
-		Conductor:         util.GetEnvVar("IRONIC_CONDUCTOR_IMAGE_URL_DEFAULT", IronicConductorContainerImage),
-		Inspector:         util.GetEnvVar("IRONIC_INSPECTOR_IMAGE_URL_DEFAULT", IronicInspectorContainerImage),
-		Pxe:               util.GetEnvVar("IRONIC_PXE_IMAGE_URL_DEFAULT", IronicPXEContainerImage),
-		NeutronAgent:      util.GetEnvVar("IRONIC_NEUTRON_AGENT_IMAGE_URL_DEFAULT", IronicNeutronAgentContainerImage),
-		IronicPythonAgent: util.GetEnvVar("IRONIC_PYTHON_AGENT_IMAGE_URL_DEFAULT", IronicPythonAgentContainerImage),
+		API:               util.GetEnvVar("RELATED_IMAGE_IRONIC_API_IMAGE_URL_DEFAULT", IronicAPIContainerImage),
+		Conductor:         util.GetEnvVar("RELATED_IMAGE_IRONIC_CONDUCTOR_IMAGE_URL_DEFAULT", IronicConductorContainerImage),
+		Inspector:         util.GetEnvVar("RELATED_IMAGE_IRONIC_INSPECTOR_IMAGE_URL_DEFAULT", IronicInspectorContainerImage),
+		Pxe:               util.GetEnvVar("RELATED_IMAGE_IRONIC_PXE_IMAGE_URL_DEFAULT", IronicPXEContainerImage),
+		NeutronAgent:      util.GetEnvVar("RELATED_IMAGE_IRONIC_NEUTRON_AGENT_IMAGE_URL_DEFAULT", IronicNeutronAgentContainerImage),
+		IronicPythonAgent: util.GetEnvVar("RELATED_IMAGE_IRONIC_PYTHON_AGENT_IMAGE_URL_DEFAULT", IronicPythonAgentContainerImage),
 	}
 
 	SetupIronicImageDefaults(imageDefaults)

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -11,15 +11,15 @@ spec:
       containers:
       - name: manager
         env:
-        - name: IRONIC_API_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_IRONIC_API_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ironic-api:current-podified
-        - name: IRONIC_CONDUCTOR_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_IRONIC_CONDUCTOR_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
-        - name: IRONIC_INSPECTOR_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_IRONIC_INSPECTOR_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ironic-inspector:current-podified
-        - name: IRONIC_PXE_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_IRONIC_PXE_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
-        - name: IRONIC_NEUTRON_AGENT_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_IRONIC_NEUTRON_AGENT_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ironic-neutron-agent:current-podified
-        - name: IRONIC_PYTHON_AGENT_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_IRONIC_PYTHON_AGENT_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/ironic-python-agent:current-podified

--- a/config/manifests/bases/ironic-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ironic-operator.clusterserviceversion.yaml
@@ -5,6 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     operatorframework.io/suggested-namespace: openstack
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
   name: ironic-operator.v0.0.0
   namespace: placeholder
 spec:

--- a/tests/kuttl/common/assert-endpoints.yaml
+++ b/tests/kuttl/common/assert-endpoints.yaml
@@ -84,3 +84,46 @@ commands:
           fi
       fi
       exit $RETURN_CODE
+---
+# when using image digests the containerImage URLs are SHAs so we verify them with a script
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: |
+      tupleTemplate='{{ range (index .spec.template.spec.containers 1).env }}{{ .name }}{{ "#" }}{{ .value}}{{"\n"}}{{ end }}'
+      imageTuples=$(oc get -n openstack-operators deployment ironic-operator-controller-manager -o go-template="$tupleTemplate")
+      for ITEM in $(echo $imageTuples); do
+        # it is an image
+        if echo $ITEM | grep 'RELATED_IMAGE' &> /dev/null; then
+          NAME=$(echo $ITEM | sed -e 's|^RELATED_IMAGE_IRONIC_\(.*\)_IMAGE.*|\1|')
+          IMG_FROM_ENV=$(echo $ITEM | sed -e 's|^.*#\(.*\)|\1|')
+          template='{{.spec.containerImage}}'
+          case $NAME in
+            API)
+              SERVICE_IMAGE=$(oc get -n $NAMESPACE ironicapi ironic-api -o go-template="$template")
+              ;;
+            CONDUCTOR)
+              SERVICE_IMAGE=$(oc get -n $NAMESPACE ironicconductor ironic-conductor -o go-template="$template")
+              ;;
+            INSPECTOR)
+              SERVICE_IMAGE=$(oc get -n $NAMESPACE ironicinspector ironic-inspector -o go-template="$template")
+              ;;
+            PXE)
+              SERVICE_IMAGE=$(oc get -n $NAMESPACE ironicconductor ironic-conductor -o go-template="{{.spec.pxeContainerImage}}")
+              ;;
+            NEUTRON_AGENT)
+              # this isn't deployed in all tests
+              continue
+              ;;
+            PYTHON_AGENT)
+              # this doesn't seem to be used ATM
+              continue
+              ;;
+          esac
+          if [ "$SERVICE_IMAGE" != "$IMG_FROM_ENV" ]; then
+            echo "$NAME image does not equal $VALUE"
+            exit 1
+          fi
+        fi
+      done
+      exit 0

--- a/tests/kuttl/tests/deploy/10-assert-deploy-ironic.yaml
+++ b/tests/kuttl/tests/deploy/10-assert-deploy-ironic.yaml
@@ -66,7 +66,6 @@ metadata:
     kind: Ironic
     name: ironic
 spec:
-  containerImage: quay.io/podified-antelope-centos9/openstack-ironic-api:current-podified
   customServiceConfig: '# add your customization here'
   databaseHostname: openstack
   debug:
@@ -97,7 +96,6 @@ metadata:
     name: ironic
 spec:
   conductorGroup: ""
-  containerImage: quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
   customServiceConfig: '# add your customization here'
   databaseHostname: openstack
   debug:
@@ -105,7 +103,6 @@ spec:
   passwordSelectors:
     database: IronicDatabasePassword
     service: IronicPassword
-  pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
   replicas: 1
   resources: {}
   rpcTransport: json-rpc
@@ -129,7 +126,6 @@ metadata:
     kind: Ironic
     name: ironic
 spec:
-  containerImage: quay.io/podified-antelope-centos9/openstack-ironic-inspector:current-podified
   customServiceConfig: '# add your customization here'
   databaseInstance: openstack
   debug:
@@ -139,7 +135,6 @@ spec:
     database: IronicInspectorDatabasePassword
     service: IronicInspectorPassword
   preserveJobs: true
-  pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
   rabbitMqClusterName: rabbitmq
   replicas: 1
   resources: {}
@@ -164,7 +159,6 @@ metadata:
     kind: Ironic
     name: ironic
 spec:
-  containerImage: quay.io/podified-antelope-centos9/openstack-ironic-neutron-agent:current-podified
   customServiceConfig: "# add your customization here"
   debug:
     service: false

--- a/tests/kuttl/tests/standalone/10-assert-deploy-ironic-standalone.yaml
+++ b/tests/kuttl/tests/standalone/10-assert-deploy-ironic-standalone.yaml
@@ -59,7 +59,6 @@ metadata:
     kind: Ironic
     name: ironic
 spec:
-  containerImage: quay.io/podified-antelope-centos9/openstack-ironic-api:current-podified
   customServiceConfig: '# add your customization here'
   databaseHostname: openstack
   debug:
@@ -90,7 +89,6 @@ metadata:
     name: ironic
 spec:
   conductorGroup: ""
-  containerImage: quay.io/podified-antelope-centos9/openstack-ironic-conductor:current-podified
   customServiceConfig: '# add your customization here'
   databaseHostname: openstack
   debug:
@@ -98,7 +96,6 @@ spec:
   passwordSelectors:
     database: IronicDatabasePassword
     service: IronicPassword
-  pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
   replicas: 1
   resources: {}
   rpcTransport: json-rpc
@@ -122,7 +119,6 @@ metadata:
     kind: Ironic
     name: ironic
 spec:
-  containerImage: quay.io/podified-antelope-centos9/openstack-ironic-inspector:current-podified
   customServiceConfig: '# add your customization here'
   databaseInstance: openstack
   debug:
@@ -132,7 +128,6 @@ spec:
     database: IronicInspectorDatabasePassword
     service: IronicInspectorPassword
   preserveJobs: true
-  pxeContainerImage: quay.io/podified-antelope-centos9/openstack-ironic-pxe:current-podified
   rabbitMqClusterName: rabbitmq
   replicas: 1
   resources: {}


### PR DESCRIPTION
This PR adds support for installing the operator in disconnected network environments. To build with image-digests set USE_IMAGE_DIGESTS=true before running make bundle.

For Prow jobs we are enabling this via .prow-ci.env

This drops the old logic from create_bundle.sh which has been broken with operator-sdk's make bundle for some time.

(NOTE: this currently requires a secure registry)