### PR TITLE
Move some validation from kubebuilder annotation to webhook

### DIFF
--- a/api/bases/ironic.openstack.org_ironics.yaml
+++ b/api/bases/ironic.openstack.org_ironics.yaml
@@ -1034,15 +1034,11 @@ spec:
                   that is created and used in Ironic
                 type: string
               rpcTransport:
-                default: json-rpc
                 description: RPC transport type - Which RPC transport implementation
                   to use between conductor and API services. 'oslo' to use oslo.messaging
                   transport or 'json-rpc' to use JSON RPC transport. NOTE -> ironic
                   and ironic-inspector require oslo.messaging transport when not in
                   standalone mode.
-                enum:
-                - oslo
-                - json-rpc
                 type: string
               secret:
                 description: Secret containing OpenStack password information for
@@ -1065,7 +1061,6 @@ spec:
             required:
             - databaseInstance
             - ironicAPI
-            - ironicConductors
             - ironicInspector
             - ironicNeutronAgent
             - secret

--- a/api/v1beta1/ironic_types.go
+++ b/api/v1beta1/ironic_types.go
@@ -112,9 +112,9 @@ type IronicSpecCore struct {
 	// IronicAPI - Spec definition for the API service of this Ironic deployment
 	IronicAPI IronicAPITemplate `json:"ironicAPI"`
 
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	// IronicConductors - Spec definitions for the conductor service of this Ironic deployment
-	IronicConductors []IronicConductorTemplate `json:"ironicConductors"`
+	IronicConductors []IronicConductorTemplate `json:"ironicConductors,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// IronicInspector - Spec definition for the inspector service of this Ironic deployment
@@ -132,8 +132,6 @@ type IronicSpecCore struct {
 	RabbitMqClusterName string `json:"rabbitMqClusterName"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Enum:=oslo;json-rpc
-	// +kubebuilder:default=json-rpc
 	// RPC transport type - Which RPC transport implementation to use between
 	// conductor and API services. 'oslo' to use oslo.messaging transport
 	// or 'json-rpc' to use JSON RPC transport. NOTE -> ironic and ironic-inspector

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -1034,15 +1034,11 @@ spec:
                   that is created and used in Ironic
                 type: string
               rpcTransport:
-                default: json-rpc
                 description: RPC transport type - Which RPC transport implementation
                   to use between conductor and API services. 'oslo' to use oslo.messaging
                   transport or 'json-rpc' to use JSON RPC transport. NOTE -> ironic
                   and ironic-inspector require oslo.messaging transport when not in
                   standalone mode.
-                enum:
-                - oslo
-                - json-rpc
                 type: string
               secret:
                 description: Secret containing OpenStack password information for
@@ -1065,7 +1061,6 @@ spec:
             required:
             - databaseInstance
             - ironicAPI
-            - ironicConductors
             - ironicInspector
             - ironicNeutronAgent
             - secret


### PR DESCRIPTION
Right now applying a OpenStackControlPlane CR without any ironic section fails with:

~~~
$ oc apply -n openstack -f ...
The OpenStackControlPlane "openstack-galera-network-isolation-3replicas" is invalid:
* spec.ironic.template.rpcTransport: Unsupported value: "": supported values: "oslo", "json-rpc"
* spec.ironic.template.ironicConductors: Invalid value: "null": spec.ironic.template.ironicConductors in body must be of type array: "null" 
~~~

To allow the OpenstackControlPlane to be deployed without specifying any ironic there is the need to change the validation/defaulting of the RPCTransport and IronicConductors.

* RPCTransport The enum check is moved to the validations webhook for create and update, default set in the defaulting webhook.

* IronicConductors IronicConductors not longer a required parameter from kubebuilder pov, but in the validations webhook checked that length of the array is > 0