### PR TITLE
Fix default network interface

### DIFF
--- a/templates/common/config/ironic.conf
+++ b/templates/common/config/ironic.conf
@@ -20,8 +20,7 @@ enabled_vendor_interfaces = no-vendor,ipmitool,idrac-redfish,redfish,ilo,fake
 # https://review.opendev.org/c/openstack/ironic/+/907269
 rbac_service_role_elevated_access=true
 
-{{/* TODO switch to neutron provider for the non-standalone when neutron-operator is available */}}
-default_network_interface={{if .Standalone}}noop{{else}}noop{{end}}
+{{if .Standalone}}default_network_interface=noop{{end}}
 
 default_resource_class=baremetal
 hash_ring_algorithm=sha256


### PR DESCRIPTION
The default interface parameter inadvertently set the default for all newly created nodes, unless they otherwise specify a network interface, to be "noop", which is only usable for standalone users.

Integrated users want flat, or neutron. Given historical usage pattern, the existing defaults set via "enabled_network_interfaces" to use flat, neutron, or noop, in that order, are generally applicable.

Jira: [OSPRH-10697](https://issues.redhat.com//browse/OSPRH-10697)