### PR TITLE
Kill ramdisk-logs inotifywait as a pre-stop command

### DIFF
--- a/pkg/ironicconductor/statefulset.go
+++ b/pkg/ironicconductor/statefulset.go
@@ -226,6 +226,18 @@ func StatefulSet(
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser: &runAsUser,
 		},
+		// inotifywait doesn't terminate on SIGTERM so call SIGKILL as a
+		// pre-stop command
+		Lifecycle: &corev1.Lifecycle{
+			PreStop: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"/usr/bin/pkill",
+						"inotifywait",
+					},
+				},
+			},
+		},
 	}
 
 	containers := []corev1.Container{

--- a/pkg/ironicinspector/statefulset.go
+++ b/pkg/ironicinspector/statefulset.go
@@ -259,6 +259,18 @@ func StatefulSet(
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser: &runAsUser,
 		},
+		// inotifywait doesn't terminate on SIGTERM so call SIGKILL as a
+		// pre-stop command
+		Lifecycle: &corev1.Lifecycle{
+			PreStop: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"/usr/bin/pkill",
+						"inotifywait",
+					},
+				},
+			},
+		},
 	}
 	containers = append(containers, ramdiskLogsContainer)
 


### PR DESCRIPTION
Currently the conductor and inspector pods do not exit gracefully and are killed after the 60 second timeout. This is because the runlogwatch.sh inotifywait doesn't terminate on SIGTERM.

This change makes the pod exit gracefully by killing inotifywait in a ramdisk-logs pre-stop command.

Jira: [OSPRH-16204](https://issues.redhat.com//browse/OSPRH-16204)