### PR TITLE
Fix httpd config for X-Forwarded-Proto Jira: <OSPRH-12377>

### DIFF
--- a/templates/ironicapi/config/ironic-api-httpd.conf
+++ b/templates/ironicapi/config/ironic-api-httpd.conf
@@ -39,14 +39,16 @@ CustomLog /dev/stdout proxy env=forwarded
     Require all granted
   </Directory>
 
-{{- if $vhost.TLS }}
+  {{- if $vhost.TLS }}
   SetEnvIf X-Forwarded-Proto https HTTPS=1
 
   ## SSL directives
   SSLEngine on
   SSLCertificateFile      "{{ $vhost.SSLCertificateFile }}"
   SSLCertificateKeyFile   "{{ $vhost.SSLCertificateKeyFile }}"
-{{- end }}
+  {{- else }}
+  SetEnvIf X-Forwarded-Proto http HTTPS=0
+  {{- end }}
 
   ## WSGI configuration
   WSGIApplicationGroup %{GLOBAL}

--- a/templates/ironicinspector/config/httpd.conf
+++ b/templates/ironicinspector/config/httpd.conf
@@ -30,8 +30,12 @@ CustomLog /dev/stdout proxy env=forwarded
   ServerName {{ $vhost.ServerName }}
 
   ## Request header rules
-  ## as per http://httpd.apache.org/docs/2.2/mod/mod_headers.html#requestheader
-  RequestHeader set X-Forwarded-Proto "https"
+  ## as per http://httpd.apache.org/docs/2.4/mod/mod_headers.html#requestheader
+  {{- if $vhost.TLS }}
+  RequestHeader setIfEmpty X-Forwarded-Proto "https"
+  {{- else }}
+  RequestHeader setIfEmpty X-Forwarded-Proto "http"
+  {{- end }}
 
   ## Proxy rules
   ProxyRequests Off
@@ -39,13 +43,15 @@ CustomLog /dev/stdout proxy env=forwarded
   ProxyPass / http://localhost:5051/ retry=10
   ProxyPassReverse / http://localhost:5051/
 
-{{- if $vhost.TLS }}
+  {{- if $vhost.TLS }}
   SetEnvIf X-Forwarded-Proto https HTTPS=1
 
   ## SSL directives
   SSLEngine on
   SSLCertificateFile      "{{ $vhost.SSLCertificateFile }}"
   SSLCertificateKeyFile   "{{ $vhost.SSLCertificateKeyFile }}"
-{{- end }}
+  {{- else }}
+  SetEnvIf X-Forwarded-Proto http HTTPS=0
+  {{- end }}
 </VirtualHost>
 {{ end }}


### PR DESCRIPTION
- Fix httpd RequestHeader setting for non-TLS deployment
- Update comment pointing to RequestHeader directive syntax

Jira: [OSPRH-12377](https://issues.redhat.com/browse/OSPRH-12377)