### PR TITLE
fix: set rbac service role for services to operate properly

### DIFF
--- a/templates/common/config/ironic.conf
+++ b/templates/common/config/ironic.conf
@@ -15,6 +15,10 @@ enabled_rescue_interfaces=no-rescue,agent
 default_rescue_interface=agent
 enabled_storage_interfaces=noop,fake
 enabled_vendor_interfaces = no-vendor,ipmitool,idrac,idrac-redfish,redfish,ilo,fake
+# This is a knob to allow service role users from the service project
+# to have "elevated" API access to see the whole of the API surface.
+# https://review.opendev.org/c/openstack/ironic/+/907269
+rbac_service_role_elevated_access=true
 
 {{/* TODO switch to neutron provider for the non-standalone when neutron-operator is available */}}
 default_network_interface={{if .Standalone}}noop{{else}}noop{{end}}


### PR DESCRIPTION
The ironic project shot down fixing "serivce" role support in older branches, so the only path forward is to explicitly set the option to be enabled by our operator.