### PR TITLE
Add a ramdisk-logs sidecar

### DIFF
--- a/templates/ironicconductor/bin/runlogwatch.sh
+++ b/templates/ironicconductor/bin/runlogwatch.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/bash
+
+# Ramdisk logs path
+LOG_DIR=${LOG_DIR:-/var/log/ironic/deploy}
+
+while :; do
+    sleep 5
+
+    while read -r fn; do
+        echo
+        echo "************ Contents of $fn ramdisk log file bundle **************"
+        tar -xOzvvf "$fn" | sed -e "s/^/$(basename "$fn"): /"
+        rm -f "$fn"
+    # find all *.tar.gz files which are older than six seconds
+    done < <(find "${LOG_DIR}" -mmin +0.1 -type f -name "*.tar.gz")
+
+done

--- a/templates/ironicconductor/bin/runlogwatch.sh
+++ b/templates/ironicconductor/bin/runlogwatch.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/bash
+#!/bin//bash
+
+set -eux
 
 # Ramdisk logs path
 LOG_DIR=${LOG_DIR:-/var/log/ironic/deploy}

--- a/templates/ironicconductor/config/ramdisk-logs-config.json
+++ b/templates/ironicconductor/config/ramdisk-logs-config.json
@@ -1,0 +1,10 @@
+{
+    "command": "/usr/local/bin/container-scripts/runlogwatch.sh",
+    "permissions": [
+        {
+            "path": "/var/log/ironic",
+            "owner": "ironic:ironic",
+            "recurse": true
+        }
+    ]
+}

--- a/tests/functional/ironicconductor_controller_test.go
+++ b/tests/functional/ironicconductor_controller_test.go
@@ -276,7 +276,7 @@ var _ = Describe("IronicConductor controller", func() {
 			// Check the resulting deployment fields
 			Expect(int(*depl.Spec.Replicas)).To(Equal(1))
 			Expect(depl.Spec.Template.Spec.Volumes).To(HaveLen(6))
-			Expect(depl.Spec.Template.Spec.Containers).To(HaveLen(2))
+			Expect(depl.Spec.Template.Spec.Containers).To(HaveLen(3))
 
 			// cert deployment volumes
 			th.AssertVolumeExists(ironicNames.CaBundleSecretName.Name, depl.Spec.Template.Spec.Volumes)
@@ -309,7 +309,7 @@ var _ = Describe("IronicConductor controller", func() {
 			// Check the resulting deployment fields
 			Expect(int(*depl.Spec.Replicas)).To(Equal(1))
 			Expect(depl.Spec.Template.Spec.Volumes).To(HaveLen(6))
-			Expect(depl.Spec.Template.Spec.Containers).To(HaveLen(2))
+			Expect(depl.Spec.Template.Spec.Containers).To(HaveLen(3))
 
 			// Grab the current config hash
 			originalHash := GetEnvVarValue(


### PR DESCRIPTION
This implements the runlogwatch.sh approach of metal3[1] to write any deployment logs to the console, making them accessable to the end user via the same mechanism as other openstack service logs.

Jira: [OSPRH-1947](https://issues.redhat.com//browse/OSPRH-1947)

[1] https://github.com/metal3-io/ironic-image/blob/main/scripts/runlogwatch.sh