### PR TITLE
Move -log sidecar container to dumb-init

### DIFF
--- a/pkg/ironicapi/deployment.go
+++ b/pkg/ironicapi/deployment.go
@@ -135,9 +135,16 @@ func Deployment(
 						{
 							Name: ironic.ServiceName + "-" + ironic.APIComponent + "-log",
 							Command: []string{
-								"/bin/bash",
+								"/usr/bin/dumb-init",
 							},
-							Args:  []string{"-c", "tail -n+1 -F " + ironic.LogPath},
+							Args: []string{
+								"--single-child",
+								"--",
+								"/usr/bin/tail",
+								"-n+1",
+								"-F",
+								ironic.LogPath,
+							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: &runAsUser,


### PR DESCRIPTION
As noticed in other operators, the -log sidecar ignores SIGTERM on delete. This patch moves the ironic-operator to the dumb-init usage to make sure the SIGTERM is handled properly by the sidecar.

Fixes: OSPRH-3278