### PR TITLE
Run ironic-python-agent-init in Inspector

### DIFF
--- a/pkg/ironicinspector/statefulset.go
+++ b/pkg/ironicinspector/statefulset.go
@@ -263,19 +263,22 @@ func StatefulSet(
 	}
 
 	initContainerDetails := APIDetails{
-		ContainerImage:       instance.Spec.ContainerImage,
-		PxeContainerImage:    instance.Spec.PxeContainerImage,
-		DatabaseHost:         instance.Status.DatabaseHostname,
-		DatabaseName:         DatabaseName,
-		OSPSecret:            instance.Spec.Secret,
-		TransportURLSecret:   instance.Status.TransportURLSecret,
-		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
-		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
-		VolumeMounts:         GetInitVolumeMounts(),
-		PxeInit:              true,
-		InspectorHTTPURL:     inspectorHTTPURL,
-		IngressDomain:        ingressDomain,
-		InspectionNetwork:    instance.Spec.InspectionNetwork,
+		ContainerImage:         instance.Spec.ContainerImage,
+		PxeContainerImage:      instance.Spec.PxeContainerImage,
+		IronicPythonAgentImage: instance.Spec.IronicPythonAgentImage,
+		ImageDirectory:         ironic.ImageDirectory,
+		DatabaseHost:           instance.Status.DatabaseHostname,
+		DatabaseName:           DatabaseName,
+		OSPSecret:              instance.Spec.Secret,
+		TransportURLSecret:     instance.Status.TransportURLSecret,
+		DBPasswordSelector:     instance.Spec.PasswordSelectors.Database,
+		UserPasswordSelector:   instance.Spec.PasswordSelectors.Service,
+		VolumeMounts:           GetInitVolumeMounts(),
+		PxeInit:                true,
+		IpaInit:                true,
+		InspectorHTTPURL:       inspectorHTTPURL,
+		IngressDomain:          ingressDomain,
+		InspectionNetwork:      instance.Spec.InspectionNetwork,
 	}
 	statefulset.Spec.Template.Spec.InitContainers = InitContainer(initContainerDetails)
 

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -389,10 +389,11 @@ func GetIronicInspector(
 
 func GetDefaultIronicInspectorSpec() map[string]interface{} {
 	return map[string]interface{}{
-		"databaseInstance": DatabaseInstance,
-		"secret":           SecretName,
-		"containerImage":   ContainerImage,
-		"serviceAccount":   "ironic",
+		"databaseInstance":       DatabaseInstance,
+		"secret":                 SecretName,
+		"containerImage":         ContainerImage,
+		"ironicPythonAgentImage": IronicPythonAgentImage,
+		"serviceAccount":         "ironic",
 	}
 }
 


### PR DESCRIPTION
We need to run the ironic-python-agent-init container to copy the images to Inspectors http directory.