### PR TITLE
[pre-commit][kuttl]Fix false positive asserts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,3 +60,11 @@ repos:
   hooks:
     - id: golangci-lint-full
       args: ["-v"]
+
+- repo: https://github.com/openstack-k8s-operators/openstack-k8s-operators-ci
+  # NOTE(gibi): we cannot automatically track main here
+  # see https://pre-commit.com/#using-the-latest-version-for-a-repository
+  rev: e30d72fcbced0ab8a7b6d23be1dee129e2a7b849
+  hooks:
+    - id: kuttl-single-test-assert
+      args: ["tests/kuttl"]

--- a/tests/kuttl/common/assert-endpoints.yaml
+++ b/tests/kuttl/common/assert-endpoints.yaml
@@ -15,7 +15,7 @@ commands:
   - script: |
       set -euxo pipefail
       template='{{.status.apiEndpoints.ironic.public}}{{":"}}{{.status.apiEndpoints.ironic.internal}}{{"\n"}}'
-      regex="http:\/\/ironic-public-$NAMESPACE\.apps.*:http:\/\/ironic-admin-$NAMESPACE\.apps.*:http:\/\/ironic-internal-$NAMESPACE\.apps.*"
+      regex="http:\/\/ironic-public\.$NAMESPACE\..*:http:\/\/ironic-internal\.$NAMESPACE\..*"
       apiEndpoints=$(oc get -n $NAMESPACE ironics.ironic.openstack.org ironic -o go-template="$template")
       matches=$(echo "$apiEndpoints" | sed -e "s?$regex??")
       if [ -z "$matches" ]; then
@@ -30,7 +30,7 @@ commands:
   - script: |
       set -euxo pipefail
       template='{{index .status.apiEndpoints "ironic-inspector" "public"}}{{":"}}{{index .status.apiEndpoints "ironic-inspector" "internal"}}{{"\n"}}'
-      regex="http:\/\/ironic-inspector-public-$NAMESPACE\.apps.*:http:\/\/ironic-inspector-admin-$NAMESPACE\.apps.*:http:\/\/ironic-inspector-internal-$NAMESPACE\.apps.*"
+      regex="http:\/\/ironic-inspector-public\.$NAMESPACE\..*:http:\/\/ironic-inspector-internal\.$NAMESPACE\..*"
       apiEndpoints=$(oc get -n $NAMESPACE ironics.ironic.openstack.org ironic -o go-template="$template")
       matches=$(echo "$apiEndpoints" | sed -e "s?$regex??")
       if [ -z "$matches" ]; then

--- a/tests/kuttl/common/assert-endpoints.yaml
+++ b/tests/kuttl/common/assert-endpoints.yaml
@@ -44,12 +44,13 @@ commands:
       set -euxo pipefail
       RETURN_CODE=0
       PUBLIC_URL=$(oc get -n $NAMESPACE ironics.ironic.openstack.org ironic -o jsonpath='{.status.apiEndpoints.ironic.public}')
+      CURL_CMD='oc run --restart=Never --rm=true --image quay.io/curl/curl:8.8.0 -ti --quiet=true -- curl curl --silent --output /dev/null --head --write-out "%{http_code}"'
       if [ -z "$PUBLIC_URL" ]; then
           RETURN_CODE=1
           echo "Endpoint: apiEndpoints.ironic.public not ready."
           sleep 10
       else
-          STATUSCODE=$(curl --silent --output /dev/stderr --head --write-out "%{http_code}" $PUBLIC_URL)
+          STATUSCODE=$($CURL_CMD $PUBLIC_URL)
           if test $STATUSCODE -ne 200; then
               RETURN_CODE=1
               echo "${PUBLIC_URL} status code expected is 200 but was ${STATUSCODE}"
@@ -62,12 +63,13 @@ commands:
       set -euxo pipefail
       RETURN_CODE=0
       PUBLIC_URL=$(oc get -n $NAMESPACE ironics.ironic.openstack.org ironic -o jsonpath='{.status.apiEndpoints.ironic-inspector.public}')
+      CURL_CMD='oc run --restart=Never --rm=true --image quay.io/curl/curl:8.8.0 -ti --quiet=true -- curl curl --silent --output /dev/null --head --write-out "%{http_code}"'
       if [ -z "$PUBLIC_URL" ]; then
           RETURN_CODE=1
           echo "Endpoint: .status.apiEndpoints.ironic-inspector.public not ready."
           sleep 10
       else
-          STATUSCODE=$(curl --silent --output /dev/stderr --head --write-out "%{http_code}" $PUBLIC_URL)
+          STATUSCODE=$($CURL_CMD $PUBLIC_URL)
           if test $STATUSCODE -ne 200; then
               RETURN_CODE=1
               echo "${PUBLIC_URL} status code expected is 200 but was ${STATUSCODE}"

--- a/tests/kuttl/common/assert-endpoints.yaml
+++ b/tests/kuttl/common/assert-endpoints.yaml
@@ -13,6 +13,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - script: |
+      set -euxo pipefail
       template='{{.status.apiEndpoints.ironic.public}}{{":"}}{{.status.apiEndpoints.ironic.internal}}{{"\n"}}'
       regex="http:\/\/ironic-public-$NAMESPACE\.apps.*:http:\/\/ironic-admin-$NAMESPACE\.apps.*:http:\/\/ironic-internal-$NAMESPACE\.apps.*"
       apiEndpoints=$(oc get -n $NAMESPACE ironics.ironic.openstack.org ironic -o go-template="$template")
@@ -22,15 +23,12 @@ commands:
       else
         exit 1
       fi
----
 # the actual addresses of the apiEndpoints are platform specific, so we can't rely on
 # kuttl asserts to check them. This short script gathers the addresses and checks that
 # the endpoints are defined and their addresses follow the default pattern
 # This test is for the ironic inspector endpoints
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-commands:
   - script: |
+      set -euxo pipefail
       template='{{index .status.apiEndpoints "ironic-inspector" "public"}}{{":"}}{{index .status.apiEndpoints "ironic-inspector" "internal"}}{{"\n"}}'
       regex="http:\/\/ironic-inspector-public-$NAMESPACE\.apps.*:http:\/\/ironic-inspector-admin-$NAMESPACE\.apps.*:http:\/\/ironic-inspector-internal-$NAMESPACE\.apps.*"
       apiEndpoints=$(oc get -n $NAMESPACE ironics.ironic.openstack.org ironic -o go-template="$template")
@@ -40,14 +38,10 @@ commands:
       else
         exit 1
       fi
----
 # Test the status code is correct for each endpoint
 # This test is for ironic endpoints
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-commands:
   - script: |
-      set -x
+      set -euxo pipefail
       RETURN_CODE=0
       PUBLIC_URL=$(oc get -n $NAMESPACE ironics.ironic.openstack.org ironic -o jsonpath='{.status.apiEndpoints.ironic.public}')
       if [ -z "$PUBLIC_URL" ]; then
@@ -62,14 +56,10 @@ commands:
           fi
       fi
       exit $RETURN_CODE
----
 # Test the status code is correct for each endpoint
 # This test is for ironic inspector endpoints
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-commands:
   - script: |
-      set -x
+      set -euxo pipefail
       RETURN_CODE=0
       PUBLIC_URL=$(oc get -n $NAMESPACE ironics.ironic.openstack.org ironic -o jsonpath='{.status.apiEndpoints.ironic-inspector.public}')
       if [ -z "$PUBLIC_URL" ]; then
@@ -84,12 +74,9 @@ commands:
           fi
       fi
       exit $RETURN_CODE
----
 # when using image digests the containerImage URLs are SHAs so we verify them with a script
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-commands:
   - script: |
+      set -euxo pipefail
       tupleTemplate='{{ range (index .spec.template.spec.containers 1).env }}{{ .name }}{{ "#" }}{{ .value}}{{"\n"}}{{ end }}'
       imageTuples=$(oc get -n openstack-operators deployment ironic-operator-controller-manager -o go-template="$tupleTemplate")
       for ITEM in $(echo $imageTuples); do

--- a/tests/kuttl/common/assert-endpoints.yaml
+++ b/tests/kuttl/common/assert-endpoints.yaml
@@ -14,9 +14,10 @@ kind: TestAssert
 commands:
   - script: |
       set -euxo pipefail
+      oc config set-context --current --namespace=$NAMESPACE
       template='{{.status.apiEndpoints.ironic.public}}{{":"}}{{.status.apiEndpoints.ironic.internal}}{{"\n"}}'
       regex="http:\/\/ironic-public\.$NAMESPACE\..*:http:\/\/ironic-internal\.$NAMESPACE\..*"
-      apiEndpoints=$(oc get -n $NAMESPACE ironics.ironic.openstack.org ironic -o go-template="$template")
+      apiEndpoints=$(oc get ironics.ironic.openstack.org ironic -o go-template="$template")
       matches=$(echo "$apiEndpoints" | sed -e "s?$regex??")
       if [ -z "$matches" ]; then
         exit 0
@@ -29,9 +30,10 @@ commands:
 # This test is for the ironic inspector endpoints
   - script: |
       set -euxo pipefail
+      oc config set-context --current --namespace=$NAMESPACE
       template='{{index .status.apiEndpoints "ironic-inspector" "public"}}{{":"}}{{index .status.apiEndpoints "ironic-inspector" "internal"}}{{"\n"}}'
       regex="http:\/\/ironic-inspector-public\.$NAMESPACE\..*:http:\/\/ironic-inspector-internal\.$NAMESPACE\..*"
-      apiEndpoints=$(oc get -n $NAMESPACE ironics.ironic.openstack.org ironic -o go-template="$template")
+      apiEndpoints=$(oc get ironics.ironic.openstack.org ironic -o go-template="$template")
       matches=$(echo "$apiEndpoints" | sed -e "s?$regex??")
       if [ -z "$matches" ]; then
         exit 0
@@ -43,7 +45,8 @@ commands:
   - script: |
       set -euxo pipefail
       RETURN_CODE=0
-      PUBLIC_URL=$(oc get -n $NAMESPACE ironics.ironic.openstack.org ironic -o jsonpath='{.status.apiEndpoints.ironic.public}')
+      oc config set-context --current --namespace=$NAMESPACE
+      PUBLIC_URL=$(oc get ironics.ironic.openstack.org ironic -o jsonpath='{.status.apiEndpoints.ironic.public}')
       CURL_CMD='oc run --restart=Never --rm=true --image quay.io/curl/curl:8.8.0 -ti --quiet=true -- curl curl --silent --output /dev/null --head --write-out "%{http_code}"'
       if [ -z "$PUBLIC_URL" ]; then
           RETURN_CODE=1
@@ -62,7 +65,8 @@ commands:
   - script: |
       set -euxo pipefail
       RETURN_CODE=0
-      PUBLIC_URL=$(oc get -n $NAMESPACE ironics.ironic.openstack.org ironic -o jsonpath='{.status.apiEndpoints.ironic-inspector.public}')
+      oc config set-context --current --namespace=$NAMESPACE
+      PUBLIC_URL=$(oc get ironics.ironic.openstack.org ironic -o jsonpath='{.status.apiEndpoints.ironic-inspector.public}')
       CURL_CMD='oc run --restart=Never --rm=true --image quay.io/curl/curl:8.8.0 -ti --quiet=true -- curl curl --silent --output /dev/null --head --write-out "%{http_code}"'
       if [ -z "$PUBLIC_URL" ]; then
           RETURN_CODE=1
@@ -79,6 +83,7 @@ commands:
 # when using image digests the containerImage URLs are SHAs so we verify them with a script
   - script: |
       set -euxo pipefail
+      oc config set-context --current --namespace=$NAMESPACE
       tupleTemplate='{{ range (index .spec.template.spec.containers 1).env }}{{ .name }}{{ "#" }}{{ .value}}{{"\n"}}{{ end }}'
       imageTuples=$(oc get -n openstack-operators deployment ironic-operator-controller-manager -o go-template="$tupleTemplate")
       for ITEM in $(echo $imageTuples); do
@@ -89,16 +94,16 @@ commands:
           template='{{.spec.containerImage}}'
           case $NAME in
             API)
-              SERVICE_IMAGE=$(oc get -n $NAMESPACE ironicapi ironic-api -o go-template="$template")
+              SERVICE_IMAGE=$(oc get ironicapi ironic-api -o go-template="$template")
               ;;
             CONDUCTOR)
-              SERVICE_IMAGE=$(oc get -n $NAMESPACE ironicconductor ironic-conductor -o go-template="$template")
+              SERVICE_IMAGE=$(oc get ironicconductor ironic-conductor -o go-template="$template")
               ;;
             INSPECTOR)
-              SERVICE_IMAGE=$(oc get -n $NAMESPACE ironicinspector ironic-inspector -o go-template="$template")
+              SERVICE_IMAGE=$(oc get ironicinspector ironic-inspector -o go-template="$template")
               ;;
             PXE)
-              SERVICE_IMAGE=$(oc get -n $NAMESPACE ironicconductor ironic-conductor -o go-template="{{.spec.pxeContainerImage}}")
+              SERVICE_IMAGE=$(oc get ironicconductor ironic-conductor -o go-template="{{.spec.pxeContainerImage}}")
               ;;
             NEUTRON_AGENT)
               # this isn't deployed in all tests

--- a/tests/kuttl/tests/deploy_tls/10-assert-deploy-ironic.yaml
+++ b/tests/kuttl/tests/deploy_tls/10-assert-deploy-ironic.yaml
@@ -109,21 +109,23 @@ commands:
   - script: |
       set -euxo pipefail
       template='{{.spec.endpoints.internal}}{{":"}}{{.spec.endpoints.public}}{{"\n"}}'
-      regex="https:\/\/ironic-internal.$NAMESPACE.*:https:\/\/ironic-public.$NAMESPACE.*"
+      regex="https:\/\/ironic-internal\.$NAMESPACE\..*:https:\/\/ironic-public\.$NAMESPACE\..*"
       apiEndpoints=$(oc get -n $NAMESPACE KeystoneEndpoint ironic -o go-template="$template")
       matches=$(echo "$apiEndpoints" | sed -e "s?$regex??")
       if [[ -n "$matches" ]]; then
         exit 1
       fi
+      exit 0
 # the actual addresses of the api endpoints are platform specific, so we can't rely on
 # kuttl asserts to check them. This short script gathers the addresses and checks that
 # the two endpoints are defined and their addresses follow the default pattern
   - script: |
       set -euxo pipefail
       template='{{.spec.endpoints.internal}}{{":"}}{{.spec.endpoints.public}}{{"\n"}}'
-      regex="https:\/\/ironic-inspector-internal.$NAMESPACE.*:https:\/\/ironic-inspector-public.$NAMESPACE.*"
+      regex="https:\/\/ironic-inspector-internal\.$NAMESPACE\..*:https:\/\/ironic-inspector-public\.$NAMESPACE\..*"
       apiEndpoints=$(oc get -n $NAMESPACE KeystoneEndpoint ironic-inspector -o go-template="$template")
       matches=$(echo "$apiEndpoints" | sed -e "s?$regex??")
       if [[ -n "$matches" ]]; then
         exit 1
       fi
+      exit 0

--- a/tests/kuttl/tests/deploy_tls/10-assert-deploy-ironic.yaml
+++ b/tests/kuttl/tests/deploy_tls/10-assert-deploy-ironic.yaml
@@ -107,6 +107,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - script: |
+      set -euxo pipefail
       template='{{.spec.endpoints.internal}}{{":"}}{{.spec.endpoints.public}}{{"\n"}}'
       regex="https:\/\/ironic-internal.$NAMESPACE.*:https:\/\/ironic-public.$NAMESPACE.*"
       apiEndpoints=$(oc get -n $NAMESPACE KeystoneEndpoint ironic -o go-template="$template")
@@ -114,14 +115,11 @@ commands:
       if [[ -n "$matches" ]]; then
         exit 1
       fi
----
 # the actual addresses of the api endpoints are platform specific, so we can't rely on
 # kuttl asserts to check them. This short script gathers the addresses and checks that
 # the two endpoints are defined and their addresses follow the default pattern
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-commands:
   - script: |
+      set -euxo pipefail
       template='{{.spec.endpoints.internal}}{{":"}}{{.spec.endpoints.public}}{{"\n"}}'
       regex="https:\/\/ironic-inspector-internal.$NAMESPACE.*:https:\/\/ironic-inspector-public.$NAMESPACE.*"
       apiEndpoints=$(oc get -n $NAMESPACE KeystoneEndpoint ironic-inspector -o go-template="$template")


### PR DESCRIPTION
Kuttl only runs the last TestAssert in an assert file and silently
ignores the rest. So this patch combines the TestAsserts into a single
one with multiple commands listed.
Also to further secure against false positives set -euxo pipefail is
added to the scripts as well.
Also added a new pre-commit check to avoid this in the future.