### PR TITLE
Mirror RBAC conditions from parent ironic <JIRA: OSPRH-18883>

### DIFF
--- a/controllers/ironicapi_controller.go
+++ b/controllers/ironicapi_controller.go
@@ -645,16 +645,20 @@ func (r *IronicAPIReconciler) reconcileNormal(ctx context.Context, instance *iro
 			return rbacResult, nil
 		}
 	} else {
-		// TODO(hjensas): Mirror conditions from parent, or check resource exist first
-		instance.RbacConditionsSet(condition.TrueCondition(
-			condition.ServiceAccountReadyCondition,
-			condition.ServiceAccountReadyMessage))
-		instance.RbacConditionsSet(condition.TrueCondition(
-			condition.RoleReadyCondition,
-			condition.RoleReadyMessage))
-		instance.RbacConditionsSet(condition.TrueCondition(
-			condition.RoleBindingReadyCondition,
-			condition.RoleBindingReadyMessage))
+		// mirroring RBAC conditions from parent Ironic
+		ctrlResult, err := r.checkParentResourceExist(ctx, instance, helper)
+		if err != nil {
+			return ctrlResult, err
+		} else if (ctrlResult != ctrl.Result{}) {
+			return ctrlResult, nil
+		}
+
+		ctrlResult, err = r.checkParentRbacConditions(ctx, instance, helper)
+		if err != nil {
+			return ctrlResult, err
+		} else if (ctrlResult != ctrl.Result{}) {
+			return ctrlResult, nil
+		}
 	}
 
 	// ConfigMap
@@ -1181,4 +1185,94 @@ func (r *IronicAPIReconciler) createHashOfInputHashes(
 		Log.Info(fmt.Sprintf("Input maps hash %s - %s", common.InputHashName, hash))
 	}
 	return hash, changed, nil
+}
+
+// checks for existence of parent resource
+func (r *IronicAPIReconciler) checkParentResourceExist(
+	ctx context.Context,
+	instance *ironicv1.IronicAPI,
+	helper *helper.Helper,
+) (ctrl.Result, error) {
+	parentName := ironicv1.GetOwningIronicName(instance)
+	parentIronic := &ironicv1.Ironic{}
+
+	rbacConditions := []condition.Type{
+		condition.ServiceAccountReadyCondition,
+		condition.RoleReadyCondition,
+		condition.RoleBindingReadyCondition,
+	}
+
+	err := helper.GetClient().Get(
+		ctx,
+		types.NamespacedName{
+			Name:      parentName,
+			Namespace: instance.Namespace,
+		},
+		parentIronic,
+	)
+	if err != nil {
+		if k8s_errors.IsNotFound(err) {
+			for _, condType := range rbacConditions {
+				instance.RbacConditionsSet(condition.FalseCondition(
+					condType,
+					condition.RequestedReason,
+					condition.SeverityInfo,
+					"Parent Ironic resource not found"))
+			}
+			return ctrl.Result{RequeueAfter: time.Second * 10}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// checks parent RBAC conditions and requeues if not ready
+func (r *IronicAPIReconciler) checkParentRbacConditions(
+	ctx context.Context,
+	instance *ironicv1.IronicAPI,
+	helper *helper.Helper,
+) (ctrl.Result, error) {
+	parentName := ironicv1.GetOwningIronicName(instance)
+	parentIronic := &ironicv1.Ironic{}
+
+	rbacConditions := []condition.Type{
+		condition.ServiceAccountReadyCondition,
+		condition.RoleReadyCondition,
+		condition.RoleBindingReadyCondition,
+	}
+
+	err := helper.GetClient().Get(
+		ctx,
+		types.NamespacedName{
+			Name:      parentName,
+			Namespace: instance.Namespace,
+		},
+		parentIronic,
+	)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	allConditionsReady := true
+	for _, condType := range rbacConditions {
+		if parentCondition := parentIronic.Status.Conditions.Get(condType); parentCondition != nil {
+			instance.RbacConditionsSet(parentCondition)
+			if parentCondition.Status != corev1.ConditionTrue {
+				allConditionsReady = false
+			}
+		} else {
+			instance.RbacConditionsSet(condition.UnknownCondition(
+				condType,
+				condition.InitReason,
+				"Parent RBAC condition not yet available"))
+			allConditionsReady = false
+		}
+	}
+
+	// requeue if any condition returns false
+	if !allConditionsReady {
+		return ctrl.Result{RequeueAfter: time.Second * 10}, nil
+	}
+
+	return ctrl.Result{}, nil
 }

--- a/controllers/ironicinspector_controller.go
+++ b/controllers/ironicinspector_controller.go
@@ -858,16 +858,19 @@ func (r *IronicInspectorReconciler) reconcileNormal(
 			return rbacResult, nil
 		}
 	} else {
-		// TODO(hjensas): Mirror conditions from parent, or check resource exist first
-		instance.RbacConditionsSet(condition.TrueCondition(
-			condition.ServiceAccountReadyCondition,
-			condition.ServiceAccountReadyMessage))
-		instance.RbacConditionsSet(condition.TrueCondition(
-			condition.RoleReadyCondition,
-			condition.RoleReadyMessage))
-		instance.RbacConditionsSet(condition.TrueCondition(
-			condition.RoleBindingReadyCondition,
-			condition.RoleBindingReadyMessage))
+		ctrlResult, err := r.checkParentResourceExist(ctx, instance, helper)
+		if err != nil {
+			return ctrlResult, err
+		} else if (ctrlResult != ctrl.Result{}) {
+			return ctrlResult, nil
+		}
+
+		ctrlResult, err = r.checkParentRbacConditions(ctx, instance, helper)
+		if err != nil {
+			return ctrlResult, err
+		} else if (ctrlResult != ctrl.Result{}) {
+			return ctrlResult, nil
+		}
 	}
 
 	ctrlResult, err := r.reconcileTransportURL(ctx, instance, helper)
@@ -1620,6 +1623,94 @@ func (r *IronicInspectorReconciler) createHashOfInputHashes(
 		Log.Info(fmt.Sprintf("Input maps hash %s - %s", common.InputHashName, hash))
 	}
 	return hash, changed, nil
+}
+
+func (r *IronicInspectorReconciler) checkParentResourceExist(
+	ctx context.Context,
+	instance *ironicv1.IronicInspector,
+	helper *helper.Helper,
+) (ctrl.Result, error) {
+	parentName := ironicv1.GetOwningIronicName(instance)
+	parentIronic := &ironicv1.Ironic{}
+
+	rbacConditions := []condition.Type{
+		condition.ServiceAccountReadyCondition,
+		condition.RoleReadyCondition,
+		condition.RoleBindingReadyCondition,
+	}
+
+	// checks for existence of parent resource
+	err := helper.GetClient().Get(
+		ctx,
+		types.NamespacedName{
+			Name:      parentName,
+			Namespace: instance.Namespace,
+		},
+		parentIronic,
+	)
+	if err != nil {
+		if k8s_errors.IsNotFound(err) {
+			for _, condType := range rbacConditions {
+				instance.RbacConditionsSet(condition.FalseCondition(
+					condType,
+					condition.RequestedReason,
+					condition.SeverityInfo,
+					"Parent Ironic resource not found"))
+			}
+			return ctrl.Result{RequeueAfter: time.Second * 10}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *IronicInspectorReconciler) checkParentRbacConditions(
+	ctx context.Context,
+	instance *ironicv1.IronicInspector,
+	helper *helper.Helper,
+) (ctrl.Result, error) {
+	parentName := ironicv1.GetOwningIronicName(instance)
+	parentIronic := &ironicv1.Ironic{}
+
+	rbacConditions := []condition.Type{
+		condition.ServiceAccountReadyCondition,
+		condition.RoleReadyCondition,
+		condition.RoleBindingReadyCondition,
+	}
+
+	err := helper.GetClient().Get(
+		ctx,
+		types.NamespacedName{
+			Name:      parentName,
+			Namespace: instance.Namespace,
+		},
+		parentIronic,
+	)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	allConditionsReady := true
+	for _, condType := range rbacConditions {
+		if parentCondition := parentIronic.Status.Conditions.Get(condType); parentCondition != nil {
+			instance.RbacConditionsSet(parentCondition)
+			if parentCondition.Status != corev1.ConditionTrue {
+				allConditionsReady = false
+			}
+		} else {
+			instance.RbacConditionsSet(condition.UnknownCondition(
+				condType,
+				condition.InitReason,
+				"Parent RBAC condition not yet available"))
+			allConditionsReady = false
+		}
+	}
+
+	if !allConditionsReady {
+		return ctrl.Result{RequeueAfter: time.Second * 10}, nil
+	}
+
+	return ctrl.Result{}, nil
 }
 
 func (r *IronicInspectorReconciler) reconcileServices(

--- a/tests/functional/ironicinspector_controller_test.go
+++ b/tests/functional/ironicinspector_controller_test.go
@@ -25,10 +25,13 @@ import (
 	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 
+	ironicv1 "github.com/openstack-k8s-operators/ironic-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	mariadb_test "github.com/openstack-k8s-operators/mariadb-operator/api/test/helpers"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("IronicInspector controller", func() {
@@ -605,6 +608,102 @@ var _ = Describe("IronicInspector controller", func() {
 				ContainSubstring(fmt.Sprintf("connection=mysql+pymysql://%s:%s@hostname-for-openstack.%s.svc/ironic_inspector?read_default_file=/etc/my.cnf",
 					username, password, ironicNames.Namespace)))
 		}).Should(Succeed())
+	})
+
+	When("IronicInspector mirrors parent RBAC conditions", func() {
+
+		It("should mirror parent RBAC conditions when child service", func() {
+			parentIronic := &ironicv1.Ironic{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ironicNames.IronicName.Name,
+					Namespace: ironicNames.Namespace,
+				},
+				Spec: ironicv1.IronicSpec{
+					IronicSpecCore: ironicv1.IronicSpecCore{
+						DatabaseInstance: DatabaseInstance,
+						Secret:           SecretName,
+						APITimeout:       60,
+						ServiceUser:      "ironic",
+						IronicConductors: []ironicv1.IronicConductorTemplate{{
+							StorageRequest: "10G",
+						}},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, parentIronic)).Should(Succeed())
+			DeferCleanup(k8sClient.Delete, ctx, parentIronic)
+
+			// set parent RBAC conditions to true
+			Eventually(func(g Gomega) {
+				parent := &ironicv1.Ironic{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name:      ironicNames.IronicName.Name,
+					Namespace: ironicNames.Namespace,
+				}, parent)).Should(Succeed())
+
+				parent.Status.Conditions.Set(condition.TrueCondition(
+					condition.ServiceAccountReadyCondition,
+					"ServiceAccount created"))
+				parent.Status.Conditions.Set(condition.TrueCondition(
+					condition.RoleReadyCondition,
+					"Role created"))
+				parent.Status.Conditions.Set(condition.TrueCondition(
+					condition.RoleBindingReadyCondition,
+					"RoleBinding created"))
+
+				g.Expect(k8sClient.Status().Update(ctx, parent)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			spec := GetDefaultIronicInspectorSpec()
+			spec["rpcTransport"] = "oslo"
+			spec["transportURLSecret"] = MessageBusSecretName
+			inspector := CreateIronicInspector(ironicNames.InspectorName, spec)
+			DeferCleanup(th.DeleteInstance, inspector)
+
+			th.ExpectCondition(
+				ironicNames.InspectorName,
+				ConditionGetterFunc(IronicInspectorConditionGetter),
+				condition.ServiceAccountReadyCondition,
+				corev1.ConditionTrue,
+			)
+
+			// set ironicInspector object is owned by parent ironic object
+			Eventually(func(g Gomega) {
+				parent := GetIronic(ironicNames.IronicName)
+				inspectorObj := GetIronicInspector(ironicNames.InspectorName)
+				inspectorObj.SetOwnerReferences([]metav1.OwnerReference{{
+					APIVersion:         "ironic.openstack.org/v1beta1",
+					Kind:               "Ironic",
+					Name:               parent.Name,
+					UID:                parent.UID,
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				}})
+				g.Expect(k8sClient.Update(ctx, inspectorObj)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			// checks that inspector mirrors parent conditions
+			Eventually(func(g Gomega) {
+				inspectorObj := GetIronicInspector(ironicNames.InspectorName)
+				serviceAccountCondition := inspectorObj.Status.Conditions.Get(condition.ServiceAccountReadyCondition)
+				g.Expect(serviceAccountCondition).ToNot(BeNil())
+				g.Expect(serviceAccountCondition.Status).To(Equal(corev1.ConditionTrue))
+				g.Expect(serviceAccountCondition.Message).To(Equal("ServiceAccount created"))
+			}, timeout, interval).Should(Succeed())
+
+			th.ExpectCondition(
+				ironicNames.InspectorName,
+				ConditionGetterFunc(IronicInspectorConditionGetter),
+				condition.RoleReadyCondition,
+				corev1.ConditionTrue,
+			)
+			th.ExpectCondition(
+				ironicNames.InspectorName,
+				ConditionGetterFunc(IronicInspectorConditionGetter),
+				condition.RoleBindingReadyCondition,
+				corev1.ConditionTrue,
+			)
+		})
 	})
 
 })


### PR DESCRIPTION
## Describe your changes
Implements the TODO comment in the controllers for the operator by mirroring the RBAC conditions from parent Ironic instead of setting it as true by default. 

## Jira Ticket Link
Jira: [OSPRH-18883](https://issues.redhat.com/browse/OSPRH-18883)

## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [x] Performed `pre-commit run --all`
- [ ] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
