### PR TITLE
Allow master ironic to run on ironic-operator

### DIFF
--- a/pkg/ironic/dbsync.go
+++ b/pkg/ironic/dbsync.go
@@ -71,7 +71,7 @@ func DbSyncJob(
 								"/bin/bash",
 							},
 							Args:  args,
-							Image: instance.Spec.Images.API,
+							Image: instance.Spec.Images.Conductor,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: &runAsUser,
 							},

--- a/templates/ironic/bin/dbsync.sh
+++ b/templates/ironic/bin/dbsync.sh
@@ -16,6 +16,15 @@
 set -ex
 
 /usr/local/bin/kolla_set_configs
+
+# prepare for 'upgrade check' loading all drivers
+if [ ! -d "/var/lib/ironic/tmp" ]; then
+    mkdir /var/lib/ironic/tmp
+fi
+if [ ! -d "/var/lib/ironic/httpboot" ]; then
+    mkdir -p /var/lib/ironic/httpboot
+fi
+
 ironic-status upgrade check && ret_val=$? || ret_val=$?
 if [ $ret_val -gt 1 ] ; then
     # NOTE(TheJulia): We need to evaluate the return code from the

--- a/templates/ironic/bin/dbsync.sh
+++ b/templates/ironic/bin/dbsync.sh
@@ -27,7 +27,8 @@ if [ $ret_val -gt 1 ] ; then
     ironic-dbsync --config-file=/etc/ironic/ironic.conf upgrade
     ironic-status upgrade check && ret_val=$? || ret_val=$?
     if [ $ret_val -gt 1 ] ; then
-        die $LINENO "Ironic DB Status check failed, returned: $ret_val"
+        echo $LINENO "Ironic DB Status check failed, returned: $ret_val"
+        exit $ret_val
     fi
 fi
 ironic-dbsync --config-file /etc/ironic/ironic.conf


### PR DESCRIPTION
These are the changes required to get master ironic to be run by ironic-operator. To deploy master ironic, an OpenStackVersion resource needs to be created:

```
$ cat custom/osv_ironic_master.yaml 
apiVersion: core.openstack.org/v1beta1
kind: OpenStackVersion
metadata:
  # the name must match the name of the already deployed OpenStackControlPlane resource
  name: openstack-galera-network-isolation-ironic
  namespace: openstack
spec:
  customContainerImages:
    ironicAPIImage: quay.io/podified-master-centos9/openstack-ironic-api:current-podified
    ironicConductorImage: quay.io/podified-master-centos9/openstack-ironic-conductor:current-podified
    ironicInspectorImage: quay.io/podified-master-centos9/openstack-ironic-inspector:current-podified
    ironicNeutronAgentImage: quay.io/podified-master-centos9/openstack-ironic-neutron-agent:current-podified
    ironicPxeImage: quay.io/podified-master-centos9/openstack-ironic-pxe:current-podified
    ironicPythonAgentImage: quay.io/podified-master-centos9/ironic-python-agent:current-podified

$ oc apply -f ./custom/osv_ironic_master.yaml
```