### PR TITLE
Ensure rpc_transport is set in ironic.conf

### DIFF
--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -931,6 +931,10 @@ func (r *IronicReconciler) generateServiceConfigMaps(
 	}
 
 	templateParameters := make(map[string]interface{})
+
+	// Set RPC transport type for template rendering
+	templateParameters["RPCTransport"] = instance.Spec.RPCTransport
+
 	// Initialize ConductorGroup key to ensure template rendering does not fail
 	templateParameters["ConductorGroup"] = nil
 

--- a/controllers/ironicapi_controller.go
+++ b/controllers/ironicapi_controller.go
@@ -1060,6 +1060,10 @@ func (r *IronicAPIReconciler) generateServiceConfigMaps(
 	}
 
 	templateParameters := make(map[string]interface{})
+
+	// Set RPC transport type for template rendering
+	templateParameters["RPCTransport"] = instance.Spec.RPCTransport
+
 	// Initialize ConductorGroup key to ensure template rendering does not fail
 	templateParameters["ConductorGroup"] = nil
 

--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -861,6 +861,10 @@ func (r *IronicConductorReconciler) generateServiceConfigMaps(
 	}
 
 	templateParameters := make(map[string]interface{})
+
+	// Set RPC transport type for template rendering
+	templateParameters["RPCTransport"] = instance.Spec.RPCTransport
+
 	if !instance.Spec.Standalone {
 		ospSecret, _, err := secret.GetSecret(ctx, h, instance.Spec.Secret, instance.Namespace)
 		if err != nil {

--- a/templates/common/config/ironic.conf
+++ b/templates/common/config/ironic.conf
@@ -24,7 +24,7 @@ rbac_service_role_elevated_access=true
 
 default_resource_class=baremetal
 hash_ring_algorithm=sha256
-rpc_transport=json-rpc
+rpc_transport = {{ .RPCTransport }}
 transport_url = {{ .TransportURL }}
 
 use_stderr=false

--- a/templates/ironicapi/config/01-api.conf
+++ b/templates/ironicapi/config/01-api.conf
@@ -1,6 +1,5 @@
 [DEFAULT]
 # API-specific configuration overrides
-transport_url = {{ .TransportURL }}
 
 [cors]
 allowed_origin=*


### PR DESCRIPTION
Fixes an issue where `rpc_transport` is not set to `oslo` even if instance.Spec.RPCTransport is `oslo`. This caused the service to try to connect using json-rpc, which failed because json-rpc service service is only exposed when RPC Transport is json-rpc.

Set rpc_transport to match instance.Spec.RPCTransport.

Jira: [OSPRH-19936](https://issues.redhat.com//browse/OSPRH-19936)

## Describe your changes

## Jira Ticket Link
Jira: <OSPRH link>

## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [x] Performed `pre-commit run --all`
- [ ] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
