### PR TITLE
Remove idrac-wsman drivers from configured list

### DIFF
--- a/templates/common/config/ironic.conf
+++ b/templates/common/config/ironic.conf
@@ -1,20 +1,20 @@
 [DEFAULT]
 enabled_hardware_types=ipmi,idrac,irmc,fake-hardware,redfish,manual-management,ilo,ilo5
-enabled_bios_interfaces=idrac-wsman,no-bios,redfish,idrac-redfish,irmc,ilo
+enabled_bios_interfaces=no-bios,redfish,idrac-redfish,irmc,ilo
 enabled_boot_interfaces=ipxe,ilo-ipxe,pxe,ilo-pxe,fake,redfish-virtual-media,idrac-redfish-virtual-media,ilo-virtual-media
 enabled_console_interfaces=ipmitool-socat,ilo,no-console,fake
 enabled_deploy_interfaces=direct,fake,ramdisk,custom-agent
 default_deploy_interface = direct
-enabled_inspect_interfaces=inspector,no-inspect,idrac,irmc,fake,redfish,ilo
+enabled_inspect_interfaces=inspector,no-inspect,irmc,fake,redfish,ilo
 default_inspect_interface=inspector
-enabled_management_interfaces=ipmitool,idrac,irmc,fake,redfish,idrac-redfish,ilo,ilo5,noop
+enabled_management_interfaces=ipmitool,irmc,fake,redfish,idrac-redfish,ilo,ilo5,noop
 enabled_network_interfaces=flat,neutron,noop
-enabled_power_interfaces=ipmitool,idrac,irmc,fake,redfish,idrac-redfish,ilo
-enabled_raid_interfaces=no-raid,irmc,agent,fake,idrac-wsman,ilo5
+enabled_power_interfaces=ipmitool,irmc,fake,redfish,idrac-redfish,ilo
+enabled_raid_interfaces=no-raid,irmc,agent,fake,ilo5
 enabled_rescue_interfaces=no-rescue,agent
 default_rescue_interface=agent
 enabled_storage_interfaces=noop,fake
-enabled_vendor_interfaces = no-vendor,ipmitool,idrac,idrac-redfish,redfish,ilo,fake
+enabled_vendor_interfaces = no-vendor,ipmitool,idrac-redfish,redfish,ilo,fake
 # This is a knob to allow service role users from the service project
 # to have "elevated" API access to see the whole of the API surface.
 # https://review.opendev.org/c/openstack/ironic/+/907269


### PR DESCRIPTION
Dracclient has been removed from the container images[1] and
ironic-conductor will not start if wsman drivers are in then enabled
list. This change removes them.

[1] https://github.com/openstack-k8s-operators/tcib/pull/224
Jira: [OSPRH-11193](https://issues.redhat.com//browse/OSPRH-11193)