### PR TITLE
Ensure golangci-lint runs on all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,5 +58,5 @@ repos:
 - repo: https://github.com/golangci/golangci-lint
   rev: v1.55.2
   hooks:
-    - id: golangci-lint
+    - id: golangci-lint-full
       args: ["-v"]

--- a/controllers/funcs.go
+++ b/controllers/funcs.go
@@ -29,9 +29,6 @@ const (
 )
 
 var (
-	ironicWatchFields = []string{
-		passwordSecretField,
-	}
 	ironicAPIWatchFields = []string{
 		passwordSecretField,
 		caBundleSecretNameField,

--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -33,7 +33,6 @@ import (
 	job "github.com/openstack-k8s-operators/lib-common/modules/common/job"
 	labels "github.com/openstack-k8s-operators/lib-common/modules/common/labels"
 	common_rbac "github.com/openstack-k8s-operators/lib-common/modules/common/rbac"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	oko_secret "github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
 	util "github.com/openstack-k8s-operators/lib-common/modules/common/util"
@@ -420,7 +419,7 @@ func (r *IronicReconciler) reconcileNormal(ctx context.Context, instance *ironic
 	}
 
 	// Handle service update
-	ctrlResult, err := r.reconcileUpdate(ctx, instance, helper)
+	ctrlResult, err := r.reconcileUpdate()
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -600,7 +599,7 @@ func (r *IronicReconciler) reconcileNormal(ctx context.Context, instance *ironic
 	return ctrl.Result{}, nil
 }
 
-func (r *IronicReconciler) reconcileUpdate(ctx context.Context, instance *ironicv1.Ironic, helper *helper.Helper) (ctrl.Result, error) {
+func (r *IronicReconciler) reconcileUpdate() (ctrl.Result, error) {
 	// Log.Info("Reconciling Ironic update")
 
 	// Log.Info("Reconciled Ironic update successfully")
@@ -844,7 +843,7 @@ func (r *IronicReconciler) generateServiceConfigMaps(
 		},
 	}
 
-	return secret.EnsureSecrets(ctx, h, instance, cms, envVars)
+	return oko_secret.EnsureSecrets(ctx, h, instance, cms, envVars)
 }
 
 // createHashOfInputHashes - creates a hash of hashes which gets added to the resources which requires a restart

--- a/controllers/ironicapi_controller.go
+++ b/controllers/ironicapi_controller.go
@@ -220,7 +220,7 @@ func (r *IronicAPIReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 		listOpts := []client.ListOption{
 			client.InNamespace(o.GetNamespace()),
 		}
-		if err := r.Client.List(context.Background(), apis, listOpts...); err != nil {
+		if err := r.Client.List(ctx, apis, listOpts...); err != nil {
 			Log.Error(err, "Unable to retrieve API CRs %v")
 			return nil
 		}
@@ -248,7 +248,7 @@ func (r *IronicAPIReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 	}
 
 	// index passwordSecretField
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &ironicv1.IronicAPI{}, passwordSecretField, func(rawObj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &ironicv1.IronicAPI{}, passwordSecretField, func(rawObj client.Object) []string {
 		// Extract the secret name from the spec, if one is provided
 		cr := rawObj.(*ironicv1.IronicAPI)
 		if cr.Spec.Secret == "" {
@@ -260,7 +260,7 @@ func (r *IronicAPIReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 	}
 
 	// index caBundleSecretNameField
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &ironicv1.IronicAPI{}, caBundleSecretNameField, func(rawObj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &ironicv1.IronicAPI{}, caBundleSecretNameField, func(rawObj client.Object) []string {
 		// Extract the secret name from the spec, if one is provided
 		cr := rawObj.(*ironicv1.IronicAPI)
 		if cr.Spec.TLS.CaBundleSecretName == "" {
@@ -272,7 +272,7 @@ func (r *IronicAPIReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 	}
 
 	// index tlsAPIInternalField
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &ironicv1.IronicAPI{}, tlsAPIInternalField, func(rawObj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &ironicv1.IronicAPI{}, tlsAPIInternalField, func(rawObj client.Object) []string {
 		// Extract the secret name from the spec, if one is provided
 		cr := rawObj.(*ironicv1.IronicAPI)
 		if cr.Spec.TLS.API.Internal.SecretName == nil {
@@ -284,7 +284,7 @@ func (r *IronicAPIReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 	}
 
 	// index tlsAPIPublicField
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &ironicv1.IronicAPI{}, tlsAPIPublicField, func(rawObj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &ironicv1.IronicAPI{}, tlsAPIPublicField, func(rawObj client.Object) []string {
 		// Extract the secret name from the spec, if one is provided
 		cr := rawObj.(*ironicv1.IronicAPI)
 		if cr.Spec.TLS.API.Public.SecretName == nil {
@@ -319,7 +319,7 @@ func (r *IronicAPIReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 func (r *IronicAPIReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(context.Background()).WithName("Controllers").WithName("IronicAPI")
+	l := log.FromContext(ctx).WithName("Controllers").WithName("IronicAPI")
 
 	for _, field := range ironicAPIWatchFields {
 		crList := &ironicv1.IronicAPIList{}
@@ -327,7 +327,7 @@ func (r *IronicAPIReconciler) findObjectsForSrc(ctx context.Context, src client.
 			FieldSelector: fields.OneTermEqualSelector(field, src.GetName()),
 			Namespace:     src.GetNamespace(),
 		}
-		err := r.List(context.TODO(), crList, listOps)
+		err := r.List(ctx, crList, listOps)
 		if err != nil {
 			return []reconcile.Request{}
 		}
@@ -807,7 +807,7 @@ func (r *IronicAPIReconciler) reconcileNormal(ctx context.Context, instance *iro
 	}
 
 	// Handle service update
-	ctrlResult, err = r.reconcileUpdate(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpdate()
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -815,7 +815,7 @@ func (r *IronicAPIReconciler) reconcileNormal(ctx context.Context, instance *iro
 	}
 
 	// Handle service upgrade
-	ctrlResult, err = r.reconcileUpgrade(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpgrade()
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -898,14 +898,14 @@ func (r *IronicAPIReconciler) reconcileNormal(ctx context.Context, instance *iro
 	return ctrl.Result{}, nil
 }
 
-func (r *IronicAPIReconciler) reconcileUpdate(ctx context.Context, instance *ironicv1.IronicAPI, helper *helper.Helper) (ctrl.Result, error) {
+func (r *IronicAPIReconciler) reconcileUpdate() (ctrl.Result, error) {
 	// Log.Info("Reconciling API update")
 
 	// Log.Info("Reconciled API update successfully")
 	return ctrl.Result{}, nil
 }
 
-func (r *IronicAPIReconciler) reconcileUpgrade(ctx context.Context, instance *ironicv1.IronicAPI, helper *helper.Helper) (ctrl.Result, error) {
+func (r *IronicAPIReconciler) reconcileUpgrade() (ctrl.Result, error) {
 	// Log.Info("Reconciling API upgrade")
 
 	// Log.Info("Reconciled API upgrade successfully")

--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/types"
 	k8s_types "k8s.io/apimachinery/pkg/types"
 
 	"github.com/go-logr/logr"
@@ -249,7 +248,7 @@ func (r *IronicConductorReconciler) SetupWithManager(ctx context.Context, mgr ct
 	}
 
 	// index passwordSecretField
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &ironicv1.IronicConductor{}, passwordSecretField, func(rawObj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &ironicv1.IronicConductor{}, passwordSecretField, func(rawObj client.Object) []string {
 		// Extract the secret name from the spec, if one is provided
 		cr := rawObj.(*ironicv1.IronicConductor)
 		if cr.Spec.Secret == "" {
@@ -261,7 +260,7 @@ func (r *IronicConductorReconciler) SetupWithManager(ctx context.Context, mgr ct
 	}
 
 	// index caBundleSecretNameField
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &ironicv1.IronicConductor{}, caBundleSecretNameField, func(rawObj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &ironicv1.IronicConductor{}, caBundleSecretNameField, func(rawObj client.Object) []string {
 		// Extract the secret name from the spec, if one is provided
 		cr := rawObj.(*ironicv1.IronicConductor)
 		if cr.Spec.TLS.CaBundleSecretName == "" {
@@ -296,7 +295,7 @@ func (r *IronicConductorReconciler) SetupWithManager(ctx context.Context, mgr ct
 func (r *IronicConductorReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(context.Background()).WithName("Controllers").WithName("IronicConductor")
+	l := log.FromContext(ctx).WithName("Controllers").WithName("IronicConductor")
 
 	for _, field := range ironicConductorWatchFields {
 		crList := &ironicv1.IronicConductorList{}
@@ -304,7 +303,7 @@ func (r *IronicConductorReconciler) findObjectsForSrc(ctx context.Context, src c
 			FieldSelector: fields.OneTermEqualSelector(field, src.GetName()),
 			Namespace:     src.GetNamespace(),
 		}
-		err := r.List(context.TODO(), crList, listOps)
+		err := r.List(ctx, crList, listOps)
 		if err != nil {
 			return []reconcile.Request{}
 		}
@@ -314,7 +313,7 @@ func (r *IronicConductorReconciler) findObjectsForSrc(ctx context.Context, src c
 
 			requests = append(requests,
 				reconcile.Request{
-					NamespacedName: types.NamespacedName{
+					NamespacedName: k8s_types.NamespacedName{
 						Name:      item.GetName(),
 						Namespace: item.GetNamespace(),
 					},
@@ -536,7 +535,7 @@ func (r *IronicConductorReconciler) reconcileNormal(ctx context.Context, instanc
 		hash, ctrlResult, err := tls.ValidateCACertSecret(
 			ctx,
 			helper.GetClient(),
-			types.NamespacedName{
+			k8s_types.NamespacedName{
 				Name:      instance.Spec.TLS.CaBundleSecretName,
 				Namespace: instance.Namespace,
 			},
@@ -605,7 +604,7 @@ func (r *IronicConductorReconciler) reconcileNormal(ctx context.Context, instanc
 	//
 
 	// Handle service update
-	ctrlResult, err := r.reconcileUpdate(ctx, instance, helper)
+	ctrlResult, err := r.reconcileUpdate()
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -613,7 +612,7 @@ func (r *IronicConductorReconciler) reconcileNormal(ctx context.Context, instanc
 	}
 
 	// Handle service upgrade
-	ctrlResult, err = r.reconcileUpgrade(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpgrade()
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -737,14 +736,14 @@ func (r *IronicConductorReconciler) reconcileNormal(ctx context.Context, instanc
 	return ctrl.Result{}, nil
 }
 
-func (r *IronicConductorReconciler) reconcileUpdate(ctx context.Context, instance *ironicv1.IronicConductor, helper *helper.Helper) (ctrl.Result, error) {
+func (r *IronicConductorReconciler) reconcileUpdate() (ctrl.Result, error) {
 	// Log.Info("Reconciling Service update")
 
 	// Log.Info("Reconciled Service update successfully")
 	return ctrl.Result{}, nil
 }
 
-func (r *IronicConductorReconciler) reconcileUpgrade(ctx context.Context, instance *ironicv1.IronicConductor, helper *helper.Helper) (ctrl.Result, error) {
+func (r *IronicConductorReconciler) reconcileUpgrade() (ctrl.Result, error) {
 	// Log.Info("Reconciling Service upgrade")
 
 	// Log.Info("Reconciled Service upgrade successfully")

--- a/controllers/ironicneutronagent_controller.go
+++ b/controllers/ironicneutronagent_controller.go
@@ -211,10 +211,10 @@ func (r *IronicNeutronAgentReconciler) Reconcile(
 
 // SetupWithManager - sets up the controller with the Manager.
 func (r *IronicNeutronAgentReconciler) SetupWithManager(
-	mgr ctrl.Manager,
+	ctx context.Context, mgr ctrl.Manager,
 ) error {
 	// index passwordSecretField
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &ironicv1.IronicNeutronAgent{}, passwordSecretField, func(rawObj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &ironicv1.IronicNeutronAgent{}, passwordSecretField, func(rawObj client.Object) []string {
 		// Extract the secret name from the spec, if one is provided
 		cr := rawObj.(*ironicv1.IronicNeutronAgent)
 		if cr.Spec.Secret == "" {
@@ -226,7 +226,7 @@ func (r *IronicNeutronAgentReconciler) SetupWithManager(
 	}
 
 	// index caBundleSecretNameField
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &ironicv1.IronicNeutronAgent{}, caBundleSecretNameField, func(rawObj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &ironicv1.IronicNeutronAgent{}, caBundleSecretNameField, func(rawObj client.Object) []string {
 		// Extract the secret name from the spec, if one is provided
 		cr := rawObj.(*ironicv1.IronicNeutronAgent)
 		if cr.Spec.TLS.CaBundleSecretName == "" {
@@ -257,7 +257,7 @@ func (r *IronicNeutronAgentReconciler) SetupWithManager(
 func (r *IronicNeutronAgentReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(context.Background()).WithName("Controllers").WithName("IronicNeutronAgent")
+	l := log.FromContext(ctx).WithName("Controllers").WithName("IronicNeutronAgent")
 
 	for _, field := range ironicNeutronAgentWatchFields {
 		crList := &ironicv1.IronicNeutronAgentList{}
@@ -265,7 +265,7 @@ func (r *IronicNeutronAgentReconciler) findObjectsForSrc(ctx context.Context, sr
 			FieldSelector: fields.OneTermEqualSelector(field, src.GetName()),
 			Namespace:     src.GetNamespace(),
 		}
-		err := r.List(context.TODO(), crList, listOps)
+		err := r.List(ctx, crList, listOps)
 		if err != nil {
 			return []reconcile.Request{}
 		}
@@ -541,7 +541,7 @@ func (r *IronicNeutronAgentReconciler) reconcileNormal(
 	}
 
 	// Handle service init
-	ctrlResult, err = r.reconcileInit(ctx, instance, helper, serviceLabels)
+	ctrlResult, err = r.reconcileInit(ctx)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -549,7 +549,7 @@ func (r *IronicNeutronAgentReconciler) reconcileNormal(
 	}
 
 	// Handle service update
-	ctrlResult, err = r.reconcileUpdate(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpdate(ctx)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -557,7 +557,7 @@ func (r *IronicNeutronAgentReconciler) reconcileNormal(
 	}
 
 	// Handle service upgrade
-	ctrlResult, err = r.reconcileUpgrade(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpgrade(ctx)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -586,9 +586,6 @@ func (r *IronicNeutronAgentReconciler) reconcileNormal(
 
 func (r *IronicNeutronAgentReconciler) reconcileInit(
 	ctx context.Context,
-	instance *ironicv1.IronicNeutronAgent,
-	helper *helper.Helper,
-	serviceLabels map[string]string,
 ) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 
@@ -615,8 +612,6 @@ func (r *IronicNeutronAgentReconciler) reconcileDelete(
 
 func (r *IronicNeutronAgentReconciler) reconcileUpdate(
 	ctx context.Context,
-	instance *ironicv1.IronicNeutronAgent,
-	helper *helper.Helper,
 ) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 
@@ -628,8 +623,6 @@ func (r *IronicNeutronAgentReconciler) reconcileUpdate(
 
 func (r *IronicNeutronAgentReconciler) reconcileUpgrade(
 	ctx context.Context,
-	instance *ironicv1.IronicNeutronAgent,
-	helper *helper.Helper,
 ) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 

--- a/main.go
+++ b/main.go
@@ -153,7 +153,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-	}).SetupWithManager(mgr, context.Background()); err != nil {
+	}).SetupWithManager(context.Background(), mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "IronicInspector")
 		os.Exit(1)
 	}
@@ -161,7 +161,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(context.Background(), mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "IronicNeutronAgent")
 		os.Exit(1)
 	}

--- a/pkg/ironic/funcs.go
+++ b/pkg/ironic/funcs.go
@@ -34,7 +34,7 @@ func GetIngressDomain(
 		},
 	)
 	err := helper.GetClient().Get(
-		context.Background(),
+		ctx,
 		client.ObjectKey{
 			Namespace: "openshift-ingress-operator",
 			Name:      "default",

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //revive:disable:dot-imports
 
 	ironic_pkg "github.com/openstack-k8s-operators/ironic-operator/pkg/ironic"
 	ironic_inspector_pkg "github.com/openstack-k8s-operators/ironic-operator/pkg/ironicinspector"

--- a/tests/functional/ironic_controller_test.go
+++ b/tests/functional/ironic_controller_test.go
@@ -19,12 +19,14 @@ package functional_test
 import (
 	"fmt"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
+	//revive:disable-next-line:dot-imports
+	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 
 	ironicv1 "github.com/openstack-k8s-operators/ironic-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 	mariadb_test "github.com/openstack-k8s-operators/mariadb-operator/api/test/helpers"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/tests/functional/ironicapi_controller_test.go
+++ b/tests/functional/ironicapi_controller_test.go
@@ -18,12 +18,15 @@ package functional_test
 import (
 	"fmt"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
+	//revive:disable-next-line:dot-imports
+	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
+
 	ironicv1 "github.com/openstack-k8s-operators/ironic-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/ironic-operator/pkg/ironic"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/tests/functional/ironicconductor_controller_test.go
+++ b/tests/functional/ironicconductor_controller_test.go
@@ -18,13 +18,16 @@ package functional_test
 import (
 	"fmt"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
+	//revive:disable-next-line:dot-imports
+	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
+
 	routev1 "github.com/openshift/api/route/v1"
 	ironicv1 "github.com/openstack-k8s-operators/ironic-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/ironic-operator/pkg/ironic"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/tests/functional/ironicinspector_controller_test.go
+++ b/tests/functional/ironicinspector_controller_test.go
@@ -19,10 +19,13 @@ package functional_test
 import (
 	"fmt"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
+	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
+
+	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	mariadb_test "github.com/openstack-k8s-operators/mariadb-operator/api/test/helpers"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/tests/functional/ironicneutronagent_controller_test.go
+++ b/tests/functional/ironicneutronagent_controller_test.go
@@ -22,11 +22,13 @@ import (
 
 	"fmt"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+
+	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 
+	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/tests/functional/sample_test.go
+++ b/tests/functional/sample_test.go
@@ -20,8 +20,8 @@ import (
 	"os"
 	"path/filepath"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -179,14 +179,14 @@ var _ = BeforeSuite(func() {
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),
 		Kclient: kclient,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(context.Background(), k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&controllers.IronicInspectorReconciler{
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),
 		Kclient: kclient,
-	}).SetupWithManager(k8sManager, context.Background())
+	}).SetupWithManager(context.Background(), k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&controllers.IronicConductorReconciler{


### PR DESCRIPTION
* removed unused func params and variables
* ignore revive dot-imports rule on ginkgo and gomega as dot import
there is the recommended practice
* various small style fixes found by the linter
