### PR TITLE
Make sure to log error in findObjectsForSrc()

### DIFF
--- a/controllers/ironicapi_controller.go
+++ b/controllers/ironicapi_controller.go
@@ -330,7 +330,8 @@ func (r *IronicAPIReconciler) findObjectsForSrc(ctx context.Context, src client.
 		}
 		err := r.List(ctx, crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {

--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -288,7 +288,8 @@ func (r *IronicConductorReconciler) findObjectsForSrc(ctx context.Context, src c
 		}
 		err := r.List(ctx, crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {

--- a/controllers/ironicinspector_controller.go
+++ b/controllers/ironicinspector_controller.go
@@ -370,7 +370,8 @@ func (r *IronicInspectorReconciler) findObjectsForSrc(ctx context.Context, src c
 		}
 		err := r.List(ctx, crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {

--- a/controllers/ironicneutronagent_controller.go
+++ b/controllers/ironicneutronagent_controller.go
@@ -268,7 +268,8 @@ func (r *IronicNeutronAgentReconciler) findObjectsForSrc(ctx context.Context, sr
 		}
 		err := r.List(ctx, crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {


### PR DESCRIPTION
It is hidden right now if there is an error in configured named fields and index. Lets log the error and return the current state of requests.

With this the findObjectsForSrc() will exit with an hidden error like:

```
"error": "Index with name field:.spec.ksmTls.caBundleSecretName does not exist"
```