### PR TITLE
force rbac policy to only leverage the new policy

### DIFF
--- a/templates/common/config/ironic.conf
+++ b/templates/common/config/ironic.conf
@@ -106,6 +106,9 @@ user_domain_name=Default
 project_name=service
 project_domain_name=Default
 
+[oslo_policy]
+enforce_scope=True
+enforce_new_defaults=True
 {{end}}
 
 [conductor]

--- a/templates/ironicinspector/config/inspector.conf
+++ b/templates/ironicinspector/config/inspector.conf
@@ -56,6 +56,9 @@ project_domain_name=Default
 project_name=services
 user_domain_name=Default
 
+[oslo_policy]
+enforce_scope=True
+enforce_new_defaults=True
 {{end}}
 
 [processing]


### PR DESCRIPTION
Upstream, Ironic has put forth a lot of work on improved policies, to improve security and overall capabilities. This change locks the default to use only the new policies which overall sets the most appropriate state for usage moving forward.