### PR TITLE
Add missing log mount to ironic-api

### DIFF
--- a/pkg/ironicapi/volumes.go
+++ b/pkg/ironicapi/volumes.go
@@ -62,6 +62,7 @@ func GetVolumeMounts() []corev1.VolumeMount {
 			SubPath:   "ironic-api-config.json",
 			ReadOnly:  true,
 		},
+		GetLogVolumeMount(),
 	}
 
 	return append(ironic.GetVolumeMounts(), volumeMounts...)


### PR DESCRIPTION
ironic-api-log is not currently logging anything because /var/log/ironic is not mounted into the ironic-api container. This change fixes that.

(cherry picked from commit 4597a402a7f2b1dbe76560d9a3def63fd7b4ca9a)
Jira: [OSPRH-10238](https://issues.redhat.com//browse/OSPRH-10238)