### PR TITLE
Rework keystone registration logic <JIRA: OSPRH-18883>

### DIFF
--- a/controllers/ironicapi_controller.go
+++ b/controllers/ironicapi_controller.go
@@ -60,6 +60,8 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
+
+	keystone "github.com/openstack-k8s-operators/ironic-operator/pkg/keystone"
 )
 
 // IronicAPIReconciler reconciles a IronicAPI object
@@ -563,65 +565,25 @@ func (r *IronicAPIReconciler) reconcileInit(
 
 	// expose service - end
 
-	//
-	// create users and endpoints
-	// TODO: rework this
-	//
 	if !instance.Spec.Standalone {
 		for _, ksSvc := range keystoneServices {
-			Log.Info("Reconciled API init successfully")
-			ksSvcSpec := keystonev1.KeystoneServiceSpec{
+			registration := keystone.ServiceRegistration{
+				Namespace:          instance.Namespace,
 				ServiceType:        ksSvc["type"],
 				ServiceName:        ksSvc["name"],
 				ServiceDescription: ksSvc["desc"],
-				Enabled:            true,
 				ServiceUser:        instance.Spec.ServiceUser,
 				Secret:             instance.Spec.Secret,
 				PasswordSelector:   instance.Spec.PasswordSelectors.Service,
+				Endpoints:          instance.Status.APIEndpoints[ksSvc["name"]],
+				Labels:             serviceLabels,
+				TimeoutSeconds:     10,
 			}
-
-			ksSvcObj := keystonev1.NewKeystoneService(ksSvcSpec, instance.Namespace, serviceLabels, 10)
-			ctrlResult, err := ksSvcObj.CreateOrPatch(ctx, helper)
+			// shared helper to create Keystone service and generate endpoints
+			ctrlResult, err := keystone.EnsureRegistration(ctx, helper, registration, &instance.Status.Conditions)
 			if err != nil {
 				return ctrlResult, err
-			}
-
-			// mirror the Status, Reason, Severity and Message of the latest keystoneservice condition
-			// into a local condition with the type condition.KeystoneServiceReadyCondition
-			c := ksSvcObj.GetConditions().Mirror(condition.KeystoneServiceReadyCondition)
-			if c != nil {
-				instance.Status.Conditions.Set(c)
-			}
-
-			if (ctrlResult != ctrl.Result{}) {
-				return ctrlResult, nil
-			}
-
-			//
-			// register endpoints
-			//
-			ksEndptSpec := keystonev1.KeystoneEndpointSpec{
-				ServiceName: ksSvc["name"],
-				Endpoints:   instance.Status.APIEndpoints[ksSvc["name"]],
-			}
-			ksEndpt := keystonev1.NewKeystoneEndpoint(
-				ksSvc["name"],
-				instance.Namespace,
-				ksEndptSpec,
-				serviceLabels,
-				10)
-			ctrlResult, err = ksEndpt.CreateOrPatch(ctx, helper)
-			if err != nil {
-				return ctrlResult, err
-			}
-			// mirror the Status, Reason, Severity and Message of the latest keystoneendpoint condition
-			// into a local condition with the type condition.KeystoneEndpointReadyCondition
-			c = ksEndpt.GetConditions().Mirror(condition.KeystoneEndpointReadyCondition)
-			if c != nil {
-				instance.Status.Conditions.Set(c)
-			}
-
-			if (ctrlResult != ctrl.Result{}) {
+			} else if (ctrlResult != ctrl.Result{}) {
 				return ctrlResult, nil
 			}
 		}

--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -464,11 +464,6 @@ func (r *IronicConductorReconciler) reconcileServices(
 		}
 	}
 
-	//
-	// create users and endpoints
-	// TODO: rework this
-	//
-
 	Log.Info("Reconciled Conductor Services successfully")
 	return ctrl.Result{}, nil
 }

--- a/pkg/keystone/keystone_registration.go
+++ b/pkg/keystone/keystone_registration.go
@@ -1,0 +1,86 @@
+// Package keystone contains helpers to interact with Keystone-related CRs.
+package keystone
+
+import (
+	"context"
+	"time"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+)
+
+// ServiceRegistration captures the inputs required to register a Keystone service and its endpoints.
+type ServiceRegistration struct {
+	Namespace          string
+	ServiceType        string
+	ServiceName        string
+	ServiceDescription string
+	ServiceUser        string
+	Secret             string
+	PasswordSelector   string
+	Endpoints          map[string]string
+	Labels             map[string]string
+	TimeoutSeconds     int
+}
+
+// EnsureRegistration ensures KeystoneService and KeystoneEndpoint exist and mirrors their conditions.
+func EnsureRegistration(
+	ctx context.Context,
+	h *helper.Helper,
+	registration ServiceRegistration,
+	conditions *condition.Conditions,
+) (ctrl.Result, error) {
+	ksSvcSpec := keystonev1.KeystoneServiceSpec{
+		ServiceType:        registration.ServiceType,
+		ServiceName:        registration.ServiceName,
+		ServiceDescription: registration.ServiceDescription,
+		Enabled:            true,
+		ServiceUser:        registration.ServiceUser,
+		Secret:             registration.Secret,
+		PasswordSelector:   registration.PasswordSelector,
+	}
+
+	ksSvcObj := keystonev1.NewKeystoneService(ksSvcSpec, registration.Namespace, registration.Labels, time.Duration(registration.TimeoutSeconds))
+	ctrlResult, err := ksSvcObj.CreateOrPatch(ctx, h)
+	if err != nil {
+		return ctrlResult, err
+	}
+	// mirror the Status, Reason, Severity and Message of the latest keystoneendpoint condition
+	// into a local condition with the type condition.KeystoneEndpointReadyCondition
+	if c := ksSvcObj.GetConditions().Mirror(condition.KeystoneServiceReadyCondition); c != nil {
+		conditions.Set(c)
+	}
+	if (ctrlResult != ctrl.Result{}) {
+		return ctrlResult, nil
+	}
+
+	// register endpoints
+	ksEndptSpec := keystonev1.KeystoneEndpointSpec{
+		ServiceName: registration.ServiceName,
+		Endpoints:   registration.Endpoints,
+	}
+	ksEndpt := keystonev1.NewKeystoneEndpoint(
+		registration.ServiceName,
+		registration.Namespace,
+		ksEndptSpec,
+		registration.Labels,
+		time.Duration(registration.TimeoutSeconds),
+	)
+	ctrlResult, err = ksEndpt.CreateOrPatch(ctx, h)
+	if err != nil {
+		return ctrlResult, err
+	}
+	// mirror the Status, Reason, Severity and Message of the latest keystoneendpoint condition
+	// into a local condition with the type condition.KeystoneEndpointReadyCondition
+	if c := ksEndpt.GetConditions().Mirror(condition.KeystoneEndpointReadyCondition); c != nil {
+		conditions.Set(c)
+	}
+	if (ctrlResult != ctrl.Result{}) {
+		return ctrlResult, nil
+	}
+
+	return ctrl.Result{}, nil
+}


### PR DESCRIPTION
## Describe your changes
Reworked keystone registration logic to be a single helper function instead of repeating in multiple places. 

## Jira Ticket Link
Jira: [OSPRH-18883](https://issues.redhat.com/browse/OSPRH-18883)

## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [x] Performed `pre-commit run --all`
- [x] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [x] ironic-operator-build-deploy-kuttl
  - [x] podified-multinode-ironic-deployment
