### PR TITLE
CRD changes for graphical console

### DIFF
--- a/api/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/api/bases/ironic.openstack.org_ironicconductors.yaml
@@ -55,6 +55,9 @@ spec:
               conductorGroup:
                 description: ConductorGroup - Ironic Conductor conductor group.
                 type: string
+              consoleImage:
+                description: ConsoleImage - Ironic Graphical Console Container Image
+                type: string
               containerImage:
                 description: ContainerImage - Ironic Conductor Container Image
                 type: string
@@ -115,6 +118,15 @@ spec:
                   - start
                   type: object
                 type: array
+              graphicalConsoles:
+                default: Disabled
+                description: 'Whether to enable graphical consoles. NOTE: Setting
+                  this to Enabled is not supported.'
+                enum:
+                - Enabled
+                - Disabled
+                - ""
+                type: string
               ironicPythonAgentImage:
                 description: IronicPythonAgentImage - Image containing the ironic-python-agent
                   kernel and ramdisk
@@ -142,6 +154,9 @@ spec:
                   NodeSelector to target subset of worker nodes running this service. Setting here overrides
                   any global NodeSelector settings within the Ironic CR
                 type: object
+              novncproxyImage:
+                description: NoVNCProxyImage - Ironic NoVNCProxy Container Image
+                type: string
               passwordSelectors:
                 default:
                   service: IronicPassword

--- a/api/bases/ironic.openstack.org_ironics.yaml
+++ b/api/bases/ironic.openstack.org_ironics.yaml
@@ -78,6 +78,15 @@ spec:
                   ConfigOverwrite - interface to overwrite default config files like e.g. policy.json.
                   But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
                 type: object
+              graphicalConsoles:
+                default: Disabled
+                description: 'Whether to enable graphical consoles. NOTE: Setting
+                  this to Enabled is not supported.'
+                enum:
+                - Enabled
+                - Disabled
+                - ""
+                type: string
               images:
                 default: {}
                 description: Images - Container images for all ironic services
@@ -90,6 +99,10 @@ spec:
                     description: Conductor - Ironic Conductor Container Image (will
                       be set to environmental default if empty)
                     type: string
+                  graphicalConsole:
+                    description: GraphicalConsole - Ironic Graphical Console Container
+                      Image (will be set to environmental default if empty)
+                    type: string
                   inspector:
                     description: Inspector - Ironic Inspector Container Image (will
                       be set to environmental default if empty)
@@ -101,6 +114,10 @@ spec:
                   neutronAgent:
                     description: NeutronAgent - ML2 baremtal - Ironic Neutron Agent
                       Image (will be set to environmental default if empty)
+                    type: string
+                  novncproxy:
+                    description: NoVNCProxy - Ironic NoVNCProxy Container Image (will
+                      be set to environmental default if empty)
                     type: string
                   pxe:
                     description: Pxe- Ironic DHCP/TFTP/HTTP Container Image URL (will

--- a/api/v1beta1/ironic_types.go
+++ b/api/v1beta1/ironic_types.go
@@ -47,6 +47,10 @@ const (
 	IronicNeutronAgentContainerImage = "quay.io/podified-antelope-centos9/openstack-ironic-neutron-agent:current-podified"
 	// IronicPythonAgentContainerImage is the fall-back container image for IronicPythonAgent
 	IronicPythonAgentContainerImage = "quay.io/podified-antelope-centos9/ironic-python-agent:current-podified"
+	// IronicNoVNCProxyContainerImage is the fall-back container image for NoVNCProxy
+	IronicNoVNCProxyContainerImage = "quay.io/podified-antelope-centos9/ironic-novncproxy:current-podified"
+	// IronicGraphicalConsoleContainer image is the fall-back container image for GraphicalConsole
+	IronicGraphicalConsoleContainerImage = "quay.io/podified-antelope-centos9/ironic-graphical-console:current-podified"
 )
 
 // IronicSpec defines the desired state of Ironic
@@ -161,6 +165,12 @@ type IronicSpecCore struct {
 	// +kubebuilder:validation:Minimum=10
 	// APITimeout for HAProxy, Apache
 	APITimeout int `json:"apiTimeout"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=Disabled
+	// +kubebuilder:validation:Enum:=Enabled;Disabled;""
+	// Whether to enable graphical consoles. NOTE: Setting this to Enabled is not supported.
+	GraphicalConsoles string `json:"graphicalConsoles"`
 }
 
 // IronicImages to specify container images required by all ironic services
@@ -188,6 +198,14 @@ type IronicImages struct {
 	// +kubebuilder:validation:Optional
 	// IronicPythonAgent - Image containing the ironic-python-agent kernel and ramdisk
 	IronicPythonAgent string `json:"ironicPythonAgent"`
+
+	// +kubebuilder:validation:Optional
+	// NoVNCProxy - Ironic NoVNCProxy Container Image (will be set to environmental default if empty)
+	NoVNCProxy string `json:"novncproxy,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// GraphicalConsole - Ironic Graphical Console Container Image (will be set to environmental default if empty)
+	GraphicalConsole string `json:"graphicalConsole,omitempty"`
 }
 
 // DHCPRange to define address range for DHCP requests
@@ -320,6 +338,8 @@ func SetupDefaults() {
 		Pxe:               util.GetEnvVar("RELATED_IMAGE_IRONIC_PXE_IMAGE_URL_DEFAULT", IronicPXEContainerImage),
 		NeutronAgent:      util.GetEnvVar("RELATED_IMAGE_IRONIC_NEUTRON_AGENT_IMAGE_URL_DEFAULT", IronicNeutronAgentContainerImage),
 		IronicPythonAgent: util.GetEnvVar("RELATED_IMAGE_IRONIC_PYTHON_AGENT_IMAGE_URL_DEFAULT", IronicPythonAgentContainerImage),
+		NoVNCProxy:        util.GetEnvVar("RELATED_IMAGE_IRONIC_NOVNC_PROXY_IMAGE_URL_DEFAULT", IronicPythonAgentContainerImage),
+		GraphicalConsole:  util.GetEnvVar("RELATED_IMAGE_IRONIC_GRAPHICAL_CONSOLE_IMAGE_URL_DEFAULT", IronicPythonAgentContainerImage),
 	}
 
 	SetupIronicImageDefaults(imageDefaults)

--- a/api/v1beta1/ironic_webhook.go
+++ b/api/v1beta1/ironic_webhook.go
@@ -57,12 +57,14 @@ type netIPStartEnd struct {
 
 // IronicDefaults - TODO remove when openstack-operator has moved to IronicImages
 type IronicDefaults struct {
-	APIContainerImageURL       string
-	ConductorContainerImageURL string
-	InspectorContainerImageURL string
-	PXEContainerImageURL       string
-	INAContainerImageURL       string
-	IPAContainerImageURL       string
+	APIContainerImageURL              string
+	ConductorContainerImageURL        string
+	InspectorContainerImageURL        string
+	PXEContainerImageURL              string
+	INAContainerImageURL              string
+	IPAContainerImageURL              string
+	NoVNCProxyContainerImageURL       string
+	GraphicalConsoleContainerImageURL string
 }
 
 // SetupIronicDefaults - TODO remove when openstack-operator has moved to SetupIronicImageDefaults
@@ -74,6 +76,8 @@ func SetupIronicDefaults(defaults IronicDefaults) {
 		Pxe:               defaults.PXEContainerImageURL,
 		NeutronAgent:      defaults.INAContainerImageURL,
 		IronicPythonAgent: defaults.IPAContainerImageURL,
+		NoVNCProxy:        defaults.NoVNCProxyContainerImageURL,
+		GraphicalConsole:  defaults.GraphicalConsoleContainerImageURL,
 	})
 }
 

--- a/api/v1beta1/ironicconductor_types.go
+++ b/api/v1beta1/ironicconductor_types.go
@@ -120,6 +120,20 @@ type IronicConductorSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// TLS - Parameters related to the TLS
 	TLS tls.Ca `json:"tls,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=Disabled
+	// +kubebuilder:validation:Enum:=Enabled;Disabled;""
+	// Whether to enable graphical consoles. NOTE: Setting this to Enabled is not supported.
+	GraphicalConsoles string `json:"graphicalConsoles"`
+
+	// +kubebuilder:validation:Optional
+	// NoVNCProxyImage - Ironic NoVNCProxy Container Image
+	NoVNCProxyImage string `json:"novncproxyImage,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// ConsoleImage - Ironic Graphical Console Container Image
+	ConsoleImage string `json:"consoleImage"`
 }
 
 // IronicConductorStatus defines the observed state of IronicConductor

--- a/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironicconductors.yaml
@@ -55,6 +55,9 @@ spec:
               conductorGroup:
                 description: ConductorGroup - Ironic Conductor conductor group.
                 type: string
+              consoleImage:
+                description: ConsoleImage - Ironic Graphical Console Container Image
+                type: string
               containerImage:
                 description: ContainerImage - Ironic Conductor Container Image
                 type: string
@@ -115,6 +118,15 @@ spec:
                   - start
                   type: object
                 type: array
+              graphicalConsoles:
+                default: Disabled
+                description: 'Whether to enable graphical consoles. NOTE: Setting
+                  this to Enabled is not supported.'
+                enum:
+                - Enabled
+                - Disabled
+                - ""
+                type: string
               ironicPythonAgentImage:
                 description: IronicPythonAgentImage - Image containing the ironic-python-agent
                   kernel and ramdisk
@@ -142,6 +154,9 @@ spec:
                   NodeSelector to target subset of worker nodes running this service. Setting here overrides
                   any global NodeSelector settings within the Ironic CR
                 type: object
+              novncproxyImage:
+                description: NoVNCProxyImage - Ironic NoVNCProxy Container Image
+                type: string
               passwordSelectors:
                 default:
                   service: IronicPassword

--- a/config/crd/bases/ironic.openstack.org_ironics.yaml
+++ b/config/crd/bases/ironic.openstack.org_ironics.yaml
@@ -78,6 +78,15 @@ spec:
                   ConfigOverwrite - interface to overwrite default config files like e.g. policy.json.
                   But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
                 type: object
+              graphicalConsoles:
+                default: Disabled
+                description: 'Whether to enable graphical consoles. NOTE: Setting
+                  this to Enabled is not supported.'
+                enum:
+                - Enabled
+                - Disabled
+                - ""
+                type: string
               images:
                 default: {}
                 description: Images - Container images for all ironic services
@@ -90,6 +99,10 @@ spec:
                     description: Conductor - Ironic Conductor Container Image (will
                       be set to environmental default if empty)
                     type: string
+                  graphicalConsole:
+                    description: GraphicalConsole - Ironic Graphical Console Container
+                      Image (will be set to environmental default if empty)
+                    type: string
                   inspector:
                     description: Inspector - Ironic Inspector Container Image (will
                       be set to environmental default if empty)
@@ -101,6 +114,10 @@ spec:
                   neutronAgent:
                     description: NeutronAgent - ML2 baremtal - Ironic Neutron Agent
                       Image (will be set to environmental default if empty)
+                    type: string
+                  novncproxy:
+                    description: NoVNCProxy - Ironic NoVNCProxy Container Image (will
+                      be set to environmental default if empty)
                     type: string
                   pxe:
                     description: Pxe- Ironic DHCP/TFTP/HTTP Container Image URL (will


### PR DESCRIPTION
This change introduces the CRD changes for the feature flag and new images required for graphical consoles.

This is required to add without any backing implementation so that openstack-operator can pull in the CRD changes and establish the CSV entries for overriding the images.

The feature flag will remain false until RHOSO-19 and this will never work with default antelope images.

## Describe your changes

## Jira Ticket Link
Jira: [OSPRH-20211](https://issues.redhat.com//browse/OSPRH-20211)

## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [x] Performed `pre-commit run --all`
- [ ] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [x] Verified that no failures present in logs(optional):
  - [x] ironic-operator-build-deploy-kuttl
  - [x] podified-multinode-ironic-deployment
