### PR TITLE
[envtest]Use database helpers from mariadb-operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.1.1-0.20230927082538-4f614f333d17
 	github.com/openstack-k8s-operators/lib-common/modules/database v0.1.1-0.20230927082538-4f614f333d17
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.1.2-0.20230927082538-4f614f333d17
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230918111825-8999b3b2dc3c
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928103342-106bb85983f4
 	k8s.io/api v0.26.9
 	k8s.io/apimachinery v0.27.1
 	k8s.io/client-go v0.26.9

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,8 @@ github.com/openstack-k8s-operators/lib-common/modules/openstack v0.1.1-0.2023092
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.1.1-0.20230927082538-4f614f333d17/go.mod h1:+iJZo5alCeOGD/524hWWdlINA6zqY+MjfWT7cDcbvBE=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.1.2-0.20230927082538-4f614f333d17 h1:zJguNin+9IwRnGKy1A7ranxASKO1vTvWxoXwkCz8MWw=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.1.2-0.20230927082538-4f614f333d17/go.mod h1:YOFHrNK/QqCvZUPlDJYmDyaCkbKIB98V04uyofiC9a8=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230918111825-8999b3b2dc3c h1:9R8T1WRwuPS5KMfsQWxAMSGPuJrGMJ7bODKK9dirhHA=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230918111825-8999b3b2dc3c/go.mod h1:xXHF/R/L0XamRHR/UkzlgzSTocBQ6GSQ2U16Q9Mf/bA=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928103342-106bb85983f4 h1:37bbJ9XzpCvB+zZckdweJEEH3pqM6Q88OHH8eHFvlpI=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928103342-106bb85983f4/go.mod h1:xhiz5wFdKWwVM7BF/VYon4TT3NuUPXp/Pyn2hWcp0CE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/tests/functional/ironic_controller_test.go
+++ b/tests/functional/ironic_controller_test.go
@@ -42,8 +42,8 @@ var _ = Describe("Ironic controller", func() {
 				CreateMessageBusSecret(ironicNames.Namespace, MessageBusSecretName),
 			)
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					ironicNames.Namespace,
 					"openstack",
 					corev1.ServiceSpec{
@@ -156,8 +156,8 @@ var _ = Describe("Ironic controller", func() {
 		It("Creates service database instance", func() {
 			th.GetTransportURL(ironicNames.IronicTransportURLName)
 			th.SimulateTransportURLReady(ironicNames.IronicTransportURLName)
-			th.GetMariaDBDatabase(ironicNames.IronicDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(ironicNames.IronicDatabaseName)
+			mariadb.GetMariaDBDatabase(ironicNames.IronicDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.IronicDatabaseName)
 			th.ExpectCondition(
 				ironicNames.IronicName,
 				ConditionGetterFunc(IronicConditionGetter),
@@ -168,8 +168,8 @@ var _ = Describe("Ironic controller", func() {
 		It("Runs service database DBsync", func() {
 			th.GetTransportURL(ironicNames.IronicTransportURLName)
 			th.SimulateTransportURLReady(ironicNames.IronicTransportURLName)
-			th.GetMariaDBDatabase(ironicNames.IronicDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(ironicNames.IronicDatabaseName)
+			mariadb.GetMariaDBDatabase(ironicNames.IronicDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.IronicDatabaseName)
 			th.SimulateJobSuccess(ironicNames.IronicDBSyncJobName)
 			th.ExpectCondition(
 				ironicNames.IronicName,
@@ -181,8 +181,8 @@ var _ = Describe("Ironic controller", func() {
 		It("Creates deployment for API, Conductor, Inspector and INA", func() {
 			th.GetTransportURL(ironicNames.IronicTransportURLName)
 			th.SimulateTransportURLReady(ironicNames.IronicTransportURLName)
-			th.GetMariaDBDatabase(ironicNames.IronicDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(ironicNames.IronicDatabaseName)
+			mariadb.GetMariaDBDatabase(ironicNames.IronicDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.IronicDatabaseName)
 			th.SimulateJobSuccess(ironicNames.IronicDBSyncJobName)
 			Eventually(func(g Gomega) {
 				g.Expect(th.K8sClient.Get(th.Ctx, types.NamespacedName{

--- a/tests/functional/ironicapi_controller_test.go
+++ b/tests/functional/ironicapi_controller_test.go
@@ -40,8 +40,8 @@ var _ = Describe("IronicAPI controller", func() {
 				CreateMessageBusSecret(ironicNames.Namespace, MessageBusSecretName),
 			)
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					ironicNames.Namespace,
 					"openstack",
 					corev1.ServiceSpec{

--- a/tests/functional/ironicconductor_controller_test.go
+++ b/tests/functional/ironicconductor_controller_test.go
@@ -41,8 +41,8 @@ var _ = Describe("IronicConductor controller", func() {
 				CreateMessageBusSecret(ironicNames.Namespace, MessageBusSecretName),
 			)
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					ironicNames.Namespace,
 					"openstack",
 					corev1.ServiceSpec{

--- a/tests/functional/ironicinspector_controller_test.go
+++ b/tests/functional/ironicinspector_controller_test.go
@@ -33,8 +33,8 @@ var _ = Describe("IronicInspector controller", func() {
 				CreateIronicSecret(ironicNames.Namespace, SecretName),
 			)
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					ironicNames.Namespace,
 					"openstack",
 					corev1.ServiceSpec{
@@ -131,8 +131,8 @@ var _ = Describe("IronicInspector controller", func() {
 		It("Creates service database instance", func() {
 			th.GetTransportURL(ironicNames.InspectorTransportURLName)
 			th.SimulateTransportURLReady(ironicNames.InspectorTransportURLName)
-			th.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
+			mariadb.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
 			th.ExpectCondition(
 				ironicNames.InspectorName,
 				ConditionGetterFunc(IronicInspectorConditionGetter),
@@ -143,8 +143,8 @@ var _ = Describe("IronicInspector controller", func() {
 		It("Runs service database DBsync", func() {
 			th.GetTransportURL(ironicNames.InspectorTransportURLName)
 			th.SimulateTransportURLReady(ironicNames.InspectorTransportURLName)
-			th.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
+			mariadb.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
 			th.SimulateJobSuccess(ironicNames.InspectorDBSyncJobName)
 			th.ExpectCondition(
 				ironicNames.InspectorName,
@@ -156,8 +156,8 @@ var _ = Describe("IronicInspector controller", func() {
 		It("Exposes services", func() {
 			th.GetTransportURL(ironicNames.InspectorTransportURLName)
 			th.SimulateTransportURLReady(ironicNames.InspectorTransportURLName)
-			th.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
+			mariadb.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
 			th.SimulateJobSuccess(ironicNames.InspectorDBSyncJobName)
 			th.ExpectCondition(
 				ironicNames.InspectorName,
@@ -169,8 +169,8 @@ var _ = Describe("IronicInspector controller", func() {
 		It("Creates StatefulSet and set status fields - Deployment is Ready", func() {
 			th.GetTransportURL(ironicNames.InspectorTransportURLName)
 			th.SimulateTransportURLReady(ironicNames.InspectorTransportURLName)
-			th.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
+			mariadb.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
 			th.SimulateJobSuccess(ironicNames.InspectorDBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(ironicNames.InspectorName)
 			keystone.SimulateKeystoneServiceReady(ironicNames.InspectorName)
@@ -185,8 +185,8 @@ var _ = Describe("IronicInspector controller", func() {
 		It("Creates keystone service, users and endpoints", func() {
 			th.GetTransportURL(ironicNames.InspectorTransportURLName)
 			th.SimulateTransportURLReady(ironicNames.InspectorTransportURLName)
-			th.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
+			mariadb.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
 			th.SimulateJobSuccess(ironicNames.InspectorDBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(ironicNames.InspectorName)
 			keystone.SimulateKeystoneServiceReady(ironicNames.InspectorName)
@@ -207,8 +207,8 @@ var _ = Describe("IronicInspector controller", func() {
 		It("Sets ReadyCondition and replica count", func() {
 			th.GetTransportURL(ironicNames.InspectorTransportURLName)
 			th.SimulateTransportURLReady(ironicNames.InspectorTransportURLName)
-			th.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
-			th.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
+			mariadb.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
 			th.SimulateJobSuccess(ironicNames.InspectorDBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(ironicNames.InspectorName)
 			keystone.SimulateKeystoneServiceReady(ironicNames.InspectorName)

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -49,6 +49,7 @@ import (
 	keystone_test "github.com/openstack-k8s-operators/keystone-operator/api/test/helpers"
 	"github.com/openstack-k8s-operators/lib-common/modules/test"
 	common_test "github.com/openstack-k8s-operators/lib-common/modules/test/helpers"
+	mariadb_test "github.com/openstack-k8s-operators/mariadb-operator/api/test/helpers"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -64,6 +65,7 @@ var (
 	logger      logr.Logger
 	th          *common_test.TestHelper
 	keystone    *keystone_test.TestHelper
+	mariadb     *mariadb_test.TestHelper
 	ironicNames IronicNames
 )
 
@@ -143,7 +145,9 @@ var _ = BeforeSuite(func() {
 	th = common_test.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
 	Expect(th).NotTo(BeNil())
 	keystone = keystone_test.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
-	Expect(th).NotTo(BeNil())
+	Expect(keystone).NotTo(BeNil())
+	mariadb = mariadb_test.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
+	Expect(mariadb).NotTo(BeNil())
 
 	// Start the controller-manager if goroutine
 	webhookInstallOptions := &testEnv.WebhookInstallOptions


### PR DESCRIPTION
This is necessary to remove a dependency cycle from lib-common