### PR TITLE
Use logger in ironicAPI and ironicConductor <JIRA: OSPRH-18579>

### DIFF
--- a/controllers/ironicapi_controller.go
+++ b/controllers/ironicapi_controller.go
@@ -927,7 +927,7 @@ func (r *IronicAPIReconciler) reconcileNormal(ctx context.Context, instance *iro
 	//
 
 	// Define a new Deployment object
-	deplDef, err := ironicapi.Deployment(instance, inputHash, serviceLabels, serviceAnnotations, topology)
+	deplDef, err := ironicapi.Deployment(ctx, instance, inputHash, serviceLabels, serviceAnnotations, topology)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,

--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -748,7 +748,7 @@ func (r *IronicConductorReconciler) reconcileNormal(ctx context.Context, instanc
 	}
 
 	// Define a new StatefulSet object
-	ssSpec, err := ironicconductor.StatefulSet(instance, inputHash, serviceLabels, ingressDomain, serviceAnnotations, topology)
+	ssSpec, err := ironicconductor.StatefulSet(ctx, instance, inputHash, serviceLabels, ingressDomain, serviceAnnotations, topology)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/ironicapi/deployment.go
+++ b/pkg/ironicapi/deployment.go
@@ -16,6 +16,8 @@ limitations under the License.
 package ironicapi
 
 import (
+	"context"
+
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	ironicv1 "github.com/openstack-k8s-operators/ironic-operator/api/v1beta1"
 	ironic "github.com/openstack-k8s-operators/ironic-operator/pkg/ironic"
@@ -38,6 +40,7 @@ const (
 
 // Deployment func
 func Deployment(
+	ctx context.Context,
 	instance *ironicv1.IronicAPI,
 	configHash string,
 	labels map[string]string,
@@ -77,7 +80,7 @@ func Deployment(
 	}
 
 	// create Volume and VolumeMounts
-	volumes := GetVolumes(instance)
+	volumes := GetVolumes(ctx, instance)
 	volumeMounts := GetVolumeMounts()
 	initVolumeMounts := GetInitVolumeMounts(instance)
 

--- a/pkg/ironicapi/volumes.go
+++ b/pkg/ironicapi/volumes.go
@@ -1,23 +1,25 @@
 package ironicapi
 
 import (
+	"context"
 	"fmt"
 
 	ironicv1 "github.com/openstack-k8s-operators/ironic-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/ironic-operator/pkg/ironic"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // GetVolumes -
-func GetVolumes(instance *ironicv1.IronicAPI) []corev1.Volume {
+func GetVolumes(ctx context.Context, instance *ironicv1.IronicAPI) []corev1.Volume {
+	Log := log.FromContext(ctx).WithName("IronicAPI").WithName("GetVolumes")
 	var config0640AccessMode int32 = 0640
 	parentName := ironicv1.GetOwningIronicName(instance)
 
 	var apiVolumes []corev1.Volume
 
 	if parentName == "" {
-		// TODO: Add proper logging
-		fmt.Println("parentName is not present")
+		Log.Info("parentName is not present for IronicAPI instance", "instance", instance.Name, "namespace", instance.Namespace)
 		// Only include logs volume when parentName is not present
 		apiVolumes = append(apiVolumes,
 			corev1.Volume{

--- a/pkg/ironicconductor/statefulset.go
+++ b/pkg/ironicconductor/statefulset.go
@@ -16,6 +16,7 @@ limitations under the License.
 package ironicconductor
 
 import (
+	"context"
 	"fmt"
 	"net"
 
@@ -41,6 +42,7 @@ const (
 
 // StatefulSet func
 func StatefulSet(
+	ctx context.Context,
 	instance *ironicv1.IronicConductor,
 	configHash string,
 	labels map[string]string,
@@ -162,7 +164,7 @@ func StatefulSet(
 	ramdiskLogsEnvVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
 	ramdiskLogsEnvVars["CONFIG_HASH"] = env.SetValue(configHash)
 
-	volumes := GetVolumes(instance)
+	volumes := GetVolumes(ctx, instance)
 	conductorVolumeMounts := GetVolumeMounts("ironic-conductor")
 	httpbootVolumeMounts := GetVolumeMounts("httpboot")
 	dnsmasqVolumeMounts := GetVolumeMounts("dnsmasq")

--- a/pkg/ironicconductor/volumes.go
+++ b/pkg/ironicconductor/volumes.go
@@ -1,15 +1,18 @@
 package ironicconductor
 
 import (
+	"context"
 	"fmt"
 
 	ironicv1 "github.com/openstack-k8s-operators/ironic-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/ironic-operator/pkg/ironic"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // GetVolumes -
-func GetVolumes(instance *ironicv1.IronicConductor) []corev1.Volume {
+func GetVolumes(ctx context.Context, instance *ironicv1.IronicConductor) []corev1.Volume {
+	Log := log.FromContext(ctx).WithName("IronicConductor").WithName("GetVolumes")
 	var config0640AccessMode int32 = 0640
 	parentName := ironicv1.GetOwningIronicName(instance)
 
@@ -28,8 +31,7 @@ func GetVolumes(instance *ironicv1.IronicConductor) []corev1.Volume {
 				},
 			})
 	} else {
-		// TODO: Add proper logging
-		fmt.Println("parentName is not present")
+		Log.Info("parentName is not present for IronicConductor instance", "instance", instance.Name, "namespace", instance.Namespace)
 	}
 
 	return append(ironic.GetVolumes(instance.Name), conductorVolumes...)


### PR DESCRIPTION
In ironicAPI and ironicConductor volumes, the logs are implemented through print statements. This needs to be changed to add the proper logging package. 

Jira: [OSPRH-18579](https://issues.redhat.com/browse/OSPRH-18579)