### PR TITLE
Use defaults for force_power_state_during_sync, automated_clean

### DIFF
--- a/templates/common/config/ironic.conf
+++ b/templates/common/config/ironic.conf
@@ -118,8 +118,6 @@ enforce_new_defaults=True
 [conductor]
 heartbeat_interval=20
 heartbeat_timeout=120
-force_power_state_during_sync=false
-automated_clean=false
 allow_provisioning_in_maintenance=false
 {{ if .ConductorGroup }}conductor_group={{ .ConductorGroup }}{{ end }}
 


### PR DESCRIPTION
These were set to non-default values based on undercloud configuration, not overcloud. Defaults are more appropriate for a BMaaS service.