### PR TITLE
Override base level customServiceConfig in api and conductor <JIRA: OSPRH-10696>

### DIFF
--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -935,8 +935,8 @@ func (r *IronicReconciler) generateServiceConfigMaps(
 	// all other files get placed into /etc/ironic to allow overwrite of e.g. policy.json
 	// TODO: make sure custom.conf can not be overwritten
 	customData := map[string]string{
-		common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig,
-		"my.cnf":                           db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
+		"01-ironic-custom.conf": instance.Spec.CustomServiceConfig,
+		"my.cnf":                db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
 
 	}
 	for key, data := range instance.Spec.DefaultConfigOverwrite {

--- a/controllers/ironicapi_controller.go
+++ b/controllers/ironicapi_controller.go
@@ -1054,15 +1054,13 @@ func (r *IronicAPIReconciler) generateServiceConfigMaps(
 	// custom.conf is going to be merged into /etc/ironic/ironic.conf
 	// TODO: make sure custom.conf can not be overwritten
 	customData := map[string]string{
-		common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig,
-		"my.cnf":                           db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
+		"02-api-custom.conf": instance.Spec.CustomServiceConfig,
+		"my.cnf":             db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
 	}
 
 	for key, data := range instance.Spec.DefaultConfigOverwrite {
 		customData[key] = data
 	}
-
-	customData[common.CustomServiceConfigFileName] = instance.Spec.CustomServiceConfig
 
 	templateParameters := make(map[string]interface{})
 	// Initialize ConductorGroup key to ensure template rendering does not fail

--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -876,15 +876,13 @@ func (r *IronicConductorReconciler) generateServiceConfigMaps(
 	// custom.conf is going to be merged into /etc/ironic/ironic.conf
 	// TODO: make sure custom.conf can not be overwritten
 	customData := map[string]string{
-		common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig,
-		"my.cnf":                           db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
+		"02-conductor-custom.conf": instance.Spec.CustomServiceConfig,
+		"my.cnf":                   db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
 	}
 
 	for key, data := range instance.Spec.DefaultConfigOverwrite {
 		customData[key] = data
 	}
-
-	customData[common.CustomServiceConfigFileName] = instance.Spec.CustomServiceConfig
 
 	templateParameters := make(map[string]interface{})
 	if !instance.Spec.Standalone {

--- a/templates/common/bin/common.sh
+++ b/templates/common/bin/common.sh
@@ -59,23 +59,6 @@ function common_ironic_config {
         merge_config_dir ${dir}
     done
 
-    # TODO: a cleaner way to handle this?
-    # Merge custom.conf with ironic.conf, since the Kolla config doesn't seem
-    # to allow us to customize the ironic command (it calls httpd instead).
-    # Can we just put custom.conf in something like /etc/ironic/ironic.conf.d/custom.conf
-    # and have it automatically detected, or would we have to somehow change the call
-    # to the ironic binary to tell it to use that custom conf dir?
-    echo merging /var/lib/config-data/default/custom.conf into ${SVC_CFG_MERGED}
-    crudini --merge ${SVC_CFG_MERGED} < /var/lib/config-data/default/custom.conf
-
-    # TODO: a cleaner way to handle this?
-    # There might be service-specific extra custom conf that needs to be merged
-    # with the main ironic.conf for this particular service
-    if [ -n "$CUSTOMCONF" ]; then
-        echo merging /var/lib/config-data/custom/${CUSTOMCONF} into ${SVC_CFG_MERGED}
-        crudini --merge ${SVC_CFG_MERGED} < /var/lib/config-data/custom/${CUSTOMCONF}
-    fi
-
     # set secrets
     # Only set rpc_transport and transport_url if $TRANSPORTURL
     if [ -n "$TRANSPORTURL" ]; then

--- a/templates/ironic/bin/dbsync.sh
+++ b/templates/ironic/bin/dbsync.sh
@@ -33,13 +33,13 @@ if [ $ret_val -gt 1 ] ; then
     # returned as greater than 1 which means there is a major upgrade
     # stopping issue which needs to be addressed.
     echo "WARNING: Status check failed, we're going to attempt to apply the schema update and then re-evaluate."
-    ironic-dbsync --config-file=/etc/ironic/ironic.conf upgrade
+    ironic-dbsync --config-file /etc/ironic/ironic.conf --config-dir /etc/ironic/ironic.conf.d/ upgrade
     ironic-status upgrade check && ret_val=$? || ret_val=$?
     if [ $ret_val -gt 1 ] ; then
         echo $LINENO "Ironic DB Status check failed, returned: $ret_val"
         exit $ret_val
     fi
 fi
-ironic-dbsync --config-file /etc/ironic/ironic.conf
+ironic-dbsync --config-file /etc/ironic/ironic.conf --config-dir /etc/ironic/ironic.conf.d/
 
-ironic-dbsync --config-file /etc/ironic/ironic.conf online_data_migrations
+ironic-dbsync --config-file /etc/ironic/ironic.conf --config-dir /etc/ironic/ironic.conf.d/ online_data_migrations

--- a/templates/ironic/config/db-sync-config.json
+++ b/templates/ironic/config/db-sync-config.json
@@ -8,8 +8,8 @@
             "perm": "0600"
         },
         {
-            "source": "/var/lib/config-data/merged/custom.conf",
-            "dest": "/etc/ironic/ironic.conf.d/custom.conf",
+            "source": "/var/lib/config-data/merged/01-ironic-custom.conf",
+            "dest": "/etc/ironic/ironic.conf.d/01-ironic-custom.conf",
             "owner": "ironic",
             "perm": "0600"
         },

--- a/templates/ironicapi/config/ironic-api-config.json
+++ b/templates/ironicapi/config/ironic-api-config.json
@@ -8,8 +8,14 @@
             "perm": "0600"
         },
         {
-            "source": "/var/lib/config-data/merged/custom.conf",
-            "dest": "/etc/ironic/ironic.conf.d/custom.conf",
+            "source": "/var/lib/config-data/merged/01-ironic-custom.conf",
+            "dest": "/etc/ironic/ironic.conf.d/01-ironic-custom.conf",
+            "owner": "ironic",
+            "perm": "0600"
+        },
+        {
+            "source": "/var/lib/config-data/merged/02-api-custom.conf",
+            "dest": "/etc/ironic/ironic.conf.d/02-api-custom.conf",
             "owner": "ironic",
             "perm": "0600"
         },

--- a/templates/ironicconductor/config/ironic-conductor-config.json
+++ b/templates/ironicconductor/config/ironic-conductor-config.json
@@ -8,8 +8,14 @@
             "perm": "0600"
         },
         {
-            "source": "/var/lib/config-data/merged/custom.conf",
-            "dest": "/etc/ironic/ironic.conf.d/custom.conf",
+            "source": "/var/lib/config-data/merged/01-ironic-custom.conf",
+            "dest": "/etc/ironic/ironic.conf.d/01-ironic-custom.conf",
+            "owner": "ironic",
+            "perm": "0600"
+        },
+        {
+            "source": "/var/lib/config-data/merged/02-conductor-custom.conf",
+            "dest": "/etc/ironic/ironic.conf.d/02-conductor-custom.conf",
             "owner": "ironic",
             "perm": "0600"
         },


### PR DESCRIPTION
With the changes in https://github.com/openstack-k8s-operators/ironic-operator/pull/573, the conductor and api pods restart when a change is made to `ironic.template.customServiceConfig`. But the config in `ironic.ironicAPI.customServiceConfig` and `ironic.ironicConductor.customServiceConfig` do not override the base level config. This PR renames the custom.conf file so it is loaded in later and overrides the config. 

Jira: [OSPRH-10696](https://issues.redhat.com/browse/OSPRH-10696)