### PR TITLE
Add rbac for ironic-operator creating namespaces

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -205,3 +205,14 @@ rules:
   - list
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch


### PR DESCRIPTION
## Describe your changes

The graphical consoles feature will create the namespace openstack-ironic-consoles which Ironic will use to create the graphical console pods.

To do this, ironic-operator needs rbac rules to create and manage (not delete) namespaces. This is proposed as a standalone change because it needs to be packaged in the openstack-operator bundle before ironic-operator can use it.

For precedence of this change, openstack-operator has the ability to manage every aspect of namespaces: https://github.com/openstack-k8s-operators/openstack-operator/blob/main/config/rbac/role.yaml#L27-L32

Jira: [OSPRH-20211](https://redhat.atlassian.net/browse/OSPRH-20211)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code and confirmed it passes tests
- [ ] Performed `pre-commit run --all`
- [ ] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
