### PR TITLE
Fix X-Forwarded-Proto in non-TLS deployments

### DIFF
--- a/templates/ironicinspector/config/httpd.conf
+++ b/templates/ironicinspector/config/httpd.conf
@@ -31,7 +31,11 @@ CustomLog /dev/stdout proxy env=forwarded
 
   ## Request header rules
   ## as per http://httpd.apache.org/docs/2.2/mod/mod_headers.html#requestheader
+{{- if $vhost.TLS }}
   RequestHeader set X-Forwarded-Proto "https"
+{{- else }}
+  RequestHeader set X-Forwarded-Proto "http"
+{{- end }}
 
   ## Proxy rules
   ProxyRequests Off


### PR DESCRIPTION
In the httpd container configuration there was an issue that "X-Forwarded-Proto" header was setting "https" protocol always, no matter if TLS was enabled in the deployment or not. It caused issues in neutron server with pagination when TLS was disabled as client was doing request to the "http://" endoint and got in response "https://" links to "next" and "prev" pages.

This patch fixes this issue by setting correct protocol for both cases: TLS and non-TLS.

Related: [OSPRH-10632](https://issues.redhat.com//browse/OSPRH-10632)