### PR TITLE
add DatabaseAccount and migrate to MariaDBAccount

### DIFF
--- a/api/bases/ironic.openstack.org_ironicapis.yaml
+++ b/api/bases/ironic.openstack.org_ironicapis.yaml
@@ -59,6 +59,11 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: ironic
+                description: DatabaseAccount - optional MariaDBAccount used for ironic
+                  DB, defaults to ironic.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Ironic Database Hostname
                 type: string
@@ -269,16 +274,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: IronicDatabasePassword
                   service: IronicPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:
-                  database:
-                    default: IronicDatabasePassword
-                    description: 'Database - Selector to get the ironic Database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
-                    type: string
                   service:
                     default: IronicPassword
                     description: Service - Selector to get the ironic service password
@@ -353,7 +352,7 @@ spec:
                 type: string
               secret:
                 description: Secret containing OpenStack password information for
-                  IronicDatabasePassword, AdminPassword
+                  AdminPassword
                 type: string
               serviceUser:
                 default: ironic

--- a/api/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/api/bases/ironic.openstack.org_ironicconductors.yaml
@@ -62,6 +62,11 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: ironic
+                description: DatabaseAccount - optional MariaDBAccount used for ironic
+                  DB, defaults to ironic.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Ironic Database Hostname
                 type: string
@@ -137,16 +142,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: IronicDatabasePassword
                   service: IronicPassword
-                description: PasswordSelectors - Selectors to identify the DB and
-                  ServiceUser password from the Secret
+                description: PasswordSelectors - Selectors to identify the ServiceUser
+                  password from the Secret
                 properties:
-                  database:
-                    default: IronicDatabasePassword
-                    description: 'Database - Selector to get the ironic Database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
-                    type: string
                   service:
                     default: IronicPassword
                     description: Service - Selector to get the ironic service password
@@ -228,7 +227,7 @@ spec:
                 type: string
               secret:
                 description: Secret containing OpenStack password information for
-                  IronicDatabasePassword, AdminPassword
+                  AdminPassword
                 type: string
               serviceUser:
                 default: ironic

--- a/api/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/api/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -59,6 +59,14 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: ironic-inspector
+                description: DatabaseAccount - optional MariaDBAccount used for ironic
+                  DB, defaults to ironic-inspector. this is separate from the account
+                  used for ironic, as a MariaDBAccount can only refer to a single
+                  MariaDBDatabase and it appears that ironic inspector uses its own
+                  MariaDBDatabase.
+                type: string
               databaseInstance:
                 description: MariaDB instance name. Right now required by the maridb-operator
                   to get the credentials from the instance to create the DB. Might
@@ -304,17 +312,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: IronicInspectorDatabasePassword
                   service: IronicInspectorPassword
-                description: PasswordSelectors - Selectors to identify the DB and
-                  ServiceUser password from the Secret
+                description: PasswordSelectors - Selectors to identify the ServiceUser
+                  password from the Secret
                 properties:
-                  database:
-                    default: IronicInspectorDatabasePassword
-                    description: 'Database - Selector to get the ironic-inspector
-                      Database user password from the Secret TODO: not used, need
-                      change in mariadb-operator'
-                    type: string
                   service:
                     default: IronicInspectorPassword
                     description: Service - Selector to get the ironic-inspector service
@@ -403,7 +404,7 @@ spec:
                 type: string
               secret:
                 description: Secret containing OpenStack password information for
-                  IronicInspectorDatabasePassword, AdminPassword
+                  AdminPassword
                 type: string
               serviceUser:
                 default: ironic-inspector

--- a/api/bases/ironic.openstack.org_ironicneutronagents.yaml
+++ b/api/bases/ironic.openstack.org_ironicneutronagents.yaml
@@ -83,11 +83,6 @@ spec:
                 description: PasswordSelectors - Selectors to identify the ServiceUser
                   password from the Secret
                 properties:
-                  database:
-                    default: IronicDatabasePassword
-                    description: 'Database - Selector to get the ironic Database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
-                    type: string
                   service:
                     default: IronicPassword
                     description: Service - Selector to get the ironic service password

--- a/api/bases/ironic.openstack.org_ironics.yaml
+++ b/api/bases/ironic.openstack.org_ironics.yaml
@@ -43,6 +43,11 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: ironic
+                description: DatabaseAccount - optional MariaDBAccount used for ironic
+                  DB, defaults to ironic.
+                type: string
               databaseInstance:
                 description: MariaDB instance name. Right now required by the maridb-operator
                   to get the credentials from the instance to create the DB. Might
@@ -546,6 +551,14 @@ spec:
                       content gets added to to /etc/<service>/<service>.conf.d directory
                       as custom.conf file.
                     type: string
+                  databaseAccount:
+                    default: ironic-inspector
+                    description: DatabaseAccount - optional MariaDBAccount used for
+                      ironic DB, defaults to ironic-inspector. this is separate from
+                      the account used for ironic, as a MariaDBAccount can only refer
+                      to a single MariaDBDatabase and it appears that ironic inspector
+                      uses its own MariaDBDatabase.
+                    type: string
                   defaultConfigOverwrite:
                     additionalProperties:
                       type: string
@@ -790,17 +803,10 @@ spec:
                     type: object
                   passwordSelectors:
                     default:
-                      database: IronicInspectorDatabasePassword
                       service: IronicInspectorPassword
-                    description: PasswordSelectors - Selectors to identify the DB
-                      and ServiceUser password from the Secret
+                    description: PasswordSelectors - Selectors to identify the ServiceUser
+                      password from the Secret
                     properties:
-                      database:
-                        default: IronicInspectorDatabasePassword
-                        description: 'Database - Selector to get the ironic-inspector
-                          Database user password from the Secret TODO: not used, need
-                          change in mariadb-operator'
-                        type: string
                       service:
                         default: IronicInspectorPassword
                         description: Service - Selector to get the ironic-inspector
@@ -1007,16 +1013,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: IronicDatabasePassword
                   service: IronicPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:
-                  database:
-                    default: IronicDatabasePassword
-                    description: 'Database - Selector to get the ironic Database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
-                    type: string
                   service:
                     default: IronicPassword
                     description: Service - Selector to get the ironic service password
@@ -1046,7 +1046,7 @@ spec:
                 type: string
               secret:
                 description: Secret containing OpenStack password information for
-                  ironic IronicDatabasePassword, IronicPassword
+                  ironic IronicPassword
                 type: string
               serviceUser:
                 default: ironic

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -53,13 +53,8 @@ type IronicServiceTemplate struct {
 	DefaultConfigOverwrite map[string]string `json:"defaultConfigOverwrite,omitempty"`
 }
 
-// PasswordSelector to identify the DB and AdminUser password from the Secret
+// PasswordSelector to identify the AdminUser password from the Secret
 type PasswordSelector struct {
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="IronicDatabasePassword"
-	// Database - Selector to get the ironic Database user password from the Secret
-	// TODO: not used, need change in mariadb-operator
-	Database string `json:"database"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="IronicPassword"
 	// Service - Selector to get the ironic service password from the Secret

--- a/api/v1beta1/ironic_types.go
+++ b/api/v1beta1/ironic_types.go
@@ -76,12 +76,17 @@ type IronicSpecCore struct {
 	// Might not be required in future.
 	DatabaseInstance string `json:"databaseInstance"`
 
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=ironic
+	// DatabaseAccount - optional MariaDBAccount used for ironic DB, defaults to ironic.
+	DatabaseAccount string `json:"databaseAccount"`
+
 	// +kubebuilder:validation:Required
-	// Secret containing OpenStack password information for ironic IronicDatabasePassword, IronicPassword
+	// Secret containing OpenStack password information for ironic IronicPassword
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: IronicDatabasePassword, service: IronicPassword}
+	// +kubebuilder:default={service: IronicPassword}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 

--- a/api/v1beta1/ironicapi_types.go
+++ b/api/v1beta1/ironicapi_types.go
@@ -72,17 +72,22 @@ type IronicAPISpec struct {
 	ServiceUser string `json:"serviceUser"`
 
 	// +kubebuilder:validation:Optional
-	// Secret containing OpenStack password information for IronicDatabasePassword, AdminPassword
+	// Secret containing OpenStack password information for AdminPassword
 	Secret string `json:"secret,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: IronicDatabasePassword, service: IronicPassword}
+	// +kubebuilder:default={service: IronicPassword}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Required
 	// DatabaseHostname - Ironic Database Hostname
 	DatabaseHostname string `json:"databaseHostname"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=ironic
+	// DatabaseAccount - optional MariaDBAccount used for ironic DB, defaults to ironic.
+	DatabaseAccount string `json:"databaseAccount"`
 
 	// +kubebuilder:validation:Optional
 	// Secret containing RabbitMq transport URL

--- a/api/v1beta1/ironicconductor_types.go
+++ b/api/v1beta1/ironicconductor_types.go
@@ -81,17 +81,22 @@ type IronicConductorSpec struct {
 	ServiceUser string `json:"serviceUser"`
 
 	// +kubebuilder:validation:Optional
-	// Secret containing OpenStack password information for IronicDatabasePassword, AdminPassword
+	// Secret containing OpenStack password information for AdminPassword
 	Secret string `json:"secret,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: IronicDatabasePassword, service: IronicPassword}
-	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
+	// +kubebuilder:default={service: IronicPassword}
+	// PasswordSelectors - Selectors to identify the ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Required
 	// DatabaseHostname - Ironic Database Hostname
 	DatabaseHostname string `json:"databaseHostname"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=ironic
+	// DatabaseAccount - optional MariaDBAccount used for ironic DB, defaults to ironic.
+	DatabaseAccount string `json:"databaseAccount"`
 
 	// +kubebuilder:validation:Optional
 	// TransportURLSecret - Secret containing RabbitMQ transportURL

--- a/api/v1beta1/ironicinspector_types.go
+++ b/api/v1beta1/ironicinspector_types.go
@@ -24,13 +24,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// IronicInspectorPasswordSelector to identify the DB and AdminUser password from the Secret
+// IronicInspectorPasswordSelector to identify the AdminUser password from the Secret
 type IronicInspectorPasswordSelector struct {
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="IronicInspectorDatabasePassword"
-	// Database - Selector to get the ironic-inspector Database user password from the Secret
-	// TODO: not used, need change in mariadb-operator
-	Database string `json:"database"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="IronicInspectorPassword"
 	// Service - Selector to get the ironic-inspector service password from the Secret
@@ -52,8 +47,16 @@ type IronicInspectorTemplate struct {
 	Replicas *int32 `json:"replicas"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: IronicInspectorDatabasePassword, service: IronicInspectorPassword}
-	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
+	// +kubebuilder:default=ironic-inspector
+	// DatabaseAccount - optional MariaDBAccount used for ironic DB, defaults to ironic-inspector.
+	// this is separate from the account used for ironic, as a MariaDBAccount can only
+	// refer to a single MariaDBDatabase and it appears that ironic inspector uses its
+	// own MariaDBDatabase.
+	DatabaseAccount string `json:"databaseAccount"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={service: IronicInspectorPassword}
+	// PasswordSelectors - Selectors to identify the ServiceUser password from the Secret
 	PasswordSelectors IronicInspectorPasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Optional
@@ -146,7 +149,7 @@ type IronicInspectorSpec struct {
 	DatabaseInstance string `json:"databaseInstance"`
 
 	// +kubebuilder:validation:Optional
-	// Secret containing OpenStack password information for IronicInspectorDatabasePassword, AdminPassword
+	// Secret containing OpenStack password information for AdminPassword
 	Secret string `json:"secret,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/ironic.openstack.org_ironicapis.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicapis.yaml
@@ -59,6 +59,11 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: ironic
+                description: DatabaseAccount - optional MariaDBAccount used for ironic
+                  DB, defaults to ironic.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Ironic Database Hostname
                 type: string
@@ -269,16 +274,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: IronicDatabasePassword
                   service: IronicPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:
-                  database:
-                    default: IronicDatabasePassword
-                    description: 'Database - Selector to get the ironic Database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
-                    type: string
                   service:
                     default: IronicPassword
                     description: Service - Selector to get the ironic service password
@@ -353,7 +352,7 @@ spec:
                 type: string
               secret:
                 description: Secret containing OpenStack password information for
-                  IronicDatabasePassword, AdminPassword
+                  AdminPassword
                 type: string
               serviceUser:
                 default: ironic

--- a/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
@@ -62,6 +62,11 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: ironic
+                description: DatabaseAccount - optional MariaDBAccount used for ironic
+                  DB, defaults to ironic.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Ironic Database Hostname
                 type: string
@@ -137,16 +142,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: IronicDatabasePassword
                   service: IronicPassword
-                description: PasswordSelectors - Selectors to identify the DB and
-                  ServiceUser password from the Secret
+                description: PasswordSelectors - Selectors to identify the ServiceUser
+                  password from the Secret
                 properties:
-                  database:
-                    default: IronicDatabasePassword
-                    description: 'Database - Selector to get the ironic Database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
-                    type: string
                   service:
                     default: IronicPassword
                     description: Service - Selector to get the ironic service password
@@ -228,7 +227,7 @@ spec:
                 type: string
               secret:
                 description: Secret containing OpenStack password information for
-                  IronicDatabasePassword, AdminPassword
+                  AdminPassword
                 type: string
               serviceUser:
                 default: ironic

--- a/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -59,6 +59,14 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: ironic-inspector
+                description: DatabaseAccount - optional MariaDBAccount used for ironic
+                  DB, defaults to ironic-inspector. this is separate from the account
+                  used for ironic, as a MariaDBAccount can only refer to a single
+                  MariaDBDatabase and it appears that ironic inspector uses its own
+                  MariaDBDatabase.
+                type: string
               databaseInstance:
                 description: MariaDB instance name. Right now required by the maridb-operator
                   to get the credentials from the instance to create the DB. Might
@@ -304,17 +312,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: IronicInspectorDatabasePassword
                   service: IronicInspectorPassword
-                description: PasswordSelectors - Selectors to identify the DB and
-                  ServiceUser password from the Secret
+                description: PasswordSelectors - Selectors to identify the ServiceUser
+                  password from the Secret
                 properties:
-                  database:
-                    default: IronicInspectorDatabasePassword
-                    description: 'Database - Selector to get the ironic-inspector
-                      Database user password from the Secret TODO: not used, need
-                      change in mariadb-operator'
-                    type: string
                   service:
                     default: IronicInspectorPassword
                     description: Service - Selector to get the ironic-inspector service
@@ -403,7 +404,7 @@ spec:
                 type: string
               secret:
                 description: Secret containing OpenStack password information for
-                  IronicInspectorDatabasePassword, AdminPassword
+                  AdminPassword
                 type: string
               serviceUser:
                 default: ironic-inspector

--- a/config/crd/bases/ironic.openstack.org_ironicneutronagents.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicneutronagents.yaml
@@ -83,11 +83,6 @@ spec:
                 description: PasswordSelectors - Selectors to identify the ServiceUser
                   password from the Secret
                 properties:
-                  database:
-                    default: IronicDatabasePassword
-                    description: 'Database - Selector to get the ironic Database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
-                    type: string
                   service:
                     default: IronicPassword
                     description: Service - Selector to get the ironic service password

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -43,6 +43,11 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: ironic
+                description: DatabaseAccount - optional MariaDBAccount used for ironic
+                  DB, defaults to ironic.
+                type: string
               databaseInstance:
                 description: MariaDB instance name. Right now required by the maridb-operator
                   to get the credentials from the instance to create the DB. Might
@@ -546,6 +551,14 @@ spec:
                       content gets added to to /etc/<service>/<service>.conf.d directory
                       as custom.conf file.
                     type: string
+                  databaseAccount:
+                    default: ironic-inspector
+                    description: DatabaseAccount - optional MariaDBAccount used for
+                      ironic DB, defaults to ironic-inspector. this is separate from
+                      the account used for ironic, as a MariaDBAccount can only refer
+                      to a single MariaDBDatabase and it appears that ironic inspector
+                      uses its own MariaDBDatabase.
+                    type: string
                   defaultConfigOverwrite:
                     additionalProperties:
                       type: string
@@ -790,17 +803,10 @@ spec:
                     type: object
                   passwordSelectors:
                     default:
-                      database: IronicInspectorDatabasePassword
                       service: IronicInspectorPassword
-                    description: PasswordSelectors - Selectors to identify the DB
-                      and ServiceUser password from the Secret
+                    description: PasswordSelectors - Selectors to identify the ServiceUser
+                      password from the Secret
                     properties:
-                      database:
-                        default: IronicInspectorDatabasePassword
-                        description: 'Database - Selector to get the ironic-inspector
-                          Database user password from the Secret TODO: not used, need
-                          change in mariadb-operator'
-                        type: string
                       service:
                         default: IronicInspectorPassword
                         description: Service - Selector to get the ironic-inspector
@@ -1007,16 +1013,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: IronicDatabasePassword
                   service: IronicPassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:
-                  database:
-                    default: IronicDatabasePassword
-                    description: 'Database - Selector to get the ironic Database user
-                      password from the Secret TODO: not used, need change in mariadb-operator'
-                    type: string
                   service:
                     default: IronicPassword
                     description: Service - Selector to get the ironic service password
@@ -1046,7 +1046,7 @@ spec:
                 type: string
               secret:
                 description: Secret containing OpenStack password information for
-                  ironic IronicDatabasePassword, IronicPassword
+                  ironic IronicPassword
                 type: string
               serviceUser:
                 default: ironic

--- a/controllers/ironicneutronagent_controller.go
+++ b/controllers/ironicneutronagent_controller.go
@@ -50,7 +50,6 @@ import (
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/deployment"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
@@ -694,7 +693,7 @@ func (r *IronicNeutronAgentReconciler) generateServiceConfigMaps(
 		},
 	}
 
-	return configmap.EnsureConfigMaps(ctx, h, instance, cms, envVars)
+	return secret.EnsureSecrets(ctx, h, instance, cms, envVars)
 }
 
 // createHashOfInputHashes - creates a hash of hashes which gets added to the resources which requires a restart

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240219094943-9bbb46c9afba
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240216173409-86913e6d5885
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240216173409-86913e6d5885
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240220132409-f96d4d040f4e
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240308170012-6b04e3e9b9ee
 	k8s.io/api v0.28.3
 	k8s.io/apimachinery v0.28.3
 	k8s.io/client-go v0.28.3

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.2024021
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240216173409-86913e6d5885/go.mod h1:8QsCFttAm+X6A8I8EQThGjNjeMAYt2hK7ivbvnR3434=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240216173409-86913e6d5885 h1:ioJ2MO3vAcBkLM+0UBu5IuKW/DPXcyiNSOLq0Xvn+Nw=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240216173409-86913e6d5885/go.mod h1:82nzS+DbBe1tzaMvNHH8FctmZzQ14ZAJysFGsMJiivo=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240220132409-f96d4d040f4e h1:6vqp5HZwcGvPH0MII/23iCd97T3/1HJZlONKW6LyNio=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240220132409-f96d4d040f4e/go.mod h1:PDqfLbP4ZWqQHAu1OtbjfpOGQUKSzLqRJChvE/9pcyQ=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240308170012-6b04e3e9b9ee h1:UYxzWJ1HixHQ+jPoZ/PeTqCUxVr1+kha4YJpV/UwL64=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240308170012-6b04e3e9b9ee/go.mod h1:f9IIyWeoskWoeWaDFF3qmAJ2Kqyovfi0Ar/QUfk3qag=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/ironic/const.go
+++ b/pkg/ironic/const.go
@@ -22,6 +22,8 @@ const (
 	ServiceType = "baremetal"
 	// DatabaseName -
 	DatabaseName = "ironic"
+	// DatabaseCRName -
+	DatabaseCRName = "ironic"
 	// IronicPublicPort -
 	IronicPublicPort int32 = 6385
 	// IronicInternalPort -

--- a/pkg/ironic/dbsync.go
+++ b/pkg/ironic/dbsync.go
@@ -90,7 +90,6 @@ func DbSyncJob(
 		DatabaseHost:         instance.Status.DatabaseHostname,
 		DatabaseName:         DatabaseName,
 		OSPSecret:            instance.Spec.Secret,
-		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
 		VolumeMounts:         initVolumeMounts,
 	}

--- a/pkg/ironic/initcontainer.go
+++ b/pkg/ironic/initcontainer.go
@@ -30,7 +30,6 @@ type APIDetails struct {
 	DatabaseName           string
 	TransportURLSecret     string
 	OSPSecret              string
-	DBPasswordSelector     string
 	UserPasswordSelector   string
 	VolumeMounts           []corev1.VolumeMount
 	Privileged             bool
@@ -61,17 +60,6 @@ func InitContainer(init APIDetails) []corev1.Container {
 	envVars["IngressDomain"] = env.SetValue(init.IngressDomain)
 
 	envs := []corev1.EnvVar{
-		{
-			Name: "DatabasePassword",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: init.OSPSecret,
-					},
-					Key: init.DBPasswordSelector,
-				},
-			},
-		},
 		{
 			Name: "IronicPassword",
 			ValueFrom: &corev1.EnvVarSource{

--- a/pkg/ironic/volumes.go
+++ b/pkg/ironic/volumes.go
@@ -13,22 +13,18 @@ func GetVolumes(name string) []corev1.Volume {
 		{
 			Name: "scripts",
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &scriptsVolumeDefaultMode,
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: name + "-scripts",
-					},
+					SecretName:  name + "-scripts",
 				},
 			},
 		},
 		{
 			Name: "config-data",
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &config0640AccessMode,
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: name + "-config-data",
-					},
+					SecretName:  name + "-config-data",
 				},
 			},
 		},

--- a/pkg/ironicapi/deployment.go
+++ b/pkg/ironicapi/deployment.go
@@ -190,7 +190,6 @@ func Deployment(
 		DatabaseName:         ironic.DatabaseName,
 		OSPSecret:            instance.Spec.Secret,
 		TransportURLSecret:   instance.Spec.TransportURLSecret,
-		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
 		VolumeMounts:         initVolumeMounts,
 		PxeInit:              false,

--- a/pkg/ironicapi/volumes.go
+++ b/pkg/ironicapi/volumes.go
@@ -13,11 +13,9 @@ func GetVolumes(name string) []corev1.Volume {
 		{
 			Name: "config-data-custom",
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &config0640AccessMode,
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: name + "-config-data",
-					},
+					SecretName:  name + "-config-data",
 				},
 			},
 		},

--- a/pkg/ironicconductor/statefulset.go
+++ b/pkg/ironicconductor/statefulset.go
@@ -276,7 +276,6 @@ func StatefulSet(
 		DatabaseName:           ironic.DatabaseName,
 		OSPSecret:              instance.Spec.Secret,
 		TransportURLSecret:     instance.Spec.TransportURLSecret,
-		DBPasswordSelector:     instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector:   instance.Spec.PasswordSelectors.Service,
 		VolumeMounts:           initVolumeMounts,
 		PxeInit:                true,

--- a/pkg/ironicconductor/volumes.go
+++ b/pkg/ironicconductor/volumes.go
@@ -20,11 +20,9 @@ func GetVolumes(instance *ironicv1.IronicConductor) []corev1.Volume {
 		{
 			Name: "config-data-custom",
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &config0640AccessMode,
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: fmt.Sprintf("%s-config-data", instance.Name),
-					},
+					SecretName:  fmt.Sprintf("%s-config-data", instance.Name),
 				},
 			},
 		},

--- a/pkg/ironicinspector/const.go
+++ b/pkg/ironicinspector/const.go
@@ -3,6 +3,8 @@ package ironicinspector
 const (
 	// DatabaseName -
 	DatabaseName = "ironic_inspector"
+	// DatabaseCRName -
+	DatabaseCRName = "ironic-inspector"
 	// IronicInspectorPublicPort -
 	IronicInspectorPublicPort int32 = 5050
 	// IronicInspectorInternalPort -

--- a/pkg/ironicinspector/initcontainer.go
+++ b/pkg/ironicinspector/initcontainer.go
@@ -32,7 +32,6 @@ type APIDetails struct {
 	DatabaseName           string
 	TransportURLSecret     string
 	OSPSecret              string
-	DBPasswordSelector     string
 	UserPasswordSelector   string
 	VolumeMounts           []corev1.VolumeMount
 	Privileged             bool
@@ -62,17 +61,6 @@ func InitContainer(init APIDetails) []corev1.Container {
 	envVars["InspectionNetwork"] = env.SetValue(init.InspectionNetwork)
 
 	envs := []corev1.EnvVar{
-		{
-			Name: "DatabasePassword",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: init.OSPSecret,
-					},
-					Key: init.DBPasswordSelector,
-				},
-			},
-		},
 		{
 			Name: "IronicInspectorPassword",
 			ValueFrom: &corev1.EnvVarSource{

--- a/pkg/ironicinspector/statefulset.go
+++ b/pkg/ironicinspector/statefulset.go
@@ -308,7 +308,6 @@ func StatefulSet(
 		DatabaseName:           DatabaseName,
 		OSPSecret:              instance.Spec.Secret,
 		TransportURLSecret:     instance.Status.TransportURLSecret,
-		DBPasswordSelector:     instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector:   instance.Spec.PasswordSelectors.Service,
 		VolumeMounts:           initVolumeMounts,
 		PxeInit:                true,

--- a/pkg/ironicinspector/volumes.go
+++ b/pkg/ironicinspector/volumes.go
@@ -13,22 +13,18 @@ func GetVolumes(name string) []corev1.Volume {
 		{
 			Name: "scripts",
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &scriptsVolumeDefaultMode,
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: name + "-scripts",
-					},
+					SecretName:  name + "-scripts",
 				},
 			},
 		},
 		{
 			Name: "config-data",
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &config0640AccessMode,
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: name + "-config-data",
-					},
+					SecretName:  name + "-config-data",
 				},
 			},
 		},

--- a/pkg/ironicneutronagent/volumes.go
+++ b/pkg/ironicneutronagent/volumes.go
@@ -29,22 +29,18 @@ func GetVolumes(name string) []corev1.Volume {
 		{
 			Name: "scripts",
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &scriptsVolumeDefaultMode,
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: name + "-scripts",
-					},
+					SecretName:  name + "-scripts",
 				},
 			},
 		},
 		{
 			Name: "config-data",
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &config0640AccessMode,
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: name + "-config-data",
-					},
+					SecretName:  name + "-config-data",
 				},
 			},
 		},

--- a/templates/common/bin/common.sh
+++ b/templates/common/bin/common.sh
@@ -36,10 +36,6 @@ function merge_config_dir {
 
 function common_ironic_config {
     # Secrets are obtained from ENV variables.
-    export DB=${DatabaseName:-"ironic"}
-    export DBHOST=${DatabaseHost:?"Please specify a DatabaseHost variable."}
-    export DBUSER=${DatabaseName:-"ironic"}
-    export DBPASSWORD=${DatabasePassword:?"Please specify a DatabasePassword variable."}
     export IRONICPASSWORD=${IronicPassword:?"Please specify a IronicPassword variable."}
     export TRANSPORTURL=${TransportURL:-""}
     # TODO: nova password
@@ -86,7 +82,6 @@ function common_ironic_config {
         crudini --set ${SVC_CFG_MERGED} DEFAULT transport_url $TRANSPORTURL
         crudini --set ${SVC_CFG_MERGED} DEFAULT rpc_transport oslo
     fi
-    crudini --set ${SVC_CFG_MERGED} database connection mysql+pymysql://${DBUSER}:${DBPASSWORD}@${DBHOST}/${DB}?read_default_file=/etc/my.cnf
     crudini --set ${SVC_CFG_MERGED} keystone_authtoken password $IRONICPASSWORD
     crudini --set ${SVC_CFG_MERGED} service_catalog password $IRONICPASSWORD
     crudini --set ${SVC_CFG_MERGED} cinder password $IRONICPASSWORD

--- a/templates/common/config/ironic.conf
+++ b/templates/common/config/ironic.conf
@@ -129,6 +129,7 @@ allow_methods=GET,POST,PUT,DELETE,OPTIONS,PATCH
 allow_headers=Content-Type,Cache-Control,Content-Language,Expires,Last-Modified,Pragma,X-Auth-Token
 
 [database]
+connection={{ .DatabaseConnection }}
 max_retries=-1
 db_max_retries=-1
 

--- a/templates/ironicinspector/bin/init.sh
+++ b/templates/ironicinspector/bin/init.sh
@@ -15,10 +15,6 @@
 # under the License.
 
 # Secrets are obtained from ENV variables.
-export DB=${DatabaseName:-"ironic_inspector"}
-export DBHOST=${DatabaseHost:?"Please specify a DatabaseHost variable."}
-export DBUSER=${DatabaseName:-"ironic_inspector"}
-export DBPASSWORD=${DatabasePassword:?"Please specify a DatabasePassword variable."}
 export INSPECTORPASSWORD=${IronicInspectorPassword:?"Please specify a IronicInspectorPassword variable."}
 export TRANSPORTURL=${TransportURL:-""}
 
@@ -66,7 +62,6 @@ fi
 if [ -n "$TRANSPORTURL" ]; then
     crudini --set ${SVC_CFG_MERGED} DEFAULT transport_url $TRANSPORTURL
 fi
-crudini --set ${SVC_CFG_MERGED} database connection mysql+pymysql://${DBUSER}:${DBPASSWORD}@${DBHOST}/${DB}
 crudini --set ${SVC_CFG_MERGED} keystone_authtoken password $INSPECTORPASSWORD
 crudini --set ${SVC_CFG_MERGED} service_catalog password $INSPECTORPASSWORD
 crudini --set ${SVC_CFG_MERGED} ironic password $INSPECTORPASSWORD

--- a/templates/ironicinspector/config/inspector.conf
+++ b/templates/ironicinspector/config/inspector.conf
@@ -16,6 +16,9 @@ allow_headers=Content-Type,Cache-Control,Content-Language,Expires,Last-Modified,
 dhcp_hostsdir=/var/lib/ironic-inspector/dhcp-hostsdir
 purge_dhcp_hostsdir=False
 
+[database]
+connection={{ .DatabaseConnection }}
+
 {{if .Standalone}}
 [ironic]
 auth_type=none

--- a/tests/functional/ironicinspector_controller_test.go
+++ b/tests/functional/ironicinspector_controller_test.go
@@ -23,7 +23,9 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
+	mariadb_test "github.com/openstack-k8s-operators/mariadb-operator/api/test/helpers"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var _ = Describe("IronicInspector controller", func() {
@@ -114,13 +116,13 @@ var _ = Describe("IronicInspector controller", func() {
 			instance := GetIronicInspector(ironicNames.InspectorName)
 			Expect(instance.Status.TransportURLSecret).To(Equal("rabbitmq-secret"))
 		})
-		It("Creates ConfigMaps and gets Secrets (input)", func() {
+		It("Creates Config Secrets and gets Secrets (input)", func() {
 			infra.GetTransportURL(ironicNames.InspectorTransportURLName)
 			infra.SimulateTransportURLReady(ironicNames.InspectorTransportURLName)
 			mariadb.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
-			mariadb.SimulateMariaDBAccountCompleted(ironicNames.InspectorDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(ironicNames.InspectorDatabaseAccount)
 			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
-			cm := th.GetConfigMap(ironicNames.InspectorConfigDataName)
+			cm := th.GetSecret(ironicNames.InspectorConfigSecretName)
 			myCnf := cm.Data["my.cnf"]
 			Expect(myCnf).To(
 				ContainSubstring("[client]\nssl=0"))
@@ -142,7 +144,7 @@ var _ = Describe("IronicInspector controller", func() {
 			infra.GetTransportURL(ironicNames.InspectorTransportURLName)
 			infra.SimulateTransportURLReady(ironicNames.InspectorTransportURLName)
 			mariadb.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
-			mariadb.SimulateMariaDBAccountCompleted(ironicNames.InspectorDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(ironicNames.InspectorDatabaseAccount)
 			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
 			th.ExpectCondition(
 				ironicNames.InspectorName,
@@ -155,7 +157,7 @@ var _ = Describe("IronicInspector controller", func() {
 			infra.GetTransportURL(ironicNames.InspectorTransportURLName)
 			infra.SimulateTransportURLReady(ironicNames.InspectorTransportURLName)
 			mariadb.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
-			mariadb.SimulateMariaDBAccountCompleted(ironicNames.InspectorDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(ironicNames.InspectorDatabaseAccount)
 			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
 			th.SimulateJobSuccess(ironicNames.InspectorDBSyncJobName)
 			th.ExpectCondition(
@@ -169,7 +171,7 @@ var _ = Describe("IronicInspector controller", func() {
 			infra.GetTransportURL(ironicNames.InspectorTransportURLName)
 			infra.SimulateTransportURLReady(ironicNames.InspectorTransportURLName)
 			mariadb.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
-			mariadb.SimulateMariaDBAccountCompleted(ironicNames.InspectorDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(ironicNames.InspectorDatabaseAccount)
 			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
 			th.SimulateJobSuccess(ironicNames.InspectorDBSyncJobName)
 			th.ExpectCondition(
@@ -183,7 +185,7 @@ var _ = Describe("IronicInspector controller", func() {
 			infra.GetTransportURL(ironicNames.InspectorTransportURLName)
 			infra.SimulateTransportURLReady(ironicNames.InspectorTransportURLName)
 			mariadb.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
-			mariadb.SimulateMariaDBAccountCompleted(ironicNames.InspectorDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(ironicNames.InspectorDatabaseAccount)
 			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
 			th.SimulateJobSuccess(ironicNames.InspectorDBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(ironicNames.InspectorName)
@@ -224,7 +226,7 @@ var _ = Describe("IronicInspector controller", func() {
 			infra.GetTransportURL(ironicNames.InspectorTransportURLName)
 			infra.SimulateTransportURLReady(ironicNames.InspectorTransportURLName)
 			mariadb.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
-			mariadb.SimulateMariaDBAccountCompleted(ironicNames.InspectorDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(ironicNames.InspectorDatabaseAccount)
 			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
 			th.SimulateJobSuccess(ironicNames.InspectorDBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(ironicNames.InspectorName)
@@ -247,7 +249,7 @@ var _ = Describe("IronicInspector controller", func() {
 			infra.GetTransportURL(ironicNames.InspectorTransportURLName)
 			infra.SimulateTransportURLReady(ironicNames.InspectorTransportURLName)
 			mariadb.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
-			mariadb.SimulateMariaDBAccountCompleted(ironicNames.InspectorDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(ironicNames.InspectorDatabaseAccount)
 			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
 			th.SimulateJobSuccess(ironicNames.InspectorDBSyncJobName)
 			th.SimulateStatefulSetReplicaReady(ironicNames.InspectorName)
@@ -303,7 +305,7 @@ var _ = Describe("IronicInspector controller", func() {
 
 			infra.GetTransportURL(ironicNames.InspectorTransportURLName)
 			infra.SimulateTransportURLReady(ironicNames.InspectorTransportURLName)
-			mariadb.SimulateMariaDBAccountCompleted(ironicNames.InspectorDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(ironicNames.InspectorDatabaseAccount)
 			mariadb.SimulateMariaDBTLSDatabaseCompleted(ironicNames.InspectorDatabaseName)
 		})
 
@@ -397,7 +399,7 @@ var _ = Describe("IronicInspector controller", func() {
 			Expect(container.ReadinessProbe.HTTPGet.Scheme).To(Equal(corev1.URISchemeHTTPS))
 			Expect(container.LivenessProbe.HTTPGet.Scheme).To(Equal(corev1.URISchemeHTTPS))
 
-			configDataMap := th.GetConfigMap(ironicNames.InspectorConfigDataName)
+			configDataMap := th.GetSecret(ironicNames.InspectorConfigSecretName)
 			Expect(configDataMap).ShouldNot(BeNil())
 			Expect(configDataMap.Data).Should(HaveKey("httpd.conf"))
 			Expect(configDataMap.Data).Should(HaveKey("ssl.conf"))
@@ -472,4 +474,93 @@ var _ = Describe("IronicInspector controller", func() {
 			}, timeout, interval).Should(Succeed())
 		})
 	})
+
+	// Run MariaDBAccount suite tests.  these are pre-packaged ginkgo tests
+	// that exercise standard account create / update patterns that should be
+	// common to all controllers that ensure MariaDBAccount CRs.
+	mariadbSuite := &mariadb_test.MariaDBTestHarness{
+		PopulateHarness: func(harness *mariadb_test.MariaDBTestHarness) {
+			harness.Setup(
+				"IronicInspector",
+				ironicNames.Namespace,
+				ironicNames.InspectorDatabaseName.Name,
+				"IronicInspector",
+				mariadb,
+				timeout,
+				interval,
+			)
+		},
+		// Generate a fully running Ironic Inspector service given an accountName
+		// needs to make it all the way to the end where the mariadb finalizers
+		// are removed from unused accounts since that's part of what we are testing
+		SetupCR: func(accountName types.NamespacedName) {
+			spec := GetDefaultIronicInspectorSpec()
+
+			spec["databaseAccount"] = accountName.Name
+
+			DeferCleanup(
+				k8sClient.Delete,
+				ctx,
+				CreateIronicSecret(ironicNames.Namespace, SecretName),
+			)
+			DeferCleanup(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
+					ironicNames.Namespace,
+					"openstack",
+					corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{{Port: 3306}},
+					},
+				),
+			)
+			DeferCleanup(
+				keystone.DeleteKeystoneAPI,
+				keystone.CreateKeystoneAPI(ironicNames.Namespace))
+
+			spec["rpcTransport"] = "oslo"
+			DeferCleanup(
+				th.DeleteInstance,
+				CreateIronicInspector(ironicNames.InspectorName, spec))
+
+			infra.GetTransportURL(ironicNames.InspectorTransportURLName)
+			infra.SimulateTransportURLReady(ironicNames.InspectorTransportURLName)
+			mariadb.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(accountName)
+			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
+			th.SimulateJobSuccess(ironicNames.InspectorDBSyncJobName)
+			th.SimulateStatefulSetReplicaReady(ironicNames.InspectorName)
+			keystone.SimulateKeystoneServiceReady(ironicNames.InspectorName)
+			keystone.SimulateKeystoneEndpointReady(ironicNames.InspectorName)
+
+		},
+		// Change the account name in the service to a new name
+		UpdateAccount: func(newAccountName types.NamespacedName) {
+
+			Eventually(func(g Gomega) {
+				inspector := GetIronicInspector(ironicNames.InspectorName)
+				inspector.Spec.DatabaseAccount = newAccountName.Name
+				g.Expect(th.K8sClient.Update(ctx, inspector)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+		},
+		// delete the keystone instance to exercise finalizer removal
+		DeleteCR: func() {
+			th.DeleteInstance(GetIronicInspector(ironicNames.InspectorName))
+		},
+	}
+
+	mariadbSuite.RunBasicSuite()
+
+	mariadbSuite.RunURLAssertSuite(func(accountName types.NamespacedName, username string, password string) {
+		Eventually(func(g Gomega) {
+			configDataMap := th.GetSecret(ironicNames.InspectorConfigSecretName)
+
+			conf := configDataMap.Data["inspector.conf"]
+
+			g.Expect(string(conf)).Should(
+				ContainSubstring(fmt.Sprintf("connection=mysql+pymysql://%s:%s@hostname-for-openstack.%s.svc/ironic_inspector?read_default_file=/etc/my.cnf",
+					username, password, ironicNames.Namespace)))
+		}).Should(Succeed())
+	})
+
 })

--- a/tests/kuttl/tests/deploy/10-assert-deploy-ironic.yaml
+++ b/tests/kuttl/tests/deploy/10-assert-deploy-ironic.yaml
@@ -26,8 +26,8 @@ spec:
     storageRequest: 10G
   ironicInspector:
     customServiceConfig: '# add your customization here'
+    databaseAccount: ironic-inspector
     passwordSelectors:
-      database: IronicInspectorDatabasePassword
       service: IronicInspectorPassword
     preserveJobs: true
     replicas: 1
@@ -35,8 +35,8 @@ spec:
   ironicNeutronAgent:
     customServiceConfig: "# add your customization here"
     replicas: 1
+  databaseAccount: ironic
   passwordSelectors:
-    database: IronicDatabasePassword
     service: IronicPassword
   preserveJobs: true
   rabbitMqClusterName: rabbitmq
@@ -66,8 +66,8 @@ metadata:
 spec:
   customServiceConfig: '# add your customization here'
   databaseHostname: openstack.ironic-kuttl-tests.svc
+  databaseAccount: ironic
   passwordSelectors:
-    database: IronicDatabasePassword
     service: IronicPassword
   replicas: 1
   resources: {}
@@ -94,8 +94,8 @@ spec:
   conductorGroup: ""
   customServiceConfig: '# add your customization here'
   databaseHostname: openstack.ironic-kuttl-tests.svc
+  databaseAccount: ironic
   passwordSelectors:
-    database: IronicDatabasePassword
     service: IronicPassword
   replicas: 1
   resources: {}
@@ -122,8 +122,8 @@ metadata:
 spec:
   customServiceConfig: '# add your customization here'
   databaseInstance: openstack
+  databaseAccount: ironic-inspector
   passwordSelectors:
-    database: IronicInspectorDatabasePassword
     service: IronicInspectorPassword
   preserveJobs: true
   rabbitMqClusterName: rabbitmq
@@ -152,7 +152,6 @@ metadata:
 spec:
   customServiceConfig: "# add your customization here"
   passwordSelectors:
-    database: IronicDatabasePassword
     service: IronicPassword
   rabbitMqClusterName: rabbitmq
   replicas: 1

--- a/tests/kuttl/tests/standalone/10-assert-deploy-ironic-standalone.yaml
+++ b/tests/kuttl/tests/standalone/10-assert-deploy-ironic-standalone.yaml
@@ -18,6 +18,7 @@ spec:
     [DEFAULT]
     debug = true
   databaseInstance: openstack
+  databaseAccount: ironic
   ironicAPI:
     replicas: 1
   ironicConductors:
@@ -25,14 +26,13 @@ spec:
     storageRequest: 10G
   ironicInspector:
     customServiceConfig: '# add your customization here'
+    databaseAccount: ironic-inspector
     passwordSelectors:
-      database: IronicInspectorDatabasePassword
       service: IronicInspectorPassword
     preserveJobs: true
     replicas: 1
     serviceUser: ironic-inspector
   passwordSelectors:
-    database: IronicDatabasePassword
     service: IronicPassword
   preserveJobs: true
   rabbitMqClusterName: rabbitmq
@@ -61,8 +61,8 @@ metadata:
 spec:
   customServiceConfig: '# add your customization here'
   databaseHostname: openstack.ironic-kuttl-tests.svc
+  databaseAccount: ironic
   passwordSelectors:
-    database: IronicDatabasePassword
     service: IronicPassword
   replicas: 1
   resources: {}
@@ -89,8 +89,8 @@ spec:
   conductorGroup: ""
   customServiceConfig: '# add your customization here'
   databaseHostname: openstack.ironic-kuttl-tests.svc
+  databaseAccount: ironic
   passwordSelectors:
-    database: IronicDatabasePassword
     service: IronicPassword
   replicas: 1
   resources: {}
@@ -117,8 +117,8 @@ metadata:
 spec:
   customServiceConfig: '# add your customization here'
   databaseInstance: openstack
+  databaseAccount: ironic-inspector
   passwordSelectors:
-    database: IronicInspectorDatabasePassword
     service: IronicInspectorPassword
   preserveJobs: true
   rabbitMqClusterName: rabbitmq


### PR DESCRIPTION
This moves ironic to fully use MariaDBAccount based on the dev work being done for mariadb-operator:

https://github.com/openstack-k8s-operators/mariadb-operator/pull/184/files

Lead Jira: [OSPRH-4095](https://issues.redhat.com/browse/OSPRH-4095)

1. [x] controller calls EnsureMariaDBAccount up front to make sure MariaDBAccount is present
2. [x] error code from EnsureMariaDBAccount is handled, Conditions are amended when error is returned
3. [x] controller calls NewDatabaseForAccount instead of NewDatabase
4. [x]  GetAccountAndSecret is used to retrieve account /secret to populate template
5. [x]  GetDatabaseByName() , normally used for delete finalizers, replaced with GetDatabaseByNameAndAccount
6. [x]  CreateOrPatchAll() used to patch the Database, replacing CreateOrPatchDB / CreateOrPatchDBByName
7. [x]  controller calls DeleteUnusedMariaDBAccountFinalizers when launched pods are definitely running on a new MariaDBAccount, returns error code if present
8. [x]  PasswordSelectors that refer to database are removed
9. [x] ~~all databaseUser replaced with databaseAccount inside of all XYZ_types.go~~ added brand new databaseAccount fields
10. [x] all databaseUser replaced with databaseAccount inside of all `kuttl/*.yaml`
11. [x] all default databaseUser names become databaseAccount, replacing underscores with dashes inside of all XYZ_types.go
12. [x] all default databaseUser names become databaseAccount, replacing underscores with dashes inside of all `kuttl/*.yaml`
13. [x] MariaDBAccountSuiteTests are used in controller ginkgo tests if it has them
14. [x] Use configsecrets for database URLs; remove from job hash
15. [x] [184](https://github.com/openstack-k8s-operators/mariadb-operator/pull/184) is merged and replaces from go.mod are removed
