### PR TITLE
Do not use MustParse to process PVC size

### DIFF
--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -719,8 +719,12 @@ func (r *IronicConductorReconciler) reconcileNormal(ctx context.Context, instanc
 	}
 
 	// Define a new StatefulSet object
+	ssSpec, err := ironicconductor.StatefulSet(instance, inputHash, serviceLabels, ingressDomain, serviceAnnotations, topology)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 	ss := statefulset.NewStatefulSet(
-		ironicconductor.StatefulSet(instance, inputHash, serviceLabels, ingressDomain, serviceAnnotations, topology),
+		ssSpec,
 		time.Duration(5)*time.Second,
 	)
 


### PR DESCRIPTION
The `resource.MustParse` function was previously used by the operator to process the `storageSize` request provided by the top-level CR. However, even though `defer()` and `recover()` can be used to handle the `panic()` generated by  the wrong user input, that approach doesn't seem to work properly and the operator crashes without any chance to recover. The `ParseQuantity` implementation returns an `error` instead of `panic()`, and it can be easily caught at the operator level. This change moves away from the `MustParse` usage and relies on the `ParseQuantity` mechanism.