### PR TITLE
[OSPRH-20312] Improve consistency of condition severity usage

### DIFF
--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -365,11 +365,13 @@ func (r *IronicReconciler) reconcileNormal(ctx context.Context, instance *ironic
 	ospSecret, hash, err := oko_secret.GetSecret(ctx, helper, instance.Spec.Secret, instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
+			// Since the OpenStack secret should have been manually created by the user and referenced in the spec,
+			// we treat this as a warning because it means that the service will not be able to start.
 			Log.Info(fmt.Sprintf("OpenStack secret %s not found", instance.Spec.Secret))
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				condition.InputReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
+				condition.ErrorReason,
+				condition.SeverityWarning,
 				condition.InputReadyWaitingMessage))
 			return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 		}

--- a/controllers/ironicapi_controller.go
+++ b/controllers/ironicapi_controller.go
@@ -638,11 +638,14 @@ func (r *IronicAPIReconciler) reconcileNormal(ctx context.Context, instance *iro
 			hash, err := secret.Hash(&s)
 			if err != nil {
 				if k8s_errors.IsNotFound(err) {
+					// Since config secrets should have been previously automatically created by the parent
+					// Ironic CR and then referenced in this instance's spec, we treat this as a warning
+					// because it means that the service will not be able to start.
 					Log.Info(fmt.Sprintf("OpenStack secret %s not found", instance.Spec.Secret))
 					instance.Status.Conditions.Set(condition.FalseCondition(
 						condition.InputReadyCondition,
-						condition.RequestedReason,
-						condition.SeverityInfo,
+						condition.ErrorReason,
+						condition.SeverityWarning,
 						condition.InputReadyWaitingMessage))
 					return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 				}
@@ -663,11 +666,13 @@ func (r *IronicAPIReconciler) reconcileNormal(ctx context.Context, instance *iro
 	ospSecret, hash, err := secret.GetSecret(ctx, helper, instance.Spec.Secret, instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
+			// Since the OpenStack secret should have been manually created by the user and referenced in the spec,
+			// we treat this as a warning because it means that the service will not be able to start.
 			Log.Info(fmt.Sprintf("OpenStack secret %s not found", instance.Spec.Secret))
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				condition.InputReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
+				condition.ErrorReason,
+				condition.SeverityWarning,
 				condition.InputReadyWaitingMessage))
 			return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 		}
@@ -689,11 +694,14 @@ func (r *IronicAPIReconciler) reconcileNormal(ctx context.Context, instance *iro
 		transportURLSecret, hash, err := secret.GetSecret(ctx, helper, instance.Spec.TransportURLSecret, instance.Namespace)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the TransportURL secret should have been previously automatically created by the parent
+				// Ironic CR and then referenced in this instance's spec, we treat this as a warning because it
+				// means that the service will not be able to start.
 				Log.Info(fmt.Sprintf("TransportURL secret %s not found", instance.Spec.TransportURLSecret))
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.InputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.InputReadyWaitingMessage))
 				return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 			}
@@ -726,10 +734,12 @@ func (r *IronicAPIReconciler) reconcileNormal(ctx context.Context, instance *iro
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
@@ -822,11 +832,13 @@ func (r *IronicAPIReconciler) reconcileNormal(ctx context.Context, instance *iro
 		nad, err := nad.GetNADWithName(ctx, helper, netAtt, instance.Namespace)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the net-attach-def CR should have been manually created by the user and referenced in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				Log.Info(fmt.Sprintf("network-attachment-definition %s not found", netAtt))
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.NetworkAttachmentsReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.NetworkAttachmentsReadyWaitingMessage,
 					netAtt))
 				return ctrl.Result{RequeueAfter: time.Second * 10}, nil

--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -512,11 +512,14 @@ func (r *IronicConductorReconciler) reconcileNormal(ctx context.Context, instanc
 			hash, err := secret.Hash(&s)
 			if err != nil {
 				if k8s_errors.IsNotFound(err) {
+					// Since config secrets should have been previously automatically created by the parent
+					// Ironic CR and then referenced in this instance's spec, we treat this as a warning
+					// because it means that the service will not be able to start.
 					Log.Info(fmt.Sprintf("OpenStack secret %s not found", instance.Spec.Secret))
 					instance.Status.Conditions.Set(condition.FalseCondition(
 						condition.InputReadyCondition,
-						condition.RequestedReason,
-						condition.SeverityInfo,
+						condition.ErrorReason,
+						condition.SeverityWarning,
 						condition.InputReadyWaitingMessage))
 					return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 				}
@@ -537,11 +540,13 @@ func (r *IronicConductorReconciler) reconcileNormal(ctx context.Context, instanc
 	ospSecret, hash, err := secret.GetSecret(ctx, helper, instance.Spec.Secret, instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
+			// Since the OpenStack secret should have been manually created by the user and referenced in the spec,
+			// we treat this as a warning because it means that the service will not be able to start.
 			Log.Info(fmt.Sprintf("OpenStack secret %s not found", instance.Spec.Secret))
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				condition.InputReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
+				condition.ErrorReason,
+				condition.SeverityWarning,
 				condition.InputReadyWaitingMessage))
 			return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 		}
@@ -563,11 +568,14 @@ func (r *IronicConductorReconciler) reconcileNormal(ctx context.Context, instanc
 		transportURLSecret, hash, err := secret.GetSecret(ctx, helper, instance.Spec.TransportURLSecret, instance.Namespace)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the TransportURL secret should have been previously automatically created by the parent
+				// Ironic CR and then referenced in this instance's spec, we treat this as a warning because it
+				// means that the service will not be able to start.
 				Log.Info(fmt.Sprintf("TransportURL secret %s not found", instance.Spec.TransportURLSecret))
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.InputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.InputReadyWaitingMessage))
 				return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 			}
@@ -600,10 +608,12 @@ func (r *IronicConductorReconciler) reconcileNormal(ctx context.Context, instanc
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
@@ -682,11 +692,13 @@ func (r *IronicConductorReconciler) reconcileNormal(ctx context.Context, instanc
 		nad, err := nad.GetNADWithName(ctx, helper, netAtt, instance.Namespace)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the net-attach-def CR should have been manually created by the user and referenced in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				Log.Info(fmt.Sprintf("network-attachment-definition %s not found", netAtt))
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.NetworkAttachmentsReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.NetworkAttachmentsReadyWaitingMessage,
 					netAtt))
 				return ctrl.Result{RequeueAfter: time.Second * 10}, nil

--- a/controllers/ironicinspector_controller.go
+++ b/controllers/ironicinspector_controller.go
@@ -561,12 +561,14 @@ func (r *IronicInspectorReconciler) reconcileConfigMapsAndSecrets(
 		instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
+			// Since the OpenStack secret should have been manually created by the user and referenced in the spec,
+			// we treat this as a warning because it means that the service will not be able to start.
 			Log.Info(fmt.Sprintf("OpenStack secret %s not found", instance.Spec.Secret))
 			instance.Status.Conditions.Set(
 				condition.FalseCondition(
 					condition.InputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.InputReadyWaitingMessage))
 			return ctrl.Result{RequeueAfter: time.Second * 10}, "", nil
 		}
@@ -586,6 +588,7 @@ func (r *IronicInspectorReconciler) reconcileConfigMapsAndSecrets(
 		transportURLSecret, hash, err := oko_secret.GetSecret(ctx, helper, instance.Status.TransportURLSecret, instance.Namespace)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// This controller itself creates the TransportURL secret, so we treat this as an info.
 				Log.Info(fmt.Sprintf("TransportURL secret %s not found", instance.Status.TransportURLSecret))
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.InputReadyCondition,
@@ -625,10 +628,12 @@ func (r *IronicInspectorReconciler) reconcileConfigMapsAndSecrets(
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{RequeueAfter: time.Second * 10}, "", nil
 			}
@@ -901,11 +906,13 @@ func (r *IronicInspectorReconciler) reconcileNormal(
 		nad, err := nad.GetNADWithName(ctx, helper, netAtt, instance.Namespace)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the net-attach-def CR should have been manually created by the user and referenced in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				Log.Info(fmt.Sprintf("network-attachment-definition %s not found", netAtt))
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.NetworkAttachmentsReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.NetworkAttachmentsReadyWaitingMessage,
 					netAtt))
 				return ctrl.Result{RequeueAfter: time.Second * 10}, nil

--- a/controllers/ironicneutronagent_controller.go
+++ b/controllers/ironicneutronagent_controller.go
@@ -431,11 +431,13 @@ func (r *IronicNeutronAgentReconciler) reconcileConfigMapsAndSecrets(
 	ospSecret, hash, err := secret.GetSecret(ctx, helper, instance.Spec.Secret, instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
+			// Since the OpenStack secret should have been manually created by the user and referenced in the spec,
+			// we treat this as a warning because it means that the service will not be able to start.
 			Log.Info(fmt.Sprintf("OpenStack secret %s not found", instance.Spec.Secret))
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				condition.InputReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
+				condition.ErrorReason,
+				condition.SeverityWarning,
 				condition.InputReadyWaitingMessage))
 			return ctrl.Result{RequeueAfter: time.Second * 10}, "", nil
 		}
@@ -454,6 +456,7 @@ func (r *IronicNeutronAgentReconciler) reconcileConfigMapsAndSecrets(
 		transportURLSecret, hash, err := secret.GetSecret(ctx, helper, instance.Status.TransportURLSecret, instance.Namespace)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// This controller itself creates the TransportURL secret, so we treat this as an info.
 				Log.Info(fmt.Sprintf("TransportURL secret %s not found", instance.Status.TransportURLSecret))
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.InputReadyCondition,
@@ -493,10 +496,12 @@ func (r *IronicNeutronAgentReconciler) reconcileConfigMapsAndSecrets(
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{RequeueAfter: time.Second * 10}, "", nil
 			}
@@ -876,11 +881,12 @@ func (r *IronicNeutronAgentReconciler) checkParentResourceExist(
 	)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
+			// If the parent Ironic is somehow missing, we treat this as a warning.
 			for _, condType := range rbacConditions {
 				instance.RbacConditionsSet(condition.FalseCondition(
 					condType,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					"Parent Ironic resource not found"))
 			}
 			return ctrl.Result{RequeueAfter: time.Second * 10}, nil

--- a/tests/functional/ironicapi_controller_test.go
+++ b/tests/functional/ironicapi_controller_test.go
@@ -282,7 +282,7 @@ var _ = Describe("IronicAPI controller", func() {
 				ConditionGetterFunc(IronicAPIConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				fmt.Sprintf("TLSInput is missing: %s", ironicNames.CaBundleSecretName.Name),
 			)
 			th.ExpectCondition(

--- a/tests/functional/ironicconductor_controller_test.go
+++ b/tests/functional/ironicconductor_controller_test.go
@@ -255,7 +255,7 @@ var _ = Describe("IronicConductor controller", func() {
 				ConditionGetterFunc(IronicConductorConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				fmt.Sprintf("TLSInput is missing: %s", ironicNames.CaBundleSecretName.Name),
 			)
 			th.ExpectCondition(

--- a/tests/functional/ironicinspector_controller_test.go
+++ b/tests/functional/ironicinspector_controller_test.go
@@ -332,7 +332,7 @@ var _ = Describe("IronicInspector controller", func() {
 				ConditionGetterFunc(IronicInspectorConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				fmt.Sprintf("TLSInput is missing: %s", ironicNames.CaBundleSecretName.Name),
 			)
 			th.ExpectCondition(

--- a/tests/functional/ironicneutronagent_controller_test.go
+++ b/tests/functional/ironicneutronagent_controller_test.go
@@ -125,7 +125,7 @@ var _ = Describe("IronicNeutronAgent controller", func() {
 				ConditionGetterFunc(INAConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				"Input data resources missing",
 			)
 		})
@@ -161,7 +161,7 @@ var _ = Describe("IronicNeutronAgent controller", func() {
 					ConditionGetterFunc(INAConditionGetter),
 					condition.InputReadyCondition,
 					corev1.ConditionFalse,
-					condition.RequestedReason,
+					condition.ErrorReason,
 					"Input data resources missing",
 				)
 			})
@@ -238,7 +238,7 @@ var _ = Describe("IronicNeutronAgent controller", func() {
 				ConditionGetterFunc(INAConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				fmt.Sprintf("TLSInput is missing: %s", ironicNames.CaBundleSecretName.Name),
 			)
 			th.ExpectCondition(


### PR DESCRIPTION
Use consistent condition severity across repeated patterns found in our operators, and otherwise use an appropriate severity for conditions unique to each operator.

Jira: https://issues.redhat.com/browse/OSPRH-20312

Co-authored-by: Claude (Anthropic) claude@anthropic.com

## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [x] Performed `pre-commit run --all`
- [x] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
