### PR TITLE
Use config-dir in ironic-conductor <JIRA: OSPRH-18581>

### DIFF
--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -935,7 +935,7 @@ func (r *IronicReconciler) generateServiceConfigMaps(
 	// all other files get placed into /etc/ironic to allow overwrite of e.g. policy.json
 	// TODO: make sure custom.conf can not be overwritten
 	customData := map[string]string{
-		"01-ironic-custom.conf": instance.Spec.CustomServiceConfig,
+		"02-ironic-custom.conf": instance.Spec.CustomServiceConfig,
 		"my.cnf":                db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
 
 	}

--- a/controllers/ironicapi_controller.go
+++ b/controllers/ironicapi_controller.go
@@ -1054,7 +1054,7 @@ func (r *IronicAPIReconciler) generateServiceConfigMaps(
 	// custom.conf is going to be merged into /etc/ironic/ironic.conf
 	// TODO: make sure custom.conf can not be overwritten
 	customData := map[string]string{
-		"02-api-custom.conf": instance.Spec.CustomServiceConfig,
+		"03-api-custom.conf": instance.Spec.CustomServiceConfig,
 		"my.cnf":             db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
 	}
 

--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -872,11 +872,9 @@ func (r *IronicConductorReconciler) generateServiceConfigMaps(
 		tlsCfg = &tls.Service{}
 	}
 
-	// customData hold any customization for the service.
-	// custom.conf is going to be merged into /etc/ironic/ironic.conf
-	// TODO: make sure custom.conf can not be overwritten
+	// Build custom config data
 	customData := map[string]string{
-		"02-conductor-custom.conf": instance.Spec.CustomServiceConfig,
+		"04-conductor-custom.conf": instance.Spec.CustomServiceConfig,
 		"my.cnf":                   db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
 	}
 
@@ -933,6 +931,7 @@ func (r *IronicConductorReconciler) generateServiceConfigMaps(
 				"get_net_ip":     "/common/bin/get_net_ip",
 				"runlogwatch.sh": "/common/bin/runlogwatch.sh",
 				"pxe-init.sh":    "/common/bin/pxe-init.sh",
+				"init.sh":        "/ironicconductor/bin/init.sh",
 			},
 			Labels: cmLabels,
 		},
@@ -945,8 +944,10 @@ func (r *IronicConductorReconciler) generateServiceConfigMaps(
 			CustomData:    customData,
 			ConfigOptions: templateParameters,
 			AdditionalTemplate: map[string]string{
-				"ironic.conf":  "/common/config/ironic.conf",
-				"dnsmasq.conf": "/common/config/dnsmasq.conf",
+				"ironic.conf":                      "/common/config/ironic.conf",
+				"01-conductor.conf":                "/ironicconductor/config/01-conductor.conf",
+				"03-init-container-conductor.conf": "/ironicconductor/config/03-init-container-conductor.conf",
+				"dnsmasq.conf":                     "/common/config/dnsmasq.conf",
 			},
 			Labels: cmLabels,
 		},

--- a/pkg/ironicconductor/volumes.go
+++ b/pkg/ironicconductor/volumes.go
@@ -65,6 +65,16 @@ func GetVolumeMounts(serviceName string) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{
 		{
 			Name:      "config-data",
+			MountPath: "/var/lib/config-data/default",
+			ReadOnly:  true,
+		},
+		{
+			Name:      "config-data-custom",
+			MountPath: "/var/lib/config-data/custom",
+			ReadOnly:  true,
+		},
+		{
+			Name:      "config-data",
 			MountPath: "/var/lib/kolla/config_files/config.json",
 			SubPath:   serviceName + "-config.json",
 			ReadOnly:  true,

--- a/templates/common/config/ironic.conf
+++ b/templates/common/config/ironic.conf
@@ -1,30 +1,11 @@
 [DEFAULT]
-enabled_hardware_types=ipmi,idrac,irmc,fake-hardware,redfish,manual-management,ilo,ilo5
-enabled_bios_interfaces=no-bios,redfish,idrac-redfish,irmc,ilo
-enabled_boot_interfaces=ipxe,ilo-ipxe,pxe,ilo-pxe,fake,redfish-virtual-media,idrac-redfish-virtual-media,ilo-virtual-media
-enabled_console_interfaces=ipmitool-socat,ilo,no-console,fake
-enabled_deploy_interfaces=direct,fake,ramdisk,custom-agent
-default_deploy_interface = direct
-enabled_inspect_interfaces=inspector,no-inspect,irmc,fake,redfish,ilo
-default_inspect_interface=inspector
-enabled_management_interfaces=ipmitool,irmc,fake,redfish,idrac-redfish,ilo,ilo5,noop
-enabled_network_interfaces=flat,neutron,noop
-enabled_power_interfaces=ipmitool,irmc,fake,redfish,idrac-redfish,ilo
-enabled_raid_interfaces=no-raid,irmc,agent,fake,ilo5
-enabled_rescue_interfaces=no-rescue,agent
-default_rescue_interface=agent
-enabled_storage_interfaces=noop,fake
-enabled_vendor_interfaces = no-vendor,ipmitool,idrac-redfish,redfish,ilo,fake
 # This is a knob to allow service role users from the service project
 # to have "elevated" API access to see the whole of the API surface.
 # https://review.opendev.org/c/openstack/ironic/+/907269
 rbac_service_role_elevated_access=true
 
-{{if .Standalone}}default_network_interface=noop{{end}}
-
 default_resource_class=baremetal
 hash_ring_algorithm=sha256
-rpc_transport=json-rpc
 
 use_stderr=false
 log_file={{ .LogPath }}
@@ -34,10 +15,6 @@ auth_strategy={{if .Standalone}}noauth{{else}}keystone{{end}}
 
 grub_config_path=EFI/BOOT/grub.cfg
 isolinux_bin=/usr/share/syslinux/isolinux.bin
-
-
-[agent]
-deploy_logs_local_path=/var/lib/ironic/ramdisk-logs
 
 {{if .Standalone}}
 [service_catalog]
@@ -118,12 +95,6 @@ enforce_scope=True
 enforce_new_defaults=True
 {{end}}
 
-[conductor]
-heartbeat_interval=20
-heartbeat_timeout=120
-allow_provisioning_in_maintenance=false
-{{ if .ConductorGroup }}conductor_group={{ .ConductorGroup }}{{ end }}
-
 [cors]
 allowed_origin=*
 expose_headers=Content-Type,Cache-Control,Content-Language,Expires,Last-Modified,Pragma
@@ -135,24 +106,6 @@ allow_headers=Content-Type,Cache-Control,Content-Language,Expires,Last-Modified,
 connection={{ .DatabaseConnection }}
 max_retries=-1
 db_max_retries=-1
-
-[deploy]
-http_root=/var/lib/ironic/httpboot
-erase_devices_priority=0
-erase_devices_metadata_priority=10
-
-[json_rpc]
-auth_strategy=noauth
-
-[pxe]
-tftp_root=/var/lib/ironic/tftpboot
-tftp_master_path=/var/lib/ironic/tftpboot/master_images
-uefi_pxe_bootfile_name=shimx64.efi
-ipxe_timeout=60
-
-[redfish]
-# TODO: Enable when swift/ceph integration is complete
-use_swift=false
 
 [oslo_middleware]
 enable_proxy_headers_parsing=true

--- a/templates/ironic/config/db-sync-config.json
+++ b/templates/ironic/config/db-sync-config.json
@@ -8,8 +8,8 @@
             "perm": "0600"
         },
         {
-            "source": "/var/lib/config-data/merged/01-ironic-custom.conf",
-            "dest": "/etc/ironic/ironic.conf.d/01-ironic-custom.conf",
+            "source": "/var/lib/config-data/merged/02-ironic-custom.conf",
+            "dest": "/etc/ironic/ironic.conf.d/02-ironic-custom.conf",
             "owner": "ironic",
             "perm": "0600"
         },

--- a/templates/ironicapi/config/ironic-api-config.json
+++ b/templates/ironicapi/config/ironic-api-config.json
@@ -8,14 +8,14 @@
             "perm": "0600"
         },
         {
-            "source": "/var/lib/config-data/merged/01-ironic-custom.conf",
-            "dest": "/etc/ironic/ironic.conf.d/01-ironic-custom.conf",
+            "source": "/var/lib/config-data/merged/02-ironic-custom.conf",
+            "dest": "/etc/ironic/ironic.conf.d/02-ironic-custom.conf",
             "owner": "ironic",
             "perm": "0600"
         },
         {
-            "source": "/var/lib/config-data/merged/02-api-custom.conf",
-            "dest": "/etc/ironic/ironic.conf.d/02-api-custom.conf",
+            "source": "/var/lib/config-data/merged/03-api-custom.conf",
+            "dest": "/etc/ironic/ironic.conf.d/03-api-custom.conf",
             "owner": "ironic",
             "perm": "0600"
         },

--- a/templates/ironicconductor/bin/init.sh
+++ b/templates/ironicconductor/bin/init.sh
@@ -15,29 +15,51 @@
 # under the License.
 set -ex
 
+echo "Starting conductor init"
+
 # Get the statefulset pod index
 export PODINDEX=$(echo ${HOSTNAME##*-})
 
-# expect that the common.sh is in the same dir as the calling script
-SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
-. ${SCRIPTPATH}/common.sh --source-only
+# Get required environment variables
+IRONICPASSWORD=${IronicPassword:-""}
+TRANSPORTURL=${TransportURL:-""}
+PROVISION_NETWORK=${ProvisionNetwork:-""}
+DEPLOY_HTTP_URL=${DeployHTTPURL:-""}
 
-common_ironic_config
+INIT_CONFIG="/var/lib/config-data/merged/03-init-container-conductor.conf"
 
-if [ -n "${ProvisionNetwork}" ]; then
-    export ProvisionNetworkIP=$(/usr/local/bin/container-scripts/get_net_ip ${ProvisionNetwork})
-    crudini --set ${SVC_CFG_MERGED} DEFAULT my_ip $ProvisionNetworkIP
+if [ -n "${PROVISION_NETWORK}" ]; then
+    export ProvisionNetworkIP=$(/usr/local/bin/container-scripts/get_net_ip ${PROVISION_NETWORK})
+    crudini --set ${INIT_CONFIG} DEFAULT my_ip ${ProvisionNetworkIP}
 fi
-export DEPLOY_HTTP_URL=$(python3 -c 'import os; print(os.environ["DeployHTTPURL"] % os.environ)')
-SVC_CFG_MERGED=/var/lib/config-data/merged/ironic.conf
-crudini --set ${SVC_CFG_MERGED} deploy http_url ${DEPLOY_HTTP_URL}
-crudini --set ${SVC_CFG_MERGED} conductor bootloader ${DEPLOY_HTTP_URL}esp.img
-crudini --set ${SVC_CFG_MERGED} conductor deploy_kernel ${DEPLOY_HTTP_URL}ironic-python-agent.kernel
-crudini --set ${SVC_CFG_MERGED} conductor deploy_ramdisk ${DEPLOY_HTTP_URL}ironic-python-agent.initramfs
-crudini --set ${SVC_CFG_MERGED} conductor rescue_kernel ${DEPLOY_HTTP_URL}ironic-python-agent.kernel
-crudini --set ${SVC_CFG_MERGED} conductor rescue_ramdisk ${DEPLOY_HTTP_URL}ironic-python-agent.initramfs
 
-export DNSMASQ_CFG=/var/lib/config-data/merged/dnsmasq.conf
+if [ -n "${TRANSPORTURL}" ]; then
+    crudini --set ${INIT_CONFIG} DEFAULT transport_url ${TRANSPORTURL}
+    crudini --set ${INIT_CONFIG} DEFAULT rpc_transport oslo
+fi
+
+if [ -n "${DEPLOY_HTTP_URL}" ]; then
+    EXPANDED_URL=$(python3 -c 'import os; print(os.environ["DeployHTTPURL"] % os.environ)')
+
+    crudini --set ${INIT_CONFIG} deploy http_url ${EXPANDED_URL}
+    crudini --set ${INIT_CONFIG} conductor bootloader ${EXPANDED_URL}esp.img
+    crudini --set ${INIT_CONFIG} conductor deploy_kernel ${EXPANDED_URL}ironic-python-agent.kernel
+    crudini --set ${INIT_CONFIG} conductor deploy_ramdisk ${EXPANDED_URL}ironic-python-agent.initramfs
+    crudini --set ${INIT_CONFIG} conductor rescue_kernel ${EXPANDED_URL}ironic-python-agent.kernel
+    crudini --set ${INIT_CONFIG} conductor rescue_ramdisk ${EXPANDED_URL}ironic-python-agent.initramfs
+fi
+
+# Set service passwords
+if [ -n "${IRONICPASSWORD}" ]; then
+    for service in keystone_authtoken service_catalog cinder glance neutron nova swift inspector; do
+        crudini --set ${INIT_CONFIG} ${service} password ${IRONICPASSWORD}
+    done
+fi
+
+# Copy required config to modifiable location
+cp /var/lib/config-data/default/dnsmasq.conf /var/lib/ironic/
+
+export DNSMASQ_CFG=/var/lib/ironic/dnsmasq.conf
 sed -e "/BLOCK_PODINDEX_${PODINDEX}_BEGIN/,/BLOCK_PODINDEX_${PODINDEX}_END/p" \
     -e "/BLOCK_PODINDEX_.*_BEGIN/,/BLOCK_PODINDEX_.*_END/d" \
     -i ${DNSMASQ_CFG}
@@ -54,3 +76,5 @@ fi
 if [ ! -d "/var/lib/ironic/ramdisk-logs" ]; then
     mkdir /var/lib/ironic/ramdisk-logs
 fi
+
+echo "Conductor init successfully completed"

--- a/templates/ironicconductor/config/01-conductor.conf
+++ b/templates/ironicconductor/config/01-conductor.conf
@@ -1,0 +1,47 @@
+[DEFAULT]
+enabled_hardware_types=ipmi,idrac,irmc,fake-hardware,redfish,manual-management,ilo,ilo5
+enabled_bios_interfaces=no-bios,redfish,idrac-redfish,irmc,ilo
+enabled_boot_interfaces=ipxe,ilo-ipxe,pxe,ilo-pxe,fake,redfish-virtual-media,idrac-redfish-virtual-media,ilo-virtual-media
+enabled_console_interfaces=ipmitool-socat,ilo,no-console,fake
+enabled_deploy_interfaces=direct,fake,ramdisk,custom-agent
+default_deploy_interface = direct
+enabled_inspect_interfaces=inspector,no-inspect,irmc,fake,redfish,ilo
+default_inspect_interface=inspector
+enabled_management_interfaces=ipmitool,irmc,fake,redfish,idrac-redfish,ilo,ilo5,noop
+enabled_network_interfaces=flat,neutron,noop
+enabled_power_interfaces=ipmitool,irmc,fake,redfish,idrac-redfish,ilo
+enabled_raid_interfaces=no-raid,irmc,agent,fake,ilo5
+enabled_rescue_interfaces=no-rescue,agent
+default_rescue_interface=agent
+enabled_storage_interfaces=noop,fake
+enabled_vendor_interfaces = no-vendor,ipmitool,idrac-redfish,redfish,ilo,fake
+
+{{if .Standalone}}default_network_interface=noop{{end}}
+
+rpc_transport=json-rpc
+
+[agent]
+deploy_logs_local_path=/var/lib/ironic/ramdisk-logs
+
+[conductor]
+heartbeat_interval=20
+heartbeat_timeout=120
+allow_provisioning_in_maintenance=false
+{{ if .ConductorGroup }}conductor_group={{ .ConductorGroup }}{{ end }}
+
+[deploy]
+http_root=/var/lib/ironic/httpboot
+erase_devices_priority=0
+erase_devices_metadata_priority=10
+
+[json_rpc]
+auth_strategy=noauth
+
+[pxe]
+tftp_root=/var/lib/ironic/tftpboot
+tftp_master_path=/var/lib/ironic/tftpboot/master_images
+uefi_pxe_bootfile_name=shimx64.efi
+ipxe_timeout=60
+
+[redfish]
+use_swift=false

--- a/templates/ironicconductor/config/03-init-container-conductor.conf
+++ b/templates/ironicconductor/config/03-init-container-conductor.conf
@@ -1,0 +1,24 @@
+[DEFAULT]
+# Base configuration for init container
+
+[conductor]
+heartbeat_interval=20
+heartbeat_timeout=120
+allow_provisioning_in_maintenance=false
+
+[deploy]
+http_root=/var/lib/ironic/httpboot
+erase_devices_priority=0
+erase_devices_metadata_priority=10
+
+[json_rpc]
+auth_strategy=noauth
+
+[pxe]
+tftp_root=/var/lib/ironic/tftpboot
+tftp_master_path=/var/lib/ironic/tftpboot/master_images
+uefi_pxe_bootfile_name=shimx64.efi
+ipxe_timeout=60
+
+[agent]
+deploy_logs_local_path=/var/lib/ironic/ramdisk-logs

--- a/templates/ironicconductor/config/dnsmasq-config.json
+++ b/templates/ironicconductor/config/dnsmasq-config.json
@@ -2,7 +2,7 @@
     "command": "/usr/sbin/dnsmasq -k",
     "config_files": [
         {
-            "source": "/var/lib/config-data/merged/dnsmasq.conf",
+            "source": "/var/lib/ironic/dnsmasq.conf",
             "dest": "/etc/dnsmasq.conf",
             "owner": "dnsmasq",
             "perm": "0644"

--- a/templates/ironicconductor/config/httpboot-config.json
+++ b/templates/ironicconductor/config/httpboot-config.json
@@ -2,7 +2,7 @@
     "command": "/usr/sbin/httpd -DFOREGROUND",
     "config_files": [
         {
-            "source": "/var/lib/config-data/merged/httpboot-httpd.conf",
+            "source": "/var/lib/config-data/default/httpboot-httpd.conf",
             "dest": "/etc/httpd/conf/httpd.conf",
             "owner": "root",
             "perm": "0644"

--- a/templates/ironicconductor/config/ironic-conductor-config.json
+++ b/templates/ironicconductor/config/ironic-conductor-config.json
@@ -1,26 +1,38 @@
 {
-    "command": "/usr/bin/ironic-conductor",
+    "command": "/usr/bin/ironic-conductor --config-file /etc/ironic/ironic.conf --config-dir /etc/ironic/ironic.conf.d",
     "config_files": [
         {
-            "source": "/var/lib/config-data/merged/ironic.conf",
+            "source": "/var/lib/config-data/default/ironic.conf",
             "dest": "/etc/ironic/ironic.conf",
             "owner": "ironic",
             "perm": "0600"
         },
         {
-            "source": "/var/lib/config-data/merged/01-ironic-custom.conf",
-            "dest": "/etc/ironic/ironic.conf.d/01-ironic-custom.conf",
+            "source": "/var/lib/config-data/default/01-conductor.conf",
+            "dest": "/etc/ironic/ironic.conf.d/01-conductor.conf",
             "owner": "ironic",
             "perm": "0600"
         },
         {
-            "source": "/var/lib/config-data/merged/02-conductor-custom.conf",
-            "dest": "/etc/ironic/ironic.conf.d/02-conductor-custom.conf",
+            "source": "/var/lib/config-data/custom/02-ironic-custom.conf",
+            "dest": "/etc/ironic/ironic.conf.d/02-ironic-custom.conf",
             "owner": "ironic",
             "perm": "0600"
         },
         {
-            "source": "/var/lib/config-data/merged/my.cnf",
+            "source": "/var/lib/config-data/merged/03-init-container-conductor.conf",
+            "dest": "/etc/ironic/ironic.conf.d/03-init-container-conductor.conf",
+            "owner": "ironic",
+            "perm": "0600"
+        },
+        {
+            "source": "/var/lib/config-data/default/04-conductor-custom.conf",
+            "dest": "/etc/ironic/ironic.conf.d/04-conductor-custom.conf",
+            "owner": "ironic",
+            "perm": "0600"
+        },
+        {
+            "source": "/var/lib/config-data/default/my.cnf",
             "dest": "/etc/my.cnf",
             "owner": "ironic",
             "perm": "0644"

--- a/tests/functional/ironicconductor_controller_test.go
+++ b/tests/functional/ironicconductor_controller_test.go
@@ -146,6 +146,9 @@ var _ = Describe("IronicConductor controller", func() {
 			configDataMap := th.GetSecret(ironicNames.ConductorConfigSecretName)
 			Expect(configDataMap).ShouldNot(BeNil())
 			Expect(configDataMap.Data).Should(HaveKey("ironic.conf"))
+			Expect(configDataMap.Data).Should(HaveKey("01-conductor.conf"))
+			Expect(configDataMap.Data).Should(HaveKey("03-init-container-conductor.conf"))
+			Expect(configDataMap.Data).Should(HaveKey("04-conductor-custom.conf"))
 			Expect(configDataMap.Data).Should(HaveKey("my.cnf"))
 			configData := string(configDataMap.Data["my.cnf"])
 			Expect(configData).To(
@@ -288,6 +291,9 @@ var _ = Describe("IronicConductor controller", func() {
 			configDataMap := th.GetSecret(ironicNames.ConductorConfigSecretName)
 			Expect(configDataMap).ShouldNot(BeNil())
 			Expect(configDataMap.Data).Should(HaveKey("ironic.conf"))
+			Expect(configDataMap.Data).Should(HaveKey("01-conductor.conf"))
+			Expect(configDataMap.Data).Should(HaveKey("03-init-container-conductor.conf"))
+			Expect(configDataMap.Data).Should(HaveKey("04-conductor-custom.conf"))
 			Expect(configDataMap.Data).Should(HaveKey("my.cnf"))
 			configData := string(configDataMap.Data["my.cnf"])
 			Expect(configData).To(


### PR DESCRIPTION
This change aims at using `--config-dir` command to load configurations in order into conductor. 

- The basic numbering has been changed on `0x-ironic-custom.conf`, so these changes have been made for ironicAPI as well. 
- A new init conf has been created for conductor-init for the init pod, this will be populated with values from the init.sh command and uses crudini. The passwords are made more secure by staying in Kubernetes secrets instead of storing it in ConfigMaps. 
- crudini usage for merging in files together has been reduced
- `01-conductor.conf` has been created to house the conductor configuration only and does not load configuration from the common init.sh conf anymore. 

Jira: [OSPRH-18581](https://issues.redhat.com/browse/OSPRH-18581)