### PR TITLE
[OSPRH-19691] Add unit test to pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,12 @@ repos:
       entry: make
       args: ['crd-schema-check']
       pass_filenames: false
+    - id: unit-test
+      name: make-unit-test
+      language: system
+      entry: make
+      args: ['unit-test']
+      pass_filenames: false
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0

--- a/Makefile
+++ b/Makefile
@@ -131,9 +131,9 @@ test: manifests generate fmt vet envtest ginkgo ## Run tests.
 	OPERATOR_TEMPLATES="$(PWD)/templates" \
 	$(GINKGO) --trace --cover --coverpkg=../../api/v1beta1,../../pkg/ironic,../../pkg/ironicapi,../../pkg/ironicconductor,../../pkg/ironicinspector,../../pkg/ironicneutronagent, --coverprofile cover.out --covermode=atomic --randomize-all ${PROC_CMD} $(GINKGO_ARGS) ./tests/...
 
-.PHONY: test-api
-test-api: manifests generate fmt vet envtest ## Run unit test for the API package
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./api/... -coverprofile cover.out
+.PHONY: unit-test
+unit-test:## Run unit test
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test $$(go list ./... | grep -v /tests) -coverprofile cover.out
 
 ##@ Build
 


### PR DESCRIPTION
We clsoed the #597, Add unit test for webhook. I tested the changes locally. Currently we are looking for unit tests only in api directory.

During CR we decided to increase the coverage of
unit tests so that if we add new unit tests for other functionality that are in other folders except tests it should run that as well as a pre-commit hook.

Also we decided to change file Makfile test name from test-api to unit-test.

This PR address the above issue:
1. Replacing `test-api` with `unit-test` in the Makefile.
2. Adding unit-test coverage for whole project excluding test directory.
3. Adding unit-test in the pre-commit hook.

## Describe your changes

## Jira Ticket Link
Jira: <OSPRH link>

## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [x] Performed `pre-commit run --all`
- [ ] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
