### PR TITLE
Set enable_proxy_headers_parsing=true

### DIFF
--- a/templates/common/config/ironic.conf
+++ b/templates/common/config/ironic.conf
@@ -140,3 +140,6 @@ ipxe_timeout=60
 [redfish]
 # TODO: Enable when swift/ceph integration is complete
 use_swift=false
+
+[oslo_middleware]
+enable_proxy_headers_parsing=true

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -41,9 +41,9 @@ const (
 	ContainerImage         = "test://ironic"
 	PxeContainerImage      = "test://pxe-image"
 	IronicPythonAgentImage = "test://ipa-image"
-	IronicInputHash        = "n5b8h55ch59ch64ch66dh67bh7h565h687h55bh6hbbhf9h59fh7bhcfh657h68fh5f8h574h654h75h675h695h5f4h588h68dh674h56bh574h5d4h568q"
-	ConductorInputHash     = "n75h57bh9h5b8h5fchcbh55h5fhd5h6dh57bhd5h547h696h5f9h79hffh58fh55fh66bh5b6h68dh9dh5ch694hf5h55bh84h9bh5bch5c5h545q"
-	APIInputHash           = "n58ch588h669h549hddh64dhd6h687h5f5h57bh679h5b6hf6hf8h96h58fh684h589h574h54dh95hf5h64bh696h7h86hd4hf6h9fh545h68ch96q"
+	IronicInputHash        = "n5b6h585hf7h555h5ffh66ch5bdh55h695h97h558h7fh5bchbch5cch5dfh68bh667hd5h68h689hbch5b9h584h565hdfh56fh57h64fh58fh77h7fq"
+	ConductorInputHash     = "n566h554h66fh6bh78h76hbbh577h567h565h5ch65ch54bh9h678h55hc6h5f8hf5h5dbh66fh576h5cbh655h595h575h5bdhf9h55dh5d6hb4h5c6q"
+	APIInputHash           = "n6fh657h688h85h547h5d4h7fh5dch9h8h648hf8h8h695hd6h599hch558h5b9h5f5hd6h667h88h584h689h66h59h677hb7h8bh5f8h6dq"
 )
 
 type IronicNames struct {


### PR DESCRIPTION
This should fix ironic-operator-build-deploy-tempest which has failing tests due to incorrectly generated links[1].

[1] https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openstack-k8s-operators_ironic-operator/355/pull-ci-openstack-k8s-operators-ironic-operator-main-ironic-operator-build-deploy-tempest/1722338128045281280/artifacts/ironic-operator-build-deploy-tempest/openstack-k8s-operators-tempest/artifacts/stestr_results.html