### PR TITLE
Modernize Go code with latest style conventions

### DIFF
--- a/controllers/funcs.go
+++ b/controllers/funcs.go
@@ -91,7 +91,7 @@ func getCommonRbacRules() []rbacv1.PolicyRule {
 
 type conditionUpdater interface {
 	Set(c *condition.Condition)
-	MarkTrue(t condition.Type, messageFormat string, messageArgs ...interface{})
+	MarkTrue(t condition.Type, messageFormat string, messageArgs ...any)
 }
 
 type topologyHandler interface {

--- a/controllers/ironic_controller.go
+++ b/controllers/ironic_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -567,9 +568,7 @@ func (r *IronicReconciler) reconcileNormal(ctx context.Context, instance *ironic
 		))
 	} else {
 		// Mirror IronicAPI status' APIEndpoints and ReadyCount to this parent CR
-		for k, v := range ironicAPI.Status.APIEndpoints {
-			instance.Status.APIEndpoints[k] = v
-		}
+		maps.Copy(instance.Status.APIEndpoints, ironicAPI.Status.APIEndpoints)
 		instance.Status.IronicAPIReadyCount = ironicAPI.Status.ReadyCount
 
 		// Mirror IronicAPI's condition status
@@ -619,9 +618,7 @@ func (r *IronicReconciler) reconcileNormal(ctx context.Context, instance *ironic
 			))
 		} else {
 			// Mirror IronicInspector status APIEndpoints and ReadyCount to this parent CR
-			for k, v := range ironicInspector.Status.APIEndpoints {
-				instance.Status.APIEndpoints[k] = v
-			}
+			maps.Copy(instance.Status.APIEndpoints, ironicInspector.Status.APIEndpoints)
 			instance.Status.InspectorReadyCount = ironicInspector.Status.ReadyCount
 
 			// Mirror IronicInspector's condition status
@@ -926,11 +923,9 @@ func (r *IronicReconciler) generateServiceConfigMaps(
 		"my.cnf":                db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
 
 	}
-	for key, data := range instance.Spec.DefaultConfigOverwrite {
-		customData[key] = data
-	}
+	maps.Copy(customData, instance.Spec.DefaultConfigOverwrite)
 
-	templateParameters := make(map[string]interface{})
+	templateParameters := make(map[string]any)
 
 	// Set RPC transport type for template rendering
 	templateParameters["RPCTransport"] = instance.Spec.RPCTransport

--- a/controllers/ironicapi_controller.go
+++ b/controllers/ironicapi_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -1021,11 +1022,9 @@ func (r *IronicAPIReconciler) generateServiceConfigMaps(
 		"my.cnf":             db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
 	}
 
-	for key, data := range instance.Spec.DefaultConfigOverwrite {
-		customData[key] = data
-	}
+	maps.Copy(customData, instance.Spec.DefaultConfigOverwrite)
 
-	templateParameters := make(map[string]interface{})
+	templateParameters := make(map[string]any)
 
 	// Set RPC transport type for template rendering
 	templateParameters["RPCTransport"] = instance.Spec.RPCTransport
@@ -1077,9 +1076,9 @@ func (r *IronicAPIReconciler) generateServiceConfigMaps(
 	)
 
 	// create httpd  vhost template parameters
-	httpdVhostConfig := map[string]interface{}{}
+	httpdVhostConfig := map[string]any{}
 	for _, endpt := range []service.Endpoint{service.EndpointInternal, service.EndpointPublic} {
-		endptConfig := map[string]interface{}{}
+		endptConfig := map[string]any{}
 		endptConfig["ServerName"] = fmt.Sprintf("%s-%s.%s.svc", ironic.ServiceName, endpt.String(), instance.Namespace)
 		endptConfig["TLS"] = false // default TLS to false, and set it below to true if enabled
 		if instance.Spec.TLS.API.Enabled(endpt) {

--- a/controllers/ironicconductor_controller.go
+++ b/controllers/ironicconductor_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -854,11 +855,9 @@ func (r *IronicConductorReconciler) generateServiceConfigMaps(
 		"my.cnf":                   db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
 	}
 
-	for key, data := range instance.Spec.DefaultConfigOverwrite {
-		customData[key] = data
-	}
+	maps.Copy(customData, instance.Spec.DefaultConfigOverwrite)
 
-	templateParameters := make(map[string]interface{})
+	templateParameters := make(map[string]any)
 
 	// Set RPC transport type for template rendering
 	templateParameters["RPCTransport"] = instance.Spec.RPCTransport

--- a/controllers/ironicinspector_controller.go
+++ b/controllers/ironicinspector_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -1436,10 +1437,8 @@ func (r *IronicInspectorReconciler) generateServiceSecrets(
 		"02-inspector-custom.conf": instance.Spec.CustomServiceConfig,
 		"my.cnf":                   db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
 	}
-	for key, data := range instance.Spec.DefaultConfigOverwrite {
-		customData[key] = data
-	}
-	templateParameters := make(map[string]interface{})
+	maps.Copy(customData, instance.Spec.DefaultConfigOverwrite)
+	templateParameters := make(map[string]any)
 
 	transportURL, err := r.getTransportURL(ctx, h, instance)
 	if err != nil {
@@ -1518,9 +1517,9 @@ func (r *IronicInspectorReconciler) generateServiceSecrets(
 	)
 
 	// create httpd  vhost template parameters
-	httpdVhostConfig := map[string]interface{}{}
+	httpdVhostConfig := map[string]any{}
 	for _, endpt := range []service.Endpoint{service.EndpointInternal, service.EndpointPublic} {
-		endptConfig := map[string]interface{}{}
+		endptConfig := map[string]any{}
 		endptConfig["ServerName"] = fmt.Sprintf("%s-%s-%s.%s.svc", ironic.ServiceName, ironic.InspectorComponent, endpt.String(), instance.Namespace)
 		endptConfig["TLS"] = false // default TLS to false, and set it below to true if enabled
 		if instance.Spec.TLS.API.Enabled(endpt) {

--- a/controllers/ironicneutronagent_controller.go
+++ b/controllers/ironicneutronagent_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"maps"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -766,9 +767,7 @@ func (r *IronicNeutronAgentReconciler) generateServiceSecrets(
 	customData := map[string]string{
 		"02-ironic_neutron_agent-custom.conf": instance.Spec.CustomServiceConfig,
 	}
-	for key, data := range instance.Spec.DefaultConfigOverwrite {
-		customData[key] = data
-	}
+	maps.Copy(customData, instance.Spec.DefaultConfigOverwrite)
 
 	keystoneAPI, err := keystonev1.GetKeystoneAPI(ctx, h, instance.Namespace, map[string]string{})
 	if err != nil {
@@ -798,7 +797,7 @@ func (r *IronicNeutronAgentReconciler) generateServiceSecrets(
 		return err
 	}
 
-	templateParameters := make(map[string]interface{})
+	templateParameters := make(map[string]any)
 	templateParameters["ServiceUser"] = instance.Spec.ServiceUser
 	templateParameters["KeystoneInternalURL"] = keystoneInternalURL
 	templateParameters["KeystonePublicURL"] = keystonePublicURL

--- a/pkg/ironic/funcs.go
+++ b/pkg/ironic/funcs.go
@@ -54,7 +54,7 @@ func GetIngressDomain(
 	ingressDomain := ""
 
 	ingressStatus := ingress.UnstructuredContent()["status"]
-	ingressStatusMap, ok := ingressStatus.(map[string]interface{})
+	ingressStatusMap, ok := ingressStatus.(map[string]any)
 	if !ok {
 		return "", fmt.Errorf("%w: wanted type map[string]interface{}; got %T", ErrIngressDomainTypeAssertion, ingressStatus)
 	}

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -297,7 +297,7 @@ func CreateMessageBusSecret(
 	s := th.CreateSecret(
 		types.NamespacedName{Namespace: namespace, Name: name},
 		map[string][]byte{
-			"transport_url": []byte(fmt.Sprintf("rabbit://%s/fake", name)),
+			"transport_url": fmt.Appendf(nil, "rabbit://%s/fake", name),
 		},
 	)
 	logger.Info("Secret created", "name", name)
@@ -306,12 +306,12 @@ func CreateMessageBusSecret(
 
 func CreateIronic(
 	name types.NamespacedName,
-	spec map[string]interface{},
+	spec map[string]any,
 ) client.Object {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "ironic.openstack.org/v1beta1",
 		"kind":       "Ironic",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -335,15 +335,15 @@ func IronicConditionGetter(name types.NamespacedName) condition.Conditions {
 	return instance.Status.Conditions
 }
 
-func GetDefaultIronicSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultIronicSpec() map[string]any {
+	return map[string]any{
 		"databaseInstance":   DatabaseInstance,
 		"secret":             SecretName,
 		"ironicAPI":          GetDefaultIronicAPISpec(),
-		"ironicConductors":   []map[string]interface{}{GetDefaultIronicConductorSpec()},
+		"ironicConductors":   []map[string]any{GetDefaultIronicConductorSpec()},
 		"ironicInspector":    GetDefaultIronicInspectorSpec(),
 		"ironicNeutronAgent": GetDefaultIronicNeutronAgentSpec(),
-		"images": map[string]interface{}{
+		"images": map[string]any{
 			"api":               ContainerImage,
 			"conductor":         ContainerImage,
 			"inspector":         ContainerImage,
@@ -356,12 +356,12 @@ func GetDefaultIronicSpec() map[string]interface{} {
 
 func CreateIronicAPI(
 	name types.NamespacedName,
-	spec map[string]interface{},
+	spec map[string]any,
 ) client.Object {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "ironic.openstack.org/v1beta1",
 		"kind":       "IronicAPI",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -395,8 +395,8 @@ func IronicAPIConditionGetter(name types.NamespacedName) condition.Conditions {
 	return instance.Status.Conditions
 }
 
-func GetDefaultIronicAPISpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultIronicAPISpec() map[string]any {
+	return map[string]any{
 		"secret":           SecretName,
 		"databaseHostname": DatabaseHostname,
 		"containerImage":   ContainerImage,
@@ -406,12 +406,12 @@ func GetDefaultIronicAPISpec() map[string]interface{} {
 
 func CreateIronicConductor(
 	name types.NamespacedName,
-	spec map[string]interface{},
+	spec map[string]any,
 ) client.Object {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "ironic.openstack.org/v1beta1",
 		"kind":       "IronicConductor",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -445,8 +445,8 @@ func IronicConductorConditionGetter(name types.NamespacedName) condition.Conditi
 	return instance.Status.Conditions
 }
 
-func GetDefaultIronicConductorSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultIronicConductorSpec() map[string]any {
+	return map[string]any{
 		"databaseHostname":       DatabaseHostname,
 		"databaseInstance":       DatabaseInstance,
 		"secret":                 SecretName,
@@ -460,12 +460,12 @@ func GetDefaultIronicConductorSpec() map[string]interface{} {
 
 func CreateIronicInspector(
 	name types.NamespacedName,
-	spec map[string]interface{},
+	spec map[string]any,
 ) client.Object {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "ironic.openstack.org/v1beta1",
 		"kind":       "IronicInspector",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -494,8 +494,8 @@ func GetIronicInspectorSpec(
 	return instance.Spec.IronicInspectorTemplate
 }
 
-func GetDefaultIronicInspectorSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultIronicInspectorSpec() map[string]any {
+	return map[string]any{
 		"databaseInstance":       DatabaseInstance,
 		"secret":                 SecretName,
 		"containerImage":         ContainerImage,
@@ -511,12 +511,12 @@ func IronicInspectorConditionGetter(name types.NamespacedName) condition.Conditi
 
 func CreateIronicNeutronAgent(
 	name types.NamespacedName,
-	spec map[string]interface{},
+	spec map[string]any,
 ) client.Object {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "ironic.openstack.org/v1beta1",
 		"kind":       "IronicNeutronAgent",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -535,8 +535,8 @@ func GetIronicNeutronAgent(
 	return instance
 }
 
-func GetDefaultIronicNeutronAgentSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultIronicNeutronAgentSpec() map[string]any {
+	return map[string]any{
 		"secret":         SecretName,
 		"containerImage": ContainerImage,
 		"serviceAccount": "ironic",
@@ -565,33 +565,33 @@ func CreateFakeIngressController() {
 	}
 
 	// Fake IngressController custom resource
-	fakeCustomResorce := map[string]interface{}{
+	fakeCustomResorce := map[string]any{
 		"apiVersion": "apiextensions.k8s.io/v1",
 		"kind":       "CustomResourceDefinition",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name": "ingresscontrollers.operator.openshift.io",
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"group": "operator.openshift.io",
-			"names": map[string]interface{}{
+			"names": map[string]any{
 				"kind":     "IngressController",
 				"listKind": "IngressControllerList",
 				"plural":   "ingresscontrollers",
 				"singular": "ingresscontroller",
 			},
 			"scope": "Namespaced",
-			"versions": []map[string]interface{}{{
+			"versions": []map[string]any{{
 				"name":    "v1",
 				"served":  true,
 				"storage": true,
-				"schema": map[string]interface{}{
-					"openAPIV3Schema": map[string]interface{}{
+				"schema": map[string]any{
+					"openAPIV3Schema": map[string]any{
 						"type": "object",
-						"properties": map[string]interface{}{
-							"status": map[string]interface{}{
+						"properties": map[string]any{
+							"status": map[string]any{
 								"type": "object",
-								"properties": map[string]interface{}{
-									"domain": map[string]interface{}{
+								"properties": map[string]any{
+									"domain": map[string]any{
 										"type": "string",
 									},
 								},
@@ -604,14 +604,14 @@ func CreateFakeIngressController() {
 	}
 
 	// Fake ingresscontroller
-	fakeIngressController := map[string]interface{}{
+	fakeIngressController := map[string]any{
 		"apiVersion": "operator.openshift.io/v1",
 		"kind":       "IngressController",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
-		"status": map[string]interface{}{
+		"status": map[string]any{
 			"domain": "test.example.com",
 		},
 	}
@@ -650,7 +650,7 @@ func CreateFakeIngressController() {
 
 }
 
-func CreateUnstructured(rawObj map[string]interface{}) *unstructured.Unstructured {
+func CreateUnstructured(rawObj map[string]any) *unstructured.Unstructured {
 	logger.Info("Creating", "raw", rawObj)
 	unstructuredObj := &unstructured.Unstructured{Object: rawObj}
 	Eventually(func(g Gomega) {
@@ -664,16 +664,16 @@ func CreateUnstructured(rawObj map[string]interface{}) *unstructured.Unstructure
 // test Service components. It returns both the user input representation
 // in the form of map[string]string, and the Golang expected representation
 // used in the test asserts.
-func GetSampleTopologySpec(label string) (map[string]interface{}, []corev1.TopologySpreadConstraint) {
+func GetSampleTopologySpec(label string) (map[string]any, []corev1.TopologySpreadConstraint) {
 	// Build the topology Spec
-	topologySpec := map[string]interface{}{
-		"topologySpreadConstraints": []map[string]interface{}{
+	topologySpec := map[string]any{
+		"topologySpreadConstraints": []map[string]any{
 			{
 				"maxSkew":           1,
 				"topologyKey":       corev1.LabelHostname,
 				"whenUnsatisfiable": "ScheduleAnyway",
-				"labelSelector": map[string]interface{}{
-					"matchLabels": map[string]interface{}{
+				"labelSelector": map[string]any{
+					"matchLabels": map[string]any{
 						"component": label,
 					},
 				},

--- a/tests/functional/ironic_controller_test.go
+++ b/tests/functional/ironic_controller_test.go
@@ -829,7 +829,7 @@ var _ = Describe("Ironic controller", func() {
 				keystone.DeleteKeystoneAPI,
 				keystone.CreateKeystoneAPI(ironicNames.Namespace))
 			spec := GetDefaultIronicSpec()
-			spec["topologyRef"] = map[string]interface{}{
+			spec["topologyRef"] = map[string]any{
 				"name": topologyRef.Name,
 			}
 			DeferCleanup(
@@ -1092,7 +1092,7 @@ var _ = Describe("Ironic controller", func() {
 				keystone.DeleteKeystoneAPI,
 				keystone.CreateKeystoneAPI(ironicNames.Namespace))
 			spec := GetDefaultIronicSpec()
-			spec["nodeSelector"] = map[string]interface{}{
+			spec["nodeSelector"] = map[string]any{
 				"foo": "bar",
 			}
 			DeferCleanup(
@@ -1514,18 +1514,18 @@ var _ = Describe("Ironic Webhook", func() {
 	It("rejects with wrong IronicAPI service override endpoint type", func() {
 		spec := GetDefaultIronicSpec()
 		apiSpec := GetDefaultIronicAPISpec()
-		apiSpec["override"] = map[string]interface{}{
-			"service": map[string]interface{}{
-				"internal": map[string]interface{}{},
-				"wrooong":  map[string]interface{}{},
+		apiSpec["override"] = map[string]any{
+			"service": map[string]any{
+				"internal": map[string]any{},
+				"wrooong":  map[string]any{},
 			},
 		}
 		spec["ironicAPI"] = apiSpec
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "ironic.openstack.org/v1beta1",
 			"kind":       "Ironic",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      ironicNames.IronicName.Name,
 				"namespace": ironicNames.IronicName.Namespace,
 			},
@@ -1545,18 +1545,18 @@ var _ = Describe("Ironic Webhook", func() {
 	It("rejects with wrong IronicInspector service override endpoint type", func() {
 		spec := GetDefaultIronicSpec()
 		apiSpec := GetDefaultIronicInspectorSpec()
-		apiSpec["override"] = map[string]interface{}{
-			"service": map[string]interface{}{
-				"internal": map[string]interface{}{},
-				"wrooong":  map[string]interface{}{},
+		apiSpec["override"] = map[string]any{
+			"service": map[string]any{
+				"internal": map[string]any{},
+				"wrooong":  map[string]any{},
 			},
 		}
 		spec["ironicInspector"] = apiSpec
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "ironic.openstack.org/v1beta1",
 			"kind":       "Ironic",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      ironicNames.IronicName.Name,
 				"namespace": ironicNames.IronicName.Namespace,
 			},
@@ -1584,8 +1584,8 @@ var _ = Describe("Ironic Webhook", func() {
 
 			// API, Inspector, NeutronAgent
 			if component != "top-level" && component != "ironicConductors" {
-				spec[component] = map[string]interface{}{
-					"topologyRef": map[string]interface{}{
+				spec[component] = map[string]any{
+					"topologyRef": map[string]any{
 						"name":      "bar",
 						"namespace": "foo",
 					},
@@ -1593,9 +1593,9 @@ var _ = Describe("Ironic Webhook", func() {
 			}
 			// Conductors
 			if component == "ironicConductors" {
-				condList := []map[string]interface{}{
+				condList := []map[string]any{
 					{
-						"topologyRef": map[string]interface{}{
+						"topologyRef": map[string]any{
 							"name":      "foo",
 							"namespace": "bar",
 						},
@@ -1604,16 +1604,16 @@ var _ = Describe("Ironic Webhook", func() {
 				spec["ironicConductors"] = condList
 				// top-level topologyRef
 			} else {
-				spec["topologyRef"] = map[string]interface{}{
+				spec["topologyRef"] = map[string]any{
 					"name":      "bar",
 					"namespace": "foo",
 				}
 			}
 			// Build the ironic CR
-			raw := map[string]interface{}{
+			raw := map[string]any{
 				"apiVersion": "ironic.openstack.org/v1beta1",
 				"kind":       "Ironic",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      ironicNames.IronicName.Name,
 					"namespace": ironicNames.IronicName.Namespace,
 				},

--- a/tests/functional/ironicapi_controller_test.go
+++ b/tests/functional/ironicapi_controller_test.go
@@ -256,12 +256,12 @@ var _ = Describe("IronicAPI controller", func() {
 			spec := GetDefaultIronicAPISpec()
 			spec["rpcTransport"] = "oslo"
 			spec["transportURLSecret"] = MessageBusSecretName
-			spec["tls"] = map[string]interface{}{
-				"api": map[string]interface{}{
-					"internal": map[string]interface{}{
+			spec["tls"] = map[string]any{
+				"api": map[string]any{
+					"internal": map[string]any{
 						"secretName": ironicNames.InternalCertSecretName.Name,
 					},
-					"public": map[string]interface{}{
+					"public": map[string]any{
 						"secretName": ironicNames.PublicCertSecretName.Name,
 					},
 				},

--- a/tests/functional/ironicconductor_controller_test.go
+++ b/tests/functional/ironicconductor_controller_test.go
@@ -238,7 +238,7 @@ var _ = Describe("IronicConductor controller", func() {
 			spec := GetDefaultIronicConductorSpec()
 			spec["rpcTransport"] = "oslo"
 			spec["transportURLSecret"] = MessageBusSecretName
-			spec["tls"] = map[string]interface{}{
+			spec["tls"] = map[string]any{
 				"caBundleSecretName": ironicNames.CaBundleSecretName.Name,
 			}
 			DeferCleanup(

--- a/tests/functional/ironicinspector_controller_test.go
+++ b/tests/functional/ironicinspector_controller_test.go
@@ -305,12 +305,12 @@ var _ = Describe("IronicInspector controller", func() {
 				keystone.CreateKeystoneAPI(ironicNames.Namespace))
 			spec := GetDefaultIronicInspectorSpec()
 			spec["rpcTransport"] = "oslo"
-			spec["tls"] = map[string]interface{}{
-				"api": map[string]interface{}{
-					"internal": map[string]interface{}{
+			spec["tls"] = map[string]any{
+				"api": map[string]any{
+					"internal": map[string]any{
 						"secretName": ironicNames.InternalCertSecretName.Name,
 					},
-					"public": map[string]interface{}{
+					"public": map[string]any{
 						"secretName": ironicNames.PublicCertSecretName.Name,
 					},
 				},

--- a/tests/functional/ironicneutronagent_controller_test.go
+++ b/tests/functional/ironicneutronagent_controller_test.go
@@ -223,7 +223,7 @@ var _ = Describe("IronicNeutronAgent controller", func() {
 				CreateMessageBusSecret(ironicNames.Namespace, MessageBusSecretName),
 			)
 			spec := GetDefaultIronicNeutronAgentSpec()
-			spec["tls"] = map[string]interface{}{
+			spec["tls"] = map[string]any{
 				"caBundleSecretName": ironicNames.CaBundleSecretName.Name,
 			}
 			DeferCleanup(th.DeleteInstance, CreateIronicNeutronAgent(ironicNames.INAName, spec))

--- a/tests/functional/sample_test.go
+++ b/tests/functional/sample_test.go
@@ -28,8 +28,8 @@ import (
 
 const SamplesDir = "../../config/samples/"
 
-func ReadSample(sampleFileName string) map[string]interface{} {
-	rawSample := make(map[string]interface{})
+func ReadSample(sampleFileName string) map[string]any {
+	rawSample := make(map[string]any)
 
 	bytes, err := os.ReadFile(filepath.Join(SamplesDir, sampleFileName)) // #nosec G304
 	Expect(err).ShouldNot(HaveOccurred())
@@ -40,35 +40,35 @@ func ReadSample(sampleFileName string) map[string]interface{} {
 
 func CreateIronicFromSample(sampleFileName string, name types.NamespacedName) types.NamespacedName {
 	raw := ReadSample(sampleFileName)
-	instance := CreateIronic(name, raw["spec"].(map[string]interface{}))
+	instance := CreateIronic(name, raw["spec"].(map[string]any))
 	DeferCleanup(th.DeleteInstance, instance)
 	return types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
 }
 
 func CreateIronicAPIFromSample(sampleFileName string, name types.NamespacedName) types.NamespacedName {
 	raw := ReadSample(sampleFileName)
-	instance := CreateIronicAPI(name, raw["spec"].(map[string]interface{}))
+	instance := CreateIronicAPI(name, raw["spec"].(map[string]any))
 	DeferCleanup(th.DeleteInstance, instance)
 	return types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
 }
 
 func CreateIronicConductorFromSample(sampleFileName string, name types.NamespacedName) types.NamespacedName {
 	raw := ReadSample(sampleFileName)
-	instance := CreateIronicConductor(name, raw["spec"].(map[string]interface{}))
+	instance := CreateIronicConductor(name, raw["spec"].(map[string]any))
 	DeferCleanup(th.DeleteInstance, instance)
 	return types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
 }
 
 func CreateIronicInspectorFromSample(sampleFileName string, name types.NamespacedName) types.NamespacedName {
 	raw := ReadSample(sampleFileName)
-	instance := CreateIronicInspector(name, raw["spec"].(map[string]interface{}))
+	instance := CreateIronicInspector(name, raw["spec"].(map[string]any))
 	DeferCleanup(th.DeleteInstance, instance)
 	return types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
 }
 
 func CreateIronicNeutronAgentFromSample(sampleFileName string, name types.NamespacedName) types.NamespacedName {
 	raw := ReadSample(sampleFileName)
-	instance := CreateIronicNeutronAgent(name, raw["spec"].(map[string]interface{}))
+	instance := CreateIronicNeutronAgent(name, raw["spec"].(map[string]any))
 	DeferCleanup(th.DeleteInstance, instance)
 	return types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
 }


### PR DESCRIPTION
Modernize using `gopls modernize tool` to update:

- Replace interface{} with any type alias (Go 1.18+)
- Update range loops to use idiomatic range syntax
- Replace fmt.Sprintf with fmt.Appendf where appropriate

These changes improve code readability and align with current Go best practices.

Co-Authored-By: Claude <noreply@anthropic.com>