### PR TITLE
Ensure nodeSelector logic is consistent for all operators

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -32,7 +32,7 @@ type IronicServiceTemplate struct {
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service. Setting here overrides
 	// any global NodeSelector settings within the Ironic CR
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// Resources - Compute Resources required by this service (Limits/Requests).

--- a/api/v1beta1/ironic_types.go
+++ b/api/v1beta1/ironic_types.go
@@ -142,7 +142,7 @@ type IronicSpecCore struct {
 	// NodeSelector to target subset of worker nodes running this service. Setting
 	// NodeSelector here acts as a default value and can be overridden by service
 	// specific NodeSelector Settings.
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
 
 	// Storage class to host data. This is passed to IronicConductors unless
 	// storageClass is explicitly set for the conductor.

--- a/api/v1beta1/ironicinspector_types.go
+++ b/api/v1beta1/ironicinspector_types.go
@@ -62,7 +62,7 @@ type IronicInspectorTemplate struct {
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service. Setting here overrides
 	// any global NodeSelector settings within the Ironic CR
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=true

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -614,9 +614,13 @@ func (in *IronicInspectorTemplate) DeepCopyInto(out *IronicInspectorTemplate) {
 	out.PasswordSelectors = in.PasswordSelectors
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		*out = new(map[string]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string]string, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val
+			}
 		}
 	}
 	if in.DefaultConfigOverwrite != nil {
@@ -815,9 +819,13 @@ func (in *IronicServiceTemplate) DeepCopyInto(out *IronicServiceTemplate) {
 	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		*out = new(map[string]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string]string, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val
+			}
 		}
 	}
 	in.Resources.DeepCopyInto(&out.Resources)
@@ -880,9 +888,13 @@ func (in *IronicSpecCore) DeepCopyInto(out *IronicSpecCore) {
 	in.IronicNeutronAgent.DeepCopyInto(&out.IronicNeutronAgent)
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		*out = new(map[string]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string]string, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val
+			}
 		}
 	}
 }

--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -778,6 +778,11 @@ func (r *IronicReconciler) conductorDeploymentCreateOrUpdate(
 		KeystoneEndpoints:       *keystoneEndpoints,
 		TLS:                     instance.Spec.IronicAPI.TLS.Ca,
 	}
+
+	if IronicConductorSpec.NodeSelector == nil {
+		IronicConductorSpec.NodeSelector = instance.Spec.NodeSelector
+	}
+
 	deployment := &ironicv1.IronicConductor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -787,9 +792,6 @@ func (r *IronicReconciler) conductorDeploymentCreateOrUpdate(
 
 	op, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, deployment, func() error {
 		deployment.Spec = IronicConductorSpec
-		if len(deployment.Spec.NodeSelector) == 0 {
-			deployment.Spec.NodeSelector = instance.Spec.NodeSelector
-		}
 		if deployment.Spec.StorageClass == "" {
 			deployment.Spec.StorageClass = instance.Spec.StorageClass
 		}
@@ -822,6 +824,10 @@ func (r *IronicReconciler) apiDeploymentCreateOrUpdate(
 		KeystoneEndpoints:  *keystoneEndpoints,
 	}
 
+	if IronicAPISpec.NodeSelector == nil {
+		IronicAPISpec.NodeSelector = instance.Spec.NodeSelector
+	}
+
 	deployment := &ironicv1.IronicAPI{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-api", instance.Name),
@@ -831,9 +837,6 @@ func (r *IronicReconciler) apiDeploymentCreateOrUpdate(
 
 	op, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, deployment, func() error {
 		deployment.Spec = IronicAPISpec
-		if len(deployment.Spec.NodeSelector) == 0 {
-			deployment.Spec.NodeSelector = instance.Spec.NodeSelector
-		}
 		err := controllerutil.SetControllerReference(instance, deployment, r.Scheme)
 		if err != nil {
 			return err
@@ -977,6 +980,11 @@ func (r *IronicReconciler) inspectorDeploymentCreateOrUpdate(
 		RabbitMqClusterName:     instance.Spec.RabbitMqClusterName,
 		Secret:                  instance.Spec.Secret,
 	}
+
+	if IronicInspectorSpec.NodeSelector == nil {
+		IronicInspectorSpec.NodeSelector = instance.Spec.NodeSelector
+	}
+
 	deployment := &ironicv1.IronicInspector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-inspector", instance.Name),
@@ -987,9 +995,6 @@ func (r *IronicReconciler) inspectorDeploymentCreateOrUpdate(
 	op, err := controllerutil.CreateOrUpdate(
 		context.TODO(), r.Client, deployment, func() error {
 			deployment.Spec = IronicInspectorSpec
-			if len(deployment.Spec.NodeSelector) == 0 {
-				deployment.Spec.NodeSelector = instance.Spec.NodeSelector
-			}
 			err := controllerutil.SetControllerReference(
 				instance, deployment, r.Scheme)
 			if err != nil {
@@ -1046,6 +1051,11 @@ func (r *IronicReconciler) ironicNeutronAgentDeploymentCreateOrUpdate(
 		ServiceUser:                instance.Spec.ServiceUser,
 		TLS:                        instance.Spec.IronicAPI.TLS.Ca,
 	}
+
+	if IronicNeutronAgentSpec.NodeSelector == nil {
+		IronicNeutronAgentSpec.NodeSelector = instance.Spec.NodeSelector
+	}
+
 	deployment := &ironicv1.IronicNeutronAgent{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-ironic-neutron-agent", instance.Name),
@@ -1056,9 +1066,6 @@ func (r *IronicReconciler) ironicNeutronAgentDeploymentCreateOrUpdate(
 	op, err := controllerutil.CreateOrUpdate(
 		context.TODO(), r.Client, deployment, func() error {
 			deployment.Spec = IronicNeutronAgentSpec
-			if len(deployment.Spec.NodeSelector) == 0 {
-				deployment.Spec.NodeSelector = instance.Spec.NodeSelector
-			}
 			err := controllerutil.SetControllerReference(
 				instance, deployment, r.Scheme)
 			if err != nil {

--- a/pkg/ironic/dbsync.go
+++ b/pkg/ironic/dbsync.go
@@ -95,5 +95,9 @@ func DbSyncJob(
 	}
 	job.Spec.Template.Spec.InitContainers = InitContainer(initContainerDetails)
 
+	if instance.Spec.NodeSelector != nil {
+		job.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
+	}
+
 	return job
 }

--- a/pkg/ironicapi/deployment.go
+++ b/pkg/ironicapi/deployment.go
@@ -187,8 +187,8 @@ func Deployment(
 		},
 		corev1.LabelHostname,
 	)
-	if instance.Spec.NodeSelector != nil && len(instance.Spec.NodeSelector) > 0 {
-		deployment.Spec.Template.Spec.NodeSelector = instance.Spec.NodeSelector
+	if instance.Spec.NodeSelector != nil {
+		deployment.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 
 	initContainerDetails := ironic.APIDetails{

--- a/pkg/ironicconductor/statefulset.go
+++ b/pkg/ironicconductor/statefulset.go
@@ -316,8 +316,8 @@ func StatefulSet(
 		},
 		corev1.LabelHostname,
 	)
-	if instance.Spec.NodeSelector != nil && len(instance.Spec.NodeSelector) > 0 {
-		statefulset.Spec.Template.Spec.NodeSelector = instance.Spec.NodeSelector
+	if instance.Spec.NodeSelector != nil {
+		statefulset.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 
 	// init.sh needs to detect and set ProvisionNetworkIP

--- a/pkg/ironicinspector/dbsync.go
+++ b/pkg/ironicinspector/dbsync.go
@@ -96,5 +96,9 @@ func DbSyncJob(
 	}
 	job.Spec.Template.Spec.InitContainers = InitContainer(initContainerDetails)
 
+	if instance.Spec.NodeSelector != nil {
+		job.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
+	}
+
 	return job
 }

--- a/pkg/ironicinspector/statefulset.go
+++ b/pkg/ironicinspector/statefulset.go
@@ -327,8 +327,8 @@ func StatefulSet(
 		[]string{ironic.ServiceName},
 		corev1.LabelHostname,
 	)
-	if instance.Spec.NodeSelector != nil && len(instance.Spec.NodeSelector) > 0 {
-		statefulset.Spec.Template.Spec.NodeSelector = instance.Spec.NodeSelector
+	if instance.Spec.NodeSelector != nil {
+		statefulset.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 
 	// init.sh needs to detect and set InspectionNetworkIP

--- a/pkg/ironicneutronagent/deployment.go
+++ b/pkg/ironicneutronagent/deployment.go
@@ -128,8 +128,8 @@ func Deployment(
 		},
 		corev1.LabelHostname,
 	)
-	if instance.Spec.NodeSelector != nil && len(instance.Spec.NodeSelector) > 0 {
-		deployment.Spec.Template.Spec.NodeSelector = instance.Spec.NodeSelector
+	if instance.Spec.NodeSelector != nil {
+		deployment.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 
 	initContainerDetails := APIDetails{

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -234,13 +234,16 @@ func GetIronicNames(
 		},
 		InternalCertSecretName: types.NamespacedName{
 			Namespace: ironicName.Namespace,
-			Name:      "internal-tls-certs"},
+			Name:      "internal-tls-certs",
+		},
 		PublicCertSecretName: types.NamespacedName{
 			Namespace: ironicName.Namespace,
-			Name:      "public-tls-certs"},
+			Name:      "public-tls-certs",
+		},
 		CaBundleSecretName: types.NamespacedName{
 			Namespace: ironicName.Namespace,
-			Name:      "combined-ca-bundle"},
+			Name:      "combined-ca-bundle",
+		},
 	}
 }
 


### PR DESCRIPTION
nodeSelectors are not currently applied consistently across all operators.

Some do not support nodeSelectors at all - will be implemented in this series of pull requests.
Some do not apply them to every pod (jobs/cronjobs esp) - will be resolved in this series of pull requests.
Some do not apply a node selector update correctly, only when not initially set.
Some support nodeSelectors but do not inherit the default nodeSelector from the OpenstackControlPlane CR.

Jira: [OSPRH-10734](https://issues.redhat.com//browse/OSPRH-10734)