### PR TITLE
Fix CrashLoopBackOff, ramdisk-logs no inotifywait

### DIFF
--- a/templates/common/bin/runlogwatch.sh
+++ b/templates/common/bin/runlogwatch.sh
@@ -3,6 +3,13 @@
 # Ramdisk logs path
 LOG_DIR=${LOG_DIR:-/var/lib/ironic/ramdisk-logs}
 
+# NOTE(hjensas): OSPRH-17520
+if ! command -v inotifywait; then
+    echo "WARNING: ramdisk-logs will not be captured, because the inotifywait command is missing. Please patch the OpenstackVersion to update container images."
+    # Start a tail on /dev/null to do nothing forever
+    tail -f /dev/null
+fi
+
 inotifywait -m "${LOG_DIR}" -e close_write |
     while read -r path _action file; do
         echo "************ Contents of ${path}${file} ramdisk log file bundle **************"


### PR DESCRIPTION
When updating the operators we end up recreating the conductor and inspector deployments. But the old service images does not yet have the required command: `inotifywait` - because of the missing command the pod enter `CrashLoopBackOff` state.

To resolve the issue, the `OpenstackVersion` must be patch to update the container images.

To workaround this issue, add a check for the `inotifywait` command, and in case it does not exist:
  * a) Print a Warning
  * b) Starta a tail for follow /dev/null (`tail -f /dev/null`) to have the container do nothing forever. 
         _(e.g. until it is restarted with new service container images after patching the `OpenstackVersion`.)_

Jira: OSPRH-17520