### PR TITLE
Remove TODO comments from conductor<JIRA: OSPRH-18881>

### DIFF
--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -292,7 +292,7 @@ func (r *IronicConductorReconciler) findObjectsForSrc(ctx context.Context, src c
 		Log.Error(err, "Unable to retrieve Conductor CRs %v")
 	} else {
 		label := src.GetLabels()
-		// TODO: Just trying to verify that the Secret is owned by this CR's managing CR
+		// NOTE: not enforcing ownership due to risk of breakage
 		if lbl, ok := label[labels.GetOwnerNameLabelSelector(labels.GetGroupLabel(ironic.ServiceName))]; ok {
 			for _, item := range crList.Items {
 				// return reconcil event for the CR where the Secret owner label AND the parentIronicName matches

--- a/pkg/ironicconductor/statefulset.go
+++ b/pkg/ironicconductor/statefulset.go
@@ -90,7 +90,6 @@ func StatefulSet(
 	//
 
 	if instance.Spec.RPCTransport == "json-rpc" {
-		// (TODO) Make a http request to the JSON-RPC port ?
 		livenessProbe.TCPSocket = &corev1.TCPSocketAction{
 			Port: intstr.IntOrString{Type: intstr.Int, IntVal: int32(8089)},
 		}
@@ -98,13 +97,11 @@ func StatefulSet(
 			Port: intstr.IntOrString{Type: intstr.Int, IntVal: int32(8089)},
 		}
 	} else {
-		// TODO
 		livenessProbe.Exec = &corev1.ExecAction{
 			Command: []string{
 				"/bin/true",
 			},
 		}
-		// TODO
 		readinessProbe.Exec = &corev1.ExecAction{
 			Command: []string{
 				"/bin/true",


### PR DESCRIPTION
## Describe your changes
In ironic conductor there are some TODOs that will not be implemented, these have been removed in this PR. 

## Jira Ticket Link
Jira: [OSPRH-18881](https://issues.redhat.com/browse/OSPRH-18881)

## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [x] Performed `pre-commit run --all`
- [ ] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
