### PR TITLE
Fix ironic-python-agent - CA bundle inject

### DIFF
--- a/templates/common/bin/pxe-init.sh
+++ b/templates/common/bin/pxe-init.sh
@@ -54,7 +54,7 @@ if [ -f "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" ] && [ -f "/var/lib/
     popd
 
     # Copy the CA certificates
-    cp /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /initramfs/etc/pki/ca-trust/extracted/pem/
+    cp /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /initramfs/etc/pki/ca-trust/source/anchors/
     echo update-ca-trust | unshare -r chroot ./initramfs
 
     # Repack the initramfs


### PR DESCRIPTION
Currently the pxe-init script copies the certificate bundle directly to `/etc/pki/ca-trust/extracted `in the initramfs. When `update-ca-trust` runs under chroot the contents under `pki/ca-trust/extracted` is overwritten. See manual page: update-ca-trust(8) "EXTRACTED CONFIGURATION" section.
    
With this change the bundle is copied to `/etc/pki/ca-trust/source/anchor`s directory in the initramfs instead, so that `update-ca-trust` will find the source and update CA certs and trusts correctly.


Jira: [OSPRH-12526](https://issues.redhat.com//browse/OSPRH-12526)