### PR TITLE
Switch to ubi for FIPS build

### DIFF
--- a/.prow_ci.env
+++ b/.prow_ci.env
@@ -1,1 +1,2 @@
 export USE_IMAGE_DIGESTS=true
+export FAIL_FIPS_CHECK=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG GOLANG_BUILDER=quay.io/projectquay/golang:1.20
-ARG OPERATOR_BASE_IMAGE=gcr.io/distroless/base
+ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.20
+ARG OPERATOR_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Build the manager binary
 FROM $GOLANG_BUILDER AS builder
@@ -12,7 +12,9 @@ ARG REMOTE_SOURCE_DIR=/remote-source
 ARG REMOTE_SOURCE_SUBDIR=
 ARG DEST_ROOT=/dest-root
 
-ARG GO_BUILD_EXTRA_ARGS=
+ARG GO_BUILD_EXTRA_ARGS="-tags strictfipsruntime"
+# note we set CGO_ENABLED=0 to force a static build so that we can use
+# distroless/static as our base image
 ARG GO_BUILD_EXTRA_ENV_ARGS="CGO_ENABLED=1 GO111MODULE=on"
 
 COPY $REMOTE_SOURCE $REMOTE_SOURCE_DIR

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,9 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+# Extra vars which will be passed to the Docker-build
+DOCKER_BUILD_ARGS ?=
+
 .PHONY: all
 all: build
 
@@ -143,7 +146,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	podman build -t ${IMG} .
+	podman build -t ${IMG} . ${DOCKER_BUILD_ARGS}
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
This enables FIPS support in a way which aligns with the current state of ovn-operator and neutron-operator, including using ubi as the base image, and setting the strictfipsruntime tag.

Issue: [OSPRH-3108](https://issues.redhat.com//browse/OSPRH-3108)