### PR TITLE
Automate OLM cleanup for running local operator w/ webhooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,12 +344,11 @@ operator-lint: gowork ## Runs operator-lint
 	go vet -vettool=$(LOCALBIN)/operator-lint ./... ./api/...
 
 # Used for webhook testing
-# Please ensure the ironic-controller-manager deployment and
-# webhook definitions are removed from the csv before running
-# this. Also, cleanup the webhook configuration for local testing
-# before deplying with olm again.
-# $oc delete -n openstack validatingwebhookconfiguration/vironic.kb.io
-# $oc delete -n openstack mutatingwebhookconfiguration/mironic.kb.io
+# The configure_local_webhooks.sh script below will remove any OLM webhooks
+# for the operator and also scale its deployment replicas down to 0 so that
+# the operator can run locally.
+# Make sure to cleanup the webhook configuration for local testing by running
+# ./hack/clean_local_webhook.sh before deplying with OLM again.
 SKIP_CERT ?=false
 .PHONY: run-with-webhook
 run-with-webhook: export METRICS_PORT?=8080

--- a/hack/configure_local_webhook.sh
+++ b/hack/configure_local_webhook.sh
@@ -87,3 +87,11 @@ webhooks:
 EOF_CAT
 
 oc apply -n openstack -f ${TMPDIR}/patch_webhook_configurations.yaml
+
+# Scale-down operator deployment replicas to zero and remove OLM webhooks
+CSV_NAME="$(oc get csv -n openstack-operators -l operators.coreos.com/ironic-operator.openstack-operators -o name)"
+
+if [ -n "${CSV_NAME}" ]; then
+    oc patch "${CSV_NAME}" -n openstack-operators --type=json -p="[{'op': 'replace', 'path': '/spec/install/spec/deployments/0/spec/replicas', 'value': 0}]"
+    oc patch "${CSV_NAME}" -n openstack-operators --type=json -p="[{'op': 'replace', 'path': '/spec/webhookdefinitions', 'value': []}]"
+fi


### PR DESCRIPTION
When using make `run-with-webhook`, local versions of the operator and its webhooks are added to the cluster. If the operator was previously installed via OLM, then there might be lingering webhooks from that installation. We've previously been assuming that the user would manually remove them, but we should just get rid of them ourselves since those OLM webhooks need to be deleted anyhow for the local webhooks to function unimpeded.  We can also automatically scale down the operator's OLM deployment in such a scenario.