### PR TITLE
Fix customServiceConfig bug <Jira: OSPRH-10696>

### DIFF
--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -935,8 +935,8 @@ func (r *IronicReconciler) generateServiceConfigMaps(
 	// all other files get placed into /etc/ironic to allow overwrite of e.g. policy.json
 	// TODO: make sure custom.conf can not be overwritten
 	customData := map[string]string{
-		common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig,
-		"my.cnf":                           db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
+		"01-ironic-custom.conf": instance.Spec.CustomServiceConfig,
+		"my.cnf":                db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
 
 	}
 	for key, data := range instance.Spec.DefaultConfigOverwrite {

--- a/pkg/ironicapi/volumes.go
+++ b/pkg/ironicapi/volumes.go
@@ -1,6 +1,9 @@
 package ironicapi
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/openstack-k8s-operators/ironic-operator/pkg/ironic"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -8,14 +11,14 @@ import (
 // GetVolumes -
 func GetVolumes(name string) []corev1.Volume {
 	var config0640AccessMode int32 = 0640
-
+	parentName := strings.Replace(name, "-api", "", 1)
 	apiVolumes := []corev1.Volume{
 		{
 			Name: "config-data-custom",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &config0640AccessMode,
-					SecretName:  name + "-config-data",
+					SecretName:  fmt.Sprintf("%s-config-data", parentName),
 				},
 			},
 		},

--- a/pkg/ironicconductor/volumes.go
+++ b/pkg/ironicconductor/volumes.go
@@ -2,6 +2,7 @@ package ironicconductor
 
 import (
 	"fmt"
+	"strings"
 
 	ironicv1 "github.com/openstack-k8s-operators/ironic-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/ironic-operator/pkg/ironic"
@@ -11,13 +12,15 @@ import (
 // GetVolumes -
 func GetVolumes(instance *ironicv1.IronicConductor) []corev1.Volume {
 	var config0640AccessMode int32 = 0640
+	parentName := strings.Replace(instance.Name, "-conductor", "", 1)
+
 	conductorVolumes := []corev1.Volume{
 		{
 			Name: "config-data-custom",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &config0640AccessMode,
-					SecretName:  fmt.Sprintf("%s-config-data", instance.Name),
+					SecretName:  fmt.Sprintf("%s-config-data", parentName),
 				},
 			},
 		},

--- a/templates/common/bin/common.sh
+++ b/templates/common/bin/common.sh
@@ -44,7 +44,7 @@ function common_ironic_config {
     export CUSTOMCONF=${CustomConf:-""}
 
     SVC_CFG=/etc/ironic/ironic.conf
-    SVC_CFG_MERGED=/var/lib/config-data/merged/ironic.conf
+    SVC_CFG_MERGED=/var/lib/config-data/merged/01-ironic-custom.conf
 
     # Copy default service config from container image as base
     cp -a ${SVC_CFG} ${SVC_CFG_MERGED}

--- a/templates/ironicapi/config/ironic-api-config.json
+++ b/templates/ironicapi/config/ironic-api-config.json
@@ -14,6 +14,12 @@
             "perm": "0600"
         },
         {
+            "source": "/var/lib/config-data/merged/01-ironic-custom.conf",
+            "dest": "/etc/ironic/ironic.conf.d/01-ironic-custom.conf",
+            "owner": "ironic",
+            "perm": "0600"
+        },
+        {
             "source": "/var/lib/config-data/merged/ironic-api-httpd.conf",
             "dest": "/etc/httpd/conf/httpd.conf",
             "owner": "root",

--- a/templates/ironicconductor/config/ironic-conductor-config.json
+++ b/templates/ironicconductor/config/ironic-conductor-config.json
@@ -14,6 +14,12 @@
             "perm": "0600"
         },
         {
+            "source": "/var/lib/config-data/merged/01-ironic-custom.conf",
+            "dest": "/etc/ironic/ironic.conf.d/01-ironic-custom.conf",
+            "owner": "ironic",
+            "perm": "0600"
+        },
+        {
             "source": "/var/lib/config-data/merged/my.cnf",
             "dest": "/etc/my.cnf",
             "owner": "ironic",


### PR DESCRIPTION
This fixes a bug where changes to the customServiceConfig at the ironic level did not propagate to ironic-api or ironic-conductor.
It is expected that it is not supposed to change the behaviour of ironic-inspector or ironic-neutron-agent.

Jira: [OSPRH-10696](https://issues.redhat.com/browse/OSPRH-10696)