### PR TITLE
Delete no-op reconcile functions <JIRA: OSPRH-18886>

### DIFF
--- a/controllers/ironicinspector_controller.go
+++ b/controllers/ironicinspector_controller.go
@@ -867,10 +867,6 @@ func (r *IronicInspectorReconciler) reconcileNormal(
 		return ctrlResult, nil
 	}
 
-	//
-	// TODO check when/if Init, Update, or Upgrade should/could be skipped
-	//
-
 	// networks to attach to
 	nadList := []networkv1.NetworkAttachmentDefinition{}
 	for _, netAtt := range instance.Spec.NetworkAttachments {
@@ -908,22 +904,6 @@ func (r *IronicInspectorReconciler) reconcileNormal(
 
 	// Handle service init
 	ctrlResult, err = r.reconcileInit(ctx, instance, helper, serviceLabels)
-	if err != nil {
-		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
-	}
-
-	// Handle service update
-	ctrlResult, err = r.reconcileUpdate(ctx)
-	if err != nil {
-		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
-	}
-
-	// Handle service upgrade
-	ctrlResult, err = r.reconcileUpgrade(ctx)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -1438,31 +1418,6 @@ func (r *IronicInspectorReconciler) reconcileInit(
 	}
 
 	Log.Info("Reconciled Ironic Inspector init successfully")
-	return ctrl.Result{}, nil
-}
-
-func (r *IronicInspectorReconciler) reconcileUpdate(
-	ctx context.Context,
-) (ctrl.Result, error) {
-	Log := r.GetLogger(ctx)
-
-	Log.Info("Reconciling Ironic Inspector Service update")
-
-	// TODO: should have minor update tasks if required
-	// - delete dbsync hash from status to rerun it?
-
-	return ctrl.Result{}, nil
-}
-
-func (r *IronicInspectorReconciler) reconcileUpgrade(
-	ctx context.Context,
-) (ctrl.Result, error) {
-	Log := r.GetLogger(ctx)
-	Log.Info("Reconciling Ironic Inspector Service upgrade")
-
-	// TODO: should have major version upgrade tasks
-	// -delete dbsync hash from status to rerun it?
-
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
## Describe your changes
The reconcileUpdate and reconcileUpgrade functions in ironic inspector for dbsync are handled in a different place instead and not here, so they are a no-op and can be removed. 

## Jira Ticket Link
Jira: [OSPRH-18886](https://issues.redhat.com/browse/OSPRH-18886)

## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [x] Performed `pre-commit run --all`
- [ ] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [x] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [x] podified-multinode-ironic-deployment
