### PR TITLE
Get secrets to hash for api and conductor pods <JIRA: OSPRH-10696>

### DIFF
--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -497,6 +497,37 @@ func (r *IronicConductorReconciler) reconcileNormal(ctx context.Context, instanc
 	// ConfigMap
 	configMapVars := make(map[string]env.Setter)
 
+	// Get secrets by Namespace and Label that we need to hash
+	labelSelectorMap := map[string]string{}
+	lbl := labels.GetOwnerNameLabelSelector(labels.GetGroupLabel(ironic.ServiceName))
+	labelSelectorMap[lbl] = ironicv1.GetOwningIronicName(instance)
+	secrets, err := secret.GetSecrets(ctx, helper, instance.Namespace, labelSelectorMap)
+	if err != nil {
+		Log.Info(fmt.Sprintf("No secrets with label %s found", lbl))
+	} else {
+		for _, s := range secrets.Items {
+			hash, err := secret.Hash(&s)
+			if err != nil {
+				if k8s_errors.IsNotFound(err) {
+					Log.Info(fmt.Sprintf("OpenStack secret %s not found", instance.Spec.Secret))
+					instance.Status.Conditions.Set(condition.FalseCondition(
+						condition.InputReadyCondition,
+						condition.RequestedReason,
+						condition.SeverityInfo,
+						condition.InputReadyWaitingMessage))
+					return ctrl.Result{RequeueAfter: time.Second * 10}, nil
+				}
+				instance.Status.Conditions.Set(condition.FalseCondition(
+					condition.InputReadyCondition,
+					condition.ErrorReason,
+					condition.SeverityWarning,
+					condition.InputReadyErrorMessage,
+					err.Error()))
+				return ctrl.Result{}, err
+			}
+			configMapVars[s.Name] = env.SetValue(hash)
+		}
+	}
 	//
 	// check for required OpenStack secret holding passwords for service/admin user and add hash to the vars map
 	//


### PR DESCRIPTION
In commit: https://github.com/openstack-k8s-operators/ironic-operator/commit/95b3db1372ff5f588fcb87e70fafe8ef319ad374 there was a switch
from using ConfigMap to using secret.

```
-       return configmap.EnsureConfigMaps(ctx, h, instance, cms, envVars)
+       return secret.EnsureSecrets(ctx, h, instance, cms, envVars)
```

This PR makes it so that the hash for secrets gets added to configMapVars so that changes to the configMap is detected and a reconcile takes place. 

Jira: [OSPRH-10696](https://issues.redhat.com/browse/OSPRH-10696)