### PR TITLE
Remove redundant scripts <JIRA: OSPRH-18581>

### DIFF
--- a/pkg/ironicapi/deployment.go
+++ b/pkg/ironicapi/deployment.go
@@ -81,7 +81,7 @@ func Deployment(
 
 	// create Volume and VolumeMounts
 	volumes := GetVolumes(ctx, instance)
-	volumeMounts := GetVolumeMounts()
+	volumeMounts := GetVolumeMounts(instance)
 	initVolumeMounts := GetInitVolumeMounts(instance)
 
 	// add CA cert if defined

--- a/pkg/ironicapi/volumes.go
+++ b/pkg/ironicapi/volumes.go
@@ -80,7 +80,7 @@ func GetInitVolumeMounts(instance *ironicv1.IronicAPI) []corev1.VolumeMount {
 }
 
 // GetVolumeMounts - Ironic API VolumeMounts
-func GetVolumeMounts() []corev1.VolumeMount {
+func GetVolumeMounts(instance *ironicv1.IronicAPI) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{
 		{
 			Name:      "config-data",
@@ -88,7 +88,22 @@ func GetVolumeMounts() []corev1.VolumeMount {
 			SubPath:   "ironic-api-config.json",
 			ReadOnly:  true,
 		},
+		{
+			Name:      "config-data",
+			MountPath: "/var/lib/config-data/default",
+			ReadOnly:  true,
+		},
 		GetLogVolumeMount(),
+	}
+
+	// Add config-data-custom volume mount if parentName is present
+	parentName := ironicv1.GetOwningIronicName(instance)
+	if parentName != "" {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "config-data-custom",
+			MountPath: "/var/lib/config-data/custom",
+			ReadOnly:  true,
+		})
 	}
 
 	return append(ironic.GetVolumeMounts(), volumeMounts...)

--- a/templates/ironicapi/config/01-api.conf
+++ b/templates/ironicapi/config/01-api.conf
@@ -1,5 +1,6 @@
 [DEFAULT]
 # API-specific configuration overrides
+transport_url = {{ .TransportURL }}
 
 [cors]
 allowed_origin=*
@@ -11,3 +12,65 @@ allow_headers=Content-Type,Cache-Control,Content-Language,Expires,Last-Modified,
 
 [oslo_middleware]
 enable_proxy_headers_parsing=true
+
+{{if .Standalone}}
+[ironic]
+auth_type=none
+{{else}}
+[ironic]
+auth_type=password
+auth_url={{ .KeystoneInternalURL }}
+username={{ .ServiceUser }}
+password = {{ .ServicePassword }}
+user_domain_name=Default
+project_name=service
+project_domain_name=Default
+max_retries=6
+retry_interval=10
+
+[keystone_authtoken]
+auth_type=password
+auth_url={{ .KeystoneInternalURL }}
+username={{ .ServiceUser }}
+password = {{ .ServicePassword }}
+www_authenticate_uri={{ .KeystonePublicURL }}
+project_domain_name=Default
+user_domain_name=Default
+project_name=service
+
+[service_catalog]
+auth_type=password
+auth_url={{ .KeystoneInternalURL }}
+username={{ .ServiceUser }}
+password = {{ .ServicePassword }}
+user_domain_name=Default
+project_name=service
+project_domain_name=Default
+
+[glance]
+auth_type=password
+auth_url={{ .KeystoneInternalURL }}
+username={{ .ServiceUser }}
+password = {{ .ServicePassword }}
+project_domain_name=Default
+project_name=services
+user_domain_name=Default
+
+[neutron]
+auth_type=password
+auth_url={{ .KeystoneInternalURL }}
+username={{ .ServiceUser }}
+password = {{ .ServicePassword }}
+project_domain_name=Default
+project_name=services
+user_domain_name=Default
+
+[nova]
+auth_type=password
+auth_url={{ .KeystoneInternalURL }}
+username={{ .ServiceUser }}
+password = {{ .ServicePassword }}
+project_domain_name=Default
+project_name=services
+user_domain_name=Default
+{{end}}

--- a/templates/ironicapi/config/ironic-api-config.json
+++ b/templates/ironicapi/config/ironic-api-config.json
@@ -2,37 +2,37 @@
     "command": "/usr/sbin/httpd -DFOREGROUND",
     "config_files": [
         {
-            "source": "/var/lib/config-data/merged/ironic.conf",
+            "source": "/var/lib/config-data/default/ironic.conf",
             "dest": "/etc/ironic/ironic.conf",
             "owner": "ironic",
             "perm": "0600"
         },
         {
-            "source": "/var/lib/config-data/merged/01-api.conf",
+            "source": "/var/lib/config-data/default/01-api.conf",
             "dest": "/etc/ironic/ironic.conf.d/01-api.conf",
             "owner": "ironic",
             "perm": "0600"
         },
         {
-            "source": "/var/lib/config-data/merged/02-ironic-custom.conf",
+            "source": "/var/lib/config-data/custom/02-ironic-custom.conf",
             "dest": "/etc/ironic/ironic.conf.d/02-ironic-custom.conf",
             "owner": "ironic",
             "perm": "0600"
         },
         {
-            "source": "/var/lib/config-data/merged/03-api-custom.conf",
+            "source": "/var/lib/config-data/default/03-api-custom.conf",
             "dest": "/etc/ironic/ironic.conf.d/03-api-custom.conf",
             "owner": "ironic",
             "perm": "0600"
         },
         {
-            "source": "/var/lib/config-data/merged/ironic-api-httpd.conf",
+            "source": "/var/lib/config-data/default/ironic-api-httpd.conf",
             "dest": "/etc/httpd/conf/httpd.conf",
             "owner": "root",
             "perm": "0644"
         },
         {
-            "source": "/var/lib/config-data/merged/ssl.conf",
+            "source": "/var/lib/config-data/default/ssl.conf",
             "dest": "/etc/httpd/conf.d/ssl.conf",
             "owner": "root",
             "perm": "0644"
@@ -54,7 +54,7 @@
             "merge": true
         },
         {
-            "source": "/var/lib/config-data/merged/my.cnf",
+            "source": "/var/lib/config-data/default/my.cnf",
             "dest": "/etc/my.cnf",
             "owner": "ironic",
             "perm": "0644"


### PR DESCRIPTION
With refactors in ironic-api and ironic-conductors configuration, the common.sh and ironic-init.sh files are not being used anymore to merge configuration using crudini. As a result, they can be removed from the repository and links to them can also be removed. 

Jira: [OSPRH-18581](https://issues.redhat.com/browse/OSPRH-18581)