### PR TITLE
Add configurable API Timeouts <JIRA: OSPRH-10958>

### DIFF
--- a/api/bases/ironic.openstack.org_ironicapis.yaml
+++ b/api/bases/ironic.openstack.org_ironicapis.yaml
@@ -52,6 +52,11 @@ spec:
           spec:
             description: IronicAPISpec defines the desired state of IronicAPI
             properties:
+              apiTimeout:
+                default: 60
+                description: APITimeout for HAProxy, Apache
+                minimum: 10
+                type: integer
               containerImage:
                 description: ContainerImage - Ironic API Container Image
                 type: string

--- a/api/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/api/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -52,6 +52,11 @@ spec:
           spec:
             description: IronicInspectorSpec defines the desired state of IronicInspector
             properties:
+              apiTimeout:
+                default: 60
+                description: APITimeout for HAProxy, Apache
+                minimum: 10
+                type: integer
               containerImage:
                 description: ContainerImage - Ironic Inspector Container Image
                 type: string

--- a/api/bases/ironic.openstack.org_ironics.yaml
+++ b/api/bases/ironic.openstack.org_ironics.yaml
@@ -48,6 +48,11 @@ spec:
           spec:
             description: IronicSpec defines the desired state of Ironic
             properties:
+              apiTimeout:
+                default: 60
+                description: APITimeout for HAProxy, Apache
+                minimum: 10
+                type: integer
               customServiceConfig:
                 default: '# add your customization here'
                 description: |-

--- a/api/v1beta1/ironic_types.go
+++ b/api/v1beta1/ironic_types.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 )
 
 const (
@@ -155,6 +155,12 @@ type IronicSpecCore struct {
 	// TopologyRef to apply the Topology defined by the associated CR referenced
 	// by name
 	TopologyRef *topologyv1.TopoRef `json:"topologyRef,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=60
+	// +kubebuilder:validation:Minimum=10
+	// APITimeout for HAProxy, Apache
+	APITimeout int `json:"apiTimeout"`
 }
 
 // IronicImages to specify container images required by all ironic services

--- a/api/v1beta1/ironicapi_types.go
+++ b/api/v1beta1/ironicapi_types.go
@@ -105,6 +105,12 @@ type IronicAPISpec struct {
 	// +kubebuilder:validation:Optional
 	// KeystoneEndpoints - Internally used Keystone API endpoints
 	KeystoneEndpoints KeystoneEndpoints `json:"keystoneEndpoints"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=60
+	// +kubebuilder:validation:Minimum=10
+	// APITimeout for HAProxy, Apache
+	APITimeout int `json:"apiTimeout"`
 }
 
 // IronicAPIStatus defines the observed state of IronicAPI

--- a/api/v1beta1/ironicinspector_types.go
+++ b/api/v1beta1/ironicinspector_types.go
@@ -172,6 +172,12 @@ type IronicInspectorSpec struct {
 	// or 'json-rpc' to use JSON RPC transport. NOTE -> ironic-inspector
 	// requires oslo.messaging transport when not in standalone mode.
 	RPCTransport string `json:"rpcTransport"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=60
+	// +kubebuilder:validation:Minimum=10
+	// APITimeout for HAProxy, Apache
+	APITimeout int `json:"apiTimeout"`
 }
 
 // IronicInspectorStatus defines the observed state of IronicInspector

--- a/config/crd/bases/ironic.openstack.org_ironicapis.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicapis.yaml
@@ -52,6 +52,11 @@ spec:
           spec:
             description: IronicAPISpec defines the desired state of IronicAPI
             properties:
+              apiTimeout:
+                default: 60
+                description: APITimeout for HAProxy, Apache
+                minimum: 10
+                type: integer
               containerImage:
                 description: ContainerImage - Ironic API Container Image
                 type: string

--- a/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicinspectors.yaml
@@ -52,6 +52,11 @@ spec:
           spec:
             description: IronicInspectorSpec defines the desired state of IronicInspector
             properties:
+              apiTimeout:
+                default: 60
+                description: APITimeout for HAProxy, Apache
+                minimum: 10
+                type: integer
               containerImage:
                 description: ContainerImage - Ironic Inspector Container Image
                 type: string

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -48,6 +48,11 @@ spec:
           spec:
             description: IronicSpec defines the desired state of Ironic
             properties:
+              apiTimeout:
+                default: 60
+                description: APITimeout for HAProxy, Apache
+                minimum: 10
+                type: integer
               customServiceConfig:
                 default: '# add your customization here'
                 description: |-

--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -839,6 +839,10 @@ func (r *IronicReconciler) apiDeploymentCreateOrUpdate(
 		IronicAPISpec.TopologyRef = instance.Spec.TopologyRef
 	}
 
+	if IronicAPISpec.APITimeout == 0 {
+		IronicAPISpec.APITimeout = instance.Spec.APITimeout
+	}
+
 	deployment := &ironicv1.IronicAPI{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-api", instance.Name),
@@ -909,6 +913,7 @@ func (r *IronicReconciler) generateServiceConfigMaps(
 	}
 	templateParameters["Standalone"] = instance.Spec.Standalone
 	templateParameters["LogPath"] = ironic.LogPath
+	templateParameters["APITimeout"] = instance.Spec.APITimeout
 
 	databaseAccount := db.GetAccount()
 	dbSecret := db.GetSecret()
@@ -1000,6 +1005,10 @@ func (r *IronicReconciler) inspectorDeploymentCreateOrUpdate(
 	// inherit from the top-level CR
 	if IronicInspectorSpec.TopologyRef == nil {
 		IronicInspectorSpec.TopologyRef = instance.Spec.TopologyRef
+	}
+
+	if IronicInspectorSpec.APITimeout == 0 {
+		IronicInspectorSpec.APITimeout = instance.Spec.APITimeout
 	}
 
 	deployment := &ironicv1.IronicInspector{

--- a/controllers/ironicapi_controller.go
+++ b/controllers/ironicapi_controller.go
@@ -1083,6 +1083,7 @@ func (r *IronicAPIReconciler) generateServiceConfigMaps(
 			endptConfig["SSLCertificateFile"] = fmt.Sprintf("/etc/pki/tls/certs/%s.crt", endpt.String())
 			endptConfig["SSLCertificateKeyFile"] = fmt.Sprintf("/etc/pki/tls/private/%s.key", endpt.String())
 		}
+		endptConfig["TimeOut"] = instance.Spec.APITimeout
 		httpdVhostConfig[endpt.String()] = endptConfig
 	}
 	templateParameters["VHosts"] = httpdVhostConfig

--- a/controllers/ironicinspector_controller.go
+++ b/controllers/ironicinspector_controller.go
@@ -1523,6 +1523,7 @@ func (r *IronicInspectorReconciler) generateServiceConfigMaps(
 		httpdVhostConfig[endpt.String()] = endptConfig
 	}
 	templateParameters["VHosts"] = httpdVhostConfig
+	templateParameters["TimeOut"] = instance.Spec.APITimeout
 
 	cms := []util.Template{
 		// Scripts ConfigMap

--- a/templates/ironicapi/config/ironic-api-httpd.conf
+++ b/templates/ironicapi/config/ironic-api-httpd.conf
@@ -56,5 +56,7 @@ CustomLog /dev/stdout proxy env=forwarded
   WSGIProcessGroup {{ $endpt }}
   WSGIScriptAlias / "/var/www/cgi-bin/ironic/app"
   WSGIPassAuthorization On
+
+  TimeOut {{ $vhost.TimeOut }}
 </VirtualHost>
 {{ end }}

--- a/templates/ironicinspector/config/httpd.conf
+++ b/templates/ironicinspector/config/httpd.conf
@@ -53,5 +53,7 @@ CustomLog /dev/stdout proxy env=forwarded
   {{- else }}
   SetEnvIf X-Forwarded-Proto http HTTPS=0
   {{- end }}
+
+  TimeOut {{ $.TimeOut }}
 </VirtualHost>
 {{ end }}


### PR DESCRIPTION
- Added apiTimeout property to ironic api with default set to 60 seconds

Jira: [OSPRH-10958](https://issues.redhat.com/browse/OSPRH-10958)