### PR TITLE
Remove no-op reconcile functions from controllers <JIRA: OSPRH-18886>

### DIFF
--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -465,16 +465,8 @@ func (r *IronicReconciler) reconcileNormal(ctx context.Context, instance *ironic
 		common.AppSelector: ironic.ServiceName,
 	}
 
-	// Handle service update
-	ctrlResult, err := r.reconcileUpdate()
-	if err != nil {
-		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
-	}
-
 	// Handle service upgrade
-	ctrlResult, err = r.reconcileUpgrade(ctx, instance, helper, serviceLabels)
+	ctrlResult, err := r.reconcileUpgrade(ctx, instance, helper, serviceLabels)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -732,13 +724,6 @@ func (r *IronicReconciler) reconcileNormal(ctx context.Context, instance *ironic
 			condition.ReadyCondition, condition.ReadyMessage)
 	}
 	Log.Info("Reconciled Ironic successfully")
-	return ctrl.Result{}, nil
-}
-
-func (r *IronicReconciler) reconcileUpdate() (ctrl.Result, error) {
-	// Log.Info("Reconciling Ironic update")
-
-	// Log.Info("Reconciled Ironic update successfully")
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/ironicapi_controller.go
+++ b/controllers/ironicapi_controller.go
@@ -845,10 +845,6 @@ func (r *IronicAPIReconciler) reconcileNormal(ctx context.Context, instance *iro
 	instance.Status.Conditions.MarkTrue(condition.ServiceConfigReadyCondition, condition.ServiceConfigReadyMessage)
 	// Create ConfigMaps and Secrets - end
 
-	//
-	// TODO check when/if Init, Update, or Upgrade should/could be skipped
-	//
-
 	serviceLabels := map[string]string{
 		common.AppSelector:       ironic.ServiceName,
 		common.ComponentSelector: ironic.APIComponent,
@@ -891,22 +887,6 @@ func (r *IronicAPIReconciler) reconcileNormal(ctx context.Context, instance *iro
 
 	// Handle service init
 	ctrlResult, err := r.reconcileInit(ctx, instance, helper, serviceLabels)
-	if err != nil {
-		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
-	}
-
-	// Handle service update
-	ctrlResult, err = r.reconcileUpdate()
-	if err != nil {
-		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
-	}
-
-	// Handle service upgrade
-	ctrlResult, err = r.reconcileUpgrade()
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -1021,20 +1001,6 @@ func (r *IronicAPIReconciler) reconcileNormal(ctx context.Context, instance *iro
 			condition.ReadyCondition, condition.ReadyMessage)
 	}
 	Log.Info("Reconciled API successfully")
-	return ctrl.Result{}, nil
-}
-
-func (r *IronicAPIReconciler) reconcileUpdate() (ctrl.Result, error) {
-	// Log.Info("Reconciling API update")
-
-	// Log.Info("Reconciled API update successfully")
-	return ctrl.Result{}, nil
-}
-
-func (r *IronicAPIReconciler) reconcileUpgrade() (ctrl.Result, error) {
-	// Log.Info("Reconciling API upgrade")
-
-	// Log.Info("Reconciled API upgrade successfully")
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -666,26 +666,6 @@ func (r *IronicConductorReconciler) reconcileNormal(ctx context.Context, instanc
 	// Create ConfigMaps and Secrets - end
 
 	//
-	// TODO check when/if Init, Update, or Upgrade should/could be skipped
-	//
-
-	// Handle service update
-	ctrlResult, err := r.reconcileUpdate()
-	if err != nil {
-		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
-	}
-
-	// Handle service upgrade
-	ctrlResult, err = r.reconcileUpgrade()
-	if err != nil {
-		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
-	}
-
-	//
 	// normal reconcile tasks
 	//
 
@@ -769,7 +749,7 @@ func (r *IronicConductorReconciler) reconcileNormal(ctx context.Context, instanc
 		time.Duration(5)*time.Second,
 	)
 
-	ctrlResult, err = ss.CreateOrPatch(ctx, helper)
+	ctrlResult, err := ss.CreateOrPatch(ctx, helper)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,
@@ -843,20 +823,6 @@ func (r *IronicConductorReconciler) reconcileNormal(ctx context.Context, instanc
 			condition.ReadyCondition, condition.ReadyMessage)
 	}
 	Log.Info("Reconciled Conductor successfully")
-	return ctrl.Result{}, nil
-}
-
-func (r *IronicConductorReconciler) reconcileUpdate() (ctrl.Result, error) {
-	// Log.Info("Reconciling Service update")
-
-	// Log.Info("Reconciled Service update successfully")
-	return ctrl.Result{}, nil
-}
-
-func (r *IronicConductorReconciler) reconcileUpgrade() (ctrl.Result, error) {
-	// Log.Info("Reconciling Service upgrade")
-
-	// Log.Info("Reconciled Service upgrade successfully")
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/ironicneutronagent_controller.go
+++ b/controllers/ironicneutronagent_controller.go
@@ -679,10 +679,6 @@ func (r *IronicNeutronAgentReconciler) reconcileNormal(
 		return ctrlResult, nil
 	}
 
-	//
-	// TODO check when/if Init, Update, or Upgrade should/could be skipped
-	//
-
 	serviceLabels := map[string]string{
 		common.AppSelector:       ironicneutronagent.ServiceName,
 		common.ComponentSelector: ironicneutronagent.ServiceName,
@@ -690,22 +686,6 @@ func (r *IronicNeutronAgentReconciler) reconcileNormal(
 
 	// Handle service init
 	ctrlResult, err = r.reconcileInit(ctx)
-	if err != nil {
-		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
-	}
-
-	// Handle service update
-	ctrlResult, err = r.reconcileUpdate(ctx)
-	if err != nil {
-		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		return ctrlResult, nil
-	}
-
-	// Handle service upgrade
-	ctrlResult, err = r.reconcileUpgrade(ctx)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -763,28 +743,6 @@ func (r *IronicNeutronAgentReconciler) reconcileDelete(
 	// Service is deleted so remove the finalizer.
 	controllerutil.RemoveFinalizer(instance, helper.GetFinalizer())
 	Log.Info("Reconciled IronicNeutronAgent delete successfully")
-
-	return ctrl.Result{}, nil
-}
-
-func (r *IronicNeutronAgentReconciler) reconcileUpdate(
-	ctx context.Context,
-) (ctrl.Result, error) {
-	Log := r.GetLogger(ctx)
-
-	Log.Info("Reconciling IronicNeutronAgent update")
-	Log.Info("Reconciled IronicNeutronAgent update successfully")
-
-	return ctrl.Result{}, nil
-}
-
-func (r *IronicNeutronAgentReconciler) reconcileUpgrade(
-	ctx context.Context,
-) (ctrl.Result, error) {
-	Log := r.GetLogger(ctx)
-
-	Log.Info("Reconciling IronicNeutronAgent upgrade")
-	Log.Info("Reconciled IronicNeutronAgent upgrade successfully")
 
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
## Describe your changes
Removes no-op reconcileUpdate/reconcileUpgrade functions from controllers. 
## Jira Ticket Link
Jira: [OSPRH-18886](https://issues.redhat.com/browse/OSPRH-18886)

## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [ ] Performed `pre-commit run --all`
- [ ] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
