### PR TITLE
[tlse] TLS database connection

### DIFF
--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -60,6 +60,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/statefulset"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
+	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 )
 
 // IronicConductorReconciler reconciles a IronicConductor object
@@ -758,10 +759,22 @@ func (r *IronicConductorReconciler) generateServiceConfigMaps(
 	Log := r.GetLogger(ctx)
 	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(ironic.ServiceName), map[string]string{})
 
+	db, err := mariadbv1.GetDatabaseByName(ctx, h, ironic.DatabaseName)
+	if err != nil {
+		return err
+	}
+	var tlsCfg *tls.Service
+	if instance.Spec.TLS.CaBundleSecretName != "" {
+		tlsCfg = &tls.Service{}
+	}
+
 	// customData hold any customization for the service.
 	// custom.conf is going to be merged into /etc/ironic/ironic.conf
 	// TODO: make sure custom.conf can not be overwritten
-	customData := map[string]string{common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
+	customData := map[string]string{
+		common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig,
+		"my.cnf":                           db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
+	}
 
 	for key, data := range instance.Spec.DefaultConfigOverwrite {
 		customData[key] = data

--- a/controllers/ironicneutronagent_controller.go
+++ b/controllers/ironicneutronagent_controller.go
@@ -651,7 +651,6 @@ func (r *IronicNeutronAgentReconciler) generateServiceConfigMaps(
 	// custom.conf is going to be merged into /etc/ironic/ironic.conf
 	// TODO: make sure custom.conf can not be overwritten
 	customData := map[string]string{common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
-	customData[common.CustomServiceConfigFileName] = instance.Spec.CustomServiceConfig
 
 	keystoneAPI, err := keystonev1.GetKeystoneAPI(ctx, h, instance.Namespace, map[string]string{})
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240219094943-9bbb46c9afba
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240216173409-86913e6d5885
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240216173409-86913e6d5885
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240219072536-62f6b4dc7798
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240220132409-f96d4d040f4e
 	k8s.io/api v0.28.3
 	k8s.io/apimachinery v0.28.3
 	k8s.io/client-go v0.28.3

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.2024021
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240216173409-86913e6d5885/go.mod h1:8QsCFttAm+X6A8I8EQThGjNjeMAYt2hK7ivbvnR3434=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240216173409-86913e6d5885 h1:ioJ2MO3vAcBkLM+0UBu5IuKW/DPXcyiNSOLq0Xvn+Nw=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240216173409-86913e6d5885/go.mod h1:82nzS+DbBe1tzaMvNHH8FctmZzQ14ZAJysFGsMJiivo=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240219072536-62f6b4dc7798 h1:zL4DdQ5HPXCLHeRMAWC2zI7ypbkZVYg3UkyEFSnzeow=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240219072536-62f6b4dc7798/go.mod h1:PDqfLbP4ZWqQHAu1OtbjfpOGQUKSzLqRJChvE/9pcyQ=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240220132409-f96d4d040f4e h1:6vqp5HZwcGvPH0MII/23iCd97T3/1HJZlONKW6LyNio=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240220132409-f96d4d040f4e/go.mod h1:PDqfLbP4ZWqQHAu1OtbjfpOGQUKSzLqRJChvE/9pcyQ=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/templates/common/bin/common.sh
+++ b/templates/common/bin/common.sh
@@ -86,7 +86,7 @@ function common_ironic_config {
         crudini --set ${SVC_CFG_MERGED} DEFAULT transport_url $TRANSPORTURL
         crudini --set ${SVC_CFG_MERGED} DEFAULT rpc_transport oslo
     fi
-    crudini --set ${SVC_CFG_MERGED} database connection mysql+pymysql://${DBUSER}:${DBPASSWORD}@${DBHOST}/${DB}
+    crudini --set ${SVC_CFG_MERGED} database connection mysql+pymysql://${DBUSER}:${DBPASSWORD}@${DBHOST}/${DB}?read_default_file=/etc/my.cnf
     crudini --set ${SVC_CFG_MERGED} keystone_authtoken password $IRONICPASSWORD
     crudini --set ${SVC_CFG_MERGED} service_catalog password $IRONICPASSWORD
     crudini --set ${SVC_CFG_MERGED} cinder password $IRONICPASSWORD

--- a/templates/ironic/config/db-sync-config.json
+++ b/templates/ironic/config/db-sync-config.json
@@ -12,6 +12,12 @@
             "dest": "/etc/ironic/ironic.conf.d/custom.conf",
             "owner": "ironic",
             "perm": "0600"
+        },
+        {
+            "source": "/var/lib/config-data/merged/my.cnf",
+            "dest": "/etc/my.cnf",
+            "owner": "ironic",
+            "perm": "0644"
         }
     ],
     "permissions": [

--- a/templates/ironicapi/config/ironic-api-config.json
+++ b/templates/ironicapi/config/ironic-api-config.json
@@ -40,6 +40,12 @@
             "perm": "0600",
             "optional": true,
             "merge": true
+        },
+        {
+            "source": "/var/lib/config-data/merged/my.cnf",
+            "dest": "/etc/my.cnf",
+            "owner": "ironic",
+            "perm": "0644"
         }
     ],
     "permissions": [

--- a/templates/ironicconductor/config/ironic-conductor-config.json
+++ b/templates/ironicconductor/config/ironic-conductor-config.json
@@ -12,6 +12,12 @@
             "dest": "/etc/ironic/ironic.conf.d/custom.conf",
             "owner": "ironic",
             "perm": "0600"
+        },
+        {
+            "source": "/var/lib/config-data/merged/my.cnf",
+            "dest": "/etc/my.cnf",
+            "owner": "ironic",
+            "perm": "0644"
         }
     ],
     "permissions": [

--- a/templates/ironicinspector/config/db-sync-config.json
+++ b/templates/ironicinspector/config/db-sync-config.json
@@ -12,6 +12,12 @@
             "dest": "/etc/ironic-inspector/inspector.conf.d/custom.conf",
             "owner": "ironic-inspector",
             "perm": "0600"
+        },
+        {
+            "source": "/var/lib/config-data/merged/my.cnf",
+            "dest": "/etc/my.cnf",
+            "owner": "ironic-inspector",
+            "perm": "0644"
         }
     ],
     "permissions": [

--- a/templates/ironicinspector/config/ironic-inspector-config.json
+++ b/templates/ironicinspector/config/ironic-inspector-config.json
@@ -12,6 +12,12 @@
             "dest": "/etc/ironic-inspector/inspector.conf.d/custom.conf",
             "owner": "ironic-inspector",
             "perm": "0600"
+        },
+        {
+            "source": "/var/lib/config-data/merged/my.cnf",
+            "dest": "/etc/my.cnf",
+            "owner": "ironic-inspector",
+            "perm": "0644"
         }
     ],
     "permissions": [

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -48,6 +48,7 @@ const (
 type IronicNames struct {
 	Namespace                 string
 	IronicName                types.NamespacedName
+	IronicConfigDataName      types.NamespacedName
 	IronicRole                types.NamespacedName
 	IronicRoleBinding         types.NamespacedName
 	IronicServiceAccount      types.NamespacedName
@@ -61,6 +62,7 @@ type IronicNames struct {
 	APIRoleBinding            types.NamespacedName
 	APIConfigDataName         types.NamespacedName
 	ConductorName             types.NamespacedName
+	ConductorConfigDataName   types.NamespacedName
 	ConductorServiceAccount   types.NamespacedName
 	ConductorRole             types.NamespacedName
 	ConductorRoleBinding      types.NamespacedName
@@ -110,6 +112,10 @@ func GetIronicNames(
 			Namespace: ironic.Namespace,
 			Name:      ironic.Name,
 		},
+		IronicConfigDataName: types.NamespacedName{
+			Namespace: ironic.Namespace,
+			Name:      ironic.Name + "-config-data",
+		},
 		IronicTransportURLName: types.NamespacedName{
 			Namespace: ironic.Namespace,
 			Name:      ironic.Name + "-transport",
@@ -157,6 +163,10 @@ func GetIronicNames(
 		ConductorName: types.NamespacedName{
 			Namespace: ironicConductor.Namespace,
 			Name:      ironicConductor.Name,
+		},
+		ConductorConfigDataName: types.NamespacedName{
+			Namespace: ironicAPI.Namespace,
+			Name:      "ironic-conductor-config-data",
 		},
 		ConductorServiceAccount: types.NamespacedName{
 			Namespace: ironicConductor.Namespace,

--- a/tests/functional/ironic_controller_test.go
+++ b/tests/functional/ironic_controller_test.go
@@ -133,6 +133,13 @@ var _ = Describe("Ironic controller", func() {
 		It("Creates ConfigMaps and gets Secrets (input) and set Hash of inputs", func() {
 			infra.GetTransportURL(ironicNames.IronicTransportURLName)
 			infra.SimulateTransportURLReady(ironicNames.IronicTransportURLName)
+			mariadb.GetMariaDBDatabase(ironicNames.IronicDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(ironicNames.IronicDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.IronicDatabaseName)
+			cm := th.GetConfigMap(ironicNames.IronicConfigDataName)
+			myCnf := cm.Data["my.cnf"]
+			Expect(myCnf).To(
+				ContainSubstring("[client]\nssl=0"))
 			th.ExpectCondition(
 				ironicNames.IronicName,
 				ConditionGetterFunc(IronicConditionGetter),

--- a/tests/functional/ironicinspector_controller_test.go
+++ b/tests/functional/ironicinspector_controller_test.go
@@ -117,6 +117,14 @@ var _ = Describe("IronicInspector controller", func() {
 		It("Creates ConfigMaps and gets Secrets (input)", func() {
 			infra.GetTransportURL(ironicNames.InspectorTransportURLName)
 			infra.SimulateTransportURLReady(ironicNames.InspectorTransportURLName)
+			mariadb.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
+			mariadb.SimulateMariaDBAccountCompleted(ironicNames.InspectorDatabaseName)
+			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
+			cm := th.GetConfigMap(ironicNames.InspectorConfigDataName)
+			myCnf := cm.Data["my.cnf"]
+			Expect(myCnf).To(
+				ContainSubstring("[client]\nssl=0"))
+
 			th.ExpectCondition(
 				ironicNames.InspectorName,
 				ConditionGetterFunc(IronicInspectorConditionGetter),
@@ -295,6 +303,8 @@ var _ = Describe("IronicInspector controller", func() {
 
 			infra.GetTransportURL(ironicNames.InspectorTransportURLName)
 			infra.SimulateTransportURLReady(ironicNames.InspectorTransportURLName)
+			mariadb.SimulateMariaDBAccountCompleted(ironicNames.InspectorDatabaseName)
+			mariadb.SimulateMariaDBTLSDatabaseCompleted(ironicNames.InspectorDatabaseName)
 		})
 
 		It("reports that the CA secret is missing", func() {
@@ -359,8 +369,6 @@ var _ = Describe("IronicInspector controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(ironicNames.PublicCertSecretName))
 
 			mariadb.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
-			mariadb.SimulateMariaDBAccountCompleted(ironicNames.InspectorDatabaseName)
-			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
 			th.SimulateJobSuccess(ironicNames.InspectorDBSyncJobName)
 
 			th.SimulateStatefulSetReplicaReady(ironicNames.InspectorName)
@@ -399,6 +407,9 @@ var _ = Describe("IronicInspector controller", func() {
 			Expect(configData).Should(ContainSubstring("SSLCertificateKeyFile   \"/etc/pki/tls/private/internal.key\""))
 			Expect(configData).Should(ContainSubstring("SSLCertificateFile      \"/etc/pki/tls/certs/public.crt\""))
 			Expect(configData).Should(ContainSubstring("SSLCertificateKeyFile   \"/etc/pki/tls/private/public.key\""))
+			configData = string(configDataMap.Data["my.cnf"])
+			Expect(configData).To(
+				ContainSubstring("[client]\nssl-ca=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem\nssl=1"))
 		})
 
 		It("TLS Endpoints are created", func() {
@@ -407,8 +418,6 @@ var _ = Describe("IronicInspector controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(ironicNames.PublicCertSecretName))
 
 			mariadb.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
-			mariadb.SimulateMariaDBAccountCompleted(ironicNames.InspectorDatabaseName)
-			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
 			th.SimulateJobSuccess(ironicNames.InspectorDBSyncJobName)
 
 			th.SimulateStatefulSetReplicaReady(ironicNames.InspectorName)
@@ -434,8 +443,6 @@ var _ = Describe("IronicInspector controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(ironicNames.PublicCertSecretName))
 
 			mariadb.GetMariaDBDatabase(ironicNames.InspectorDatabaseName)
-			mariadb.SimulateMariaDBAccountCompleted(ironicNames.InspectorDatabaseName)
-			mariadb.SimulateMariaDBDatabaseCompleted(ironicNames.InspectorDatabaseName)
 			th.SimulateJobSuccess(ironicNames.InspectorDBSyncJobName)
 
 			th.SimulateStatefulSetReplicaReady(ironicNames.InspectorName)


### PR DESCRIPTION
The my.cnf file gets added to the secret holding the service configs. The content of my.cnf is centrally managed in the mariadb-operator and retrieved calling db.GetDatabaseClientConfig(tlsCfg)

Depends-On: https://github.com/openstack-k8s-operators/mariadb-operator/pull/190
Depends-On: https://github.com/openstack-k8s-operators/mariadb-operator/pull/191

Jira: [OSPRH-4547](https://issues.redhat.com//browse/OSPRH-4547)