### PR TITLE
Fix race condition - envsubst $file | tee $file

### DIFF
--- a/templates/ironicinspector/bin/inspector-pxe-init.sh
+++ b/templates/ironicinspector/bin/inspector-pxe-init.sh
@@ -33,10 +33,19 @@ sed -e "/BLOCK_PODINDEX_${PODINDEX}_BEGIN/,/BLOCK_PODINDEX_${PODINDEX}_END/p" \
 sed -e "/BLOCK_PODINDEX_${PODINDEX}_BEGIN/d" \
     -e "/BLOCK_PODINDEX_${PODINDEX}_END/d" \
     -i ${DNSMASQ_CFG}
-envsubst < ${DNSMASQ_CFG} | tee ${DNSMASQ_CFG}
+
+# OSPCIX-870: Copy the config to tempdir to avoid race condition where pipe to
+#             tee may wipe the file.
+export TMP_DNSMASQ_CFG=/var/tmp/dnsmasq.conf
+cp ${DNSMASQ_CFG} ${TMP_DNSMASQ_CFG}
+envsubst < ${TMP_DNSMASQ_CFG} | tee ${DNSMASQ_CFG}
 
 export INSPECTOR_IPXE=/var/lib/ironic/inspector.ipxe
-envsubst < ${INSPECTOR_IPXE} | tee ${INSPECTOR_IPXE}
+# OSPCIX-870: Copy the config to tempdir to avoid race condition where pipe to
+#             tee may wipe the file.
+export TMP_INSPECTOR_IPXE=/var/tmp/inspector.ipxe
+cp ${INSPECTOR_IPXE} ${TMP_INSPECTOR_IPXE}
+envsubst < ${TMP_INSPECTOR_IPXE} | tee ${INSPECTOR_IPXE}
 
 # run common pxe-init script
 /usr/local/bin/container-scripts/pxe-init.sh


### PR DESCRIPTION
When running `envsubst $file` and pipe to `tee $file` there is a race causing the target file to be wiped.

The following script can be used to reproduce the race condition:
```
  #!/bin/sh
  echo -e "foo\nbar\nbaz" > /tmp/test_file
  count=0
  while [ -s /tmp/test_file ]; do
    envsubst < /tmp/test_file | tee /tmp/test_file > /dev/null
    ((count+=1))
  done

  if [ ! -s /tmp/test_file ]; then
    echo "File was wiped after $count run's of:  envsubst < \$file | tee \$file"
  fi
```

```
$ sh test.sh
File was wiped after 16 run's of:  envsubst < $file | tee $file
$ sh test.sh
File was wiped after 42 run's of:  envsubst < $file | tee $file
$ sh test.sh
File was wiped after 37 run's of:  envsubst < $file | tee $file
$ sh test.sh
File was wiped after 73 run's of:  envsubst < $file | tee $file
$ sh test.sh
File was wiped after 4 run's of:  envsubst < $file | tee $file
```

Jira: [OSPRH-17012](https://issues.redhat.com//browse/OSPRH-17012)
Jira: [OSPCIX-870](https://issues.redhat.com//browse/OSPCIX-870)