### PR TITLE
Fix IPv6 URL formatting in init scripts

### DIFF
--- a/templates/ironicinspector/config/dnsmasq.conf
+++ b/templates/ironicinspector/config/dnsmasq.conf
@@ -61,7 +61,7 @@ dhcp-option=tag:ipxe6,option6:bootfile-url,${INSPECTOR_HTTP_URL}inspector.ipxe
 
 # Client is PXE booting over EFI without iPXE ROM; send EFI version of iPXE chainloader
 dhcp-boot=tag:efi,tag:!ipxe,snponly.efi
-dhcp-option=tag:efi6,tag:!ipxe6,option6:bootfile-url,tftp://${InspectorNetworkIP}/snponly.efi
+dhcp-option=tag:efi6,tag:!ipxe6,option6:bootfile-url,tftp://${InspectorNetworkIPForURL}/snponly.efi
 
 # Client is running PXE over BIOS; send BIOS version of iPXE chainloader
-dhcp-boot=undionly.kpxe,localhost.localdomain,${InspectorNetworkIP}
+dhcp-boot=undionly.kpxe,localhost.localdomain,${InspectorNetworkIPForURL}

--- a/templates/ironicinspector/config/inspector.ipxe
+++ b/templates/ironicinspector/config/inspector.ipxe
@@ -2,6 +2,6 @@
 
 :retry_boot
 imgfree
-kernel --timeout 60000 ${INSPECTOR_HTTP_URL}ironic-python-agent.kernel ipa-inspection-callback-url=http://${InspectorNetworkIP}:5050/v1/continue ipa-inspection-collectors=default,extra-hardware,numa-topology,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
+kernel --timeout 60000 ${INSPECTOR_HTTP_URL}ironic-python-agent.kernel ipa-inspection-callback-url=http://${InspectorNetworkIPForURL}:5050/v1/continue ipa-inspection-collectors=default,extra-hardware,numa-topology,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
 initrd --timeout 60000 ${INSPECTOR_HTTP_URL}ironic-python-agent.initramfs || goto retry_boot
 boot


### PR DESCRIPTION
The init scripts for ironic conductor and inspector need to detect IPv6 and format the http and tftp URL's accordingly.

Fixes: [OSPRH-20483](https://issues.redhat.com//browse/OSPRH-20483)

## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [x] Performed `pre-commit run --all`
- [ ] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
