### PR TITLE
Refactor ironicapi configuration structure <JIRA: OSPRH-18581>

### DIFF
--- a/controllers/ironicapi_controller.go
+++ b/controllers/ironicapi_controller.go
@@ -1125,6 +1125,7 @@ func (r *IronicAPIReconciler) generateServiceConfigMaps(
 			ConfigOptions: templateParameters,
 			AdditionalTemplate: map[string]string{
 				"ironic.conf": "/common/config/ironic.conf",
+				"01-api.conf": "/ironicapi/config/01-api.conf",
 			},
 			Labels: cmLabels,
 		},

--- a/templates/common/config/ironic.conf
+++ b/templates/common/config/ironic.conf
@@ -118,13 +118,6 @@ enforce_scope=True
 enforce_new_defaults=True
 {{end}}
 
-[cors]
-allowed_origin=*
-expose_headers=Content-Type,Cache-Control,Content-Language,Expires,Last-Modified,Pragma
-max_age=3600
-allow_methods=GET,POST,PUT,DELETE,OPTIONS,PATCH
-allow_headers=Content-Type,Cache-Control,Content-Language,Expires,Last-Modified,Pragma,X-Auth-Token
-
 [database]
 connection={{ .DatabaseConnection }}
 max_retries=-1

--- a/templates/ironicapi/config/01-api.conf
+++ b/templates/ironicapi/config/01-api.conf
@@ -1,0 +1,13 @@
+[DEFAULT]
+# API-specific configuration overrides
+
+[cors]
+allowed_origin=*
+allow_credentials=true
+expose_headers=Content-Type,Cache-Control,Content-Language,Expires,Last-Modified,Pragma
+max_age=3600
+allow_methods=GET,POST,PUT,DELETE,OPTIONS,PATCH
+allow_headers=Content-Type,Cache-Control,Content-Language,Expires,Last-Modified,Pragma,X-Auth-Token
+
+[oslo_middleware]
+enable_proxy_headers_parsing=true

--- a/templates/ironicapi/config/ironic-api-config.json
+++ b/templates/ironicapi/config/ironic-api-config.json
@@ -8,6 +8,12 @@
             "perm": "0600"
         },
         {
+            "source": "/var/lib/config-data/merged/01-api.conf",
+            "dest": "/etc/ironic/ironic.conf.d/01-api.conf",
+            "owner": "ironic",
+            "perm": "0600"
+        },
+        {
             "source": "/var/lib/config-data/merged/02-ironic-custom.conf",
             "dest": "/etc/ironic/ironic.conf.d/02-ironic-custom.conf",
             "owner": "ironic",

--- a/tests/functional/ironicapi_controller_test.go
+++ b/tests/functional/ironicapi_controller_test.go
@@ -153,6 +153,8 @@ var _ = Describe("IronicAPI controller", func() {
 			configDataMap := th.GetSecret(ironicNames.APIConfigSecretName)
 			Expect(configDataMap).ShouldNot(BeNil())
 			Expect(configDataMap.Data).Should(HaveKey("ironic.conf"))
+			Expect(configDataMap.Data).Should(HaveKey("01-api.conf"))
+			Expect(configDataMap.Data).Should(HaveKey("03-api-custom.conf"))
 			configData := string(configDataMap.Data["ironic.conf"])
 			// as part of additional hardening we now require service_token_roles_required
 			// to be set to true to ensure that the service token is not just a user token


### PR DESCRIPTION
When looking at how to change ironic-api to add in `--config-dir` it was discovered that it actually uses the Apache server to spin up the service using the command `command": "/usr/sbin/httpd -DFOREGROUND`. Since ironicAPI uses oslo.config to load in configuration, it does not need the explicit `--config-dir` to load in configuration from `/etc/ironic/ironic.conf.d/` since it's automatically discovering all the files in that location.
Hence, this PR addresses only the addition of `01-api.conf` to make it in line with the other services and refactor related to that. 

Jira: [OSPRH-18581](https://issues.redhat.com/browse/OSPRH-18581)