### PR TITLE
Refactor PXE initialization with File Validation <JIRA:OSPRH-27096>

### DIFF
--- a/templates/common/bin/pxe-init.sh
+++ b/templates/common/bin/pxe-init.sh
@@ -80,7 +80,8 @@ if [ -f "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" ] && [ -f "/var/lib/
     rm -rf /initramfs
 fi
 
-# Build an ESP image
+# TODO: Remove the block below when esp.img is prebuilt in the ironic-pxe container for 2 minor releases
+# Build an ESP image at runtime
 pushd /var/lib/ironic/httpboot
 if [ ! -a "esp.img" ]; then
     if ! command -v dd || ! command -v mkfs.msdos || ! command -v mmd; then
@@ -97,3 +98,102 @@ if [ ! -a "esp.img" ]; then
     fi
 fi
 popd
+
+# Configure HTTP deployment URL for boot assets (for conductor only)
+# Skip this section if called from inspector-pxe-init.sh (DeployHTTPURL not set for inspector)
+if [ -n "${DeployHTTPURL}" ]; then
+    # Calculate provision network IP if ProvisionNetwork is set
+    if [ -n "${ProvisionNetwork}" ]; then
+        export ProvisionNetworkIP=$(/usr/local/bin/container-scripts/get_net_ip ${ProvisionNetwork})
+    fi
+
+    # Configure HTTP deployment URL for boot assets
+    export DEPLOY_HTTP_URL=$(python3 -c '
+import os
+import ipaddress
+
+# Get the IP address
+ip_str = os.environ.get("ProvisionNetworkIP", "")
+
+# Check if it is an IPv6 address and format accordingly
+try:
+    ip = ipaddress.ip_address(ip_str)
+    if isinstance(ip, ipaddress.IPv6Address):
+        # For IPv6, we need to wrap the IP in brackets for URL formatting
+        formatted_env = dict(os.environ)
+        formatted_env["ProvisionNetworkIP"] = f"[{ip_str}]"
+        print(os.environ["DeployHTTPURL"] % formatted_env)
+    else:
+        # For IPv4, use as-is
+        print(os.environ["DeployHTTPURL"] % os.environ)
+except ValueError:
+    # If IP parsing fails, use as-is (fallback)
+    print(os.environ["DeployHTTPURL"] % os.environ)
+')
+
+    INIT_CONFIG="/var/lib/config-data/merged/03-init-container-conductor.conf"
+
+    crudini --set ${INIT_CONFIG} deploy http_url ${DEPLOY_HTTP_URL}
+    crudini --set ${INIT_CONFIG} conductor bootloader ${DEPLOY_HTTP_URL}esp.img
+    crudini --set ${INIT_CONFIG} conductor deploy_kernel ${DEPLOY_HTTP_URL}ironic-python-agent.kernel
+    crudini --set ${INIT_CONFIG} conductor deploy_ramdisk ${DEPLOY_HTTP_URL}ironic-python-agent.initramfs
+    crudini --set ${INIT_CONFIG} conductor rescue_kernel ${DEPLOY_HTTP_URL}ironic-python-agent.kernel
+    crudini --set ${INIT_CONFIG} conductor rescue_ramdisk ${DEPLOY_HTTP_URL}ironic-python-agent.initramfs
+fi
+
+# Validate boot file existence
+echo "Validating boot file existence..."
+
+# Check legacy (root-level) boot files
+HTTPBOOT_DIR="/var/lib/ironic/httpboot"
+MISSING_FILES=()
+FOUND_FILES=()
+
+for file in esp.img bootx64.efi undionly.kpxe snponly.efi; do
+    if [ ! -f "${HTTPBOOT_DIR}/${file}" ]; then
+        MISSING_FILES+=("${HTTPBOOT_DIR}/${file}")
+    else
+        FOUND_FILES+=("${HTTPBOOT_DIR}/${file}")
+    fi
+done
+
+# Check x86_64 architecture-specific files if directory exists
+if [ -d "${HTTPBOOT_DIR}/x86_64" ]; then
+    echo "Detected x86_64 boot assets directory"
+    for file in esp.img bootx64.efi undionly.kpxe snponly.efi; do
+        if [ ! -f "${HTTPBOOT_DIR}/x86_64/${file}" ]; then
+            MISSING_FILES+=("${HTTPBOOT_DIR}/x86_64/${file}")
+        else
+            FOUND_FILES+=("${HTTPBOOT_DIR}/x86_64/${file}")
+        fi
+    done
+fi
+
+# Check aarch64 architecture-specific files if directory exists
+if [ -d "${HTTPBOOT_DIR}/aarch64" ]; then
+    echo "Detected aarch64 boot assets directory"
+    for file in esp.img bootaa64.efi snponly.efi; do
+        if [ ! -f "${HTTPBOOT_DIR}/aarch64/${file}" ]; then
+            MISSING_FILES+=("${HTTPBOOT_DIR}/aarch64/${file}")
+        else
+            FOUND_FILES+=("${HTTPBOOT_DIR}/aarch64/${file}")
+        fi
+    done
+fi
+
+# Fail fast if any required files are missing
+if [ ${#MISSING_FILES[@]} -gt 0 ]; then
+    echo "ERROR: Missing required boot files:"
+    for missing in "${MISSING_FILES[@]}"; do
+        echo "  - ${missing}"
+    done
+    echo "Boot asset initialization failed. Please ensure the ironic-pxe container image contains all required files."
+    exit 1
+fi
+
+echo "All required boot files validated successfully"
+
+echo "Found boot files:"
+for found in "${FOUND_FILES[@]}"; do
+    echo "  - ${found}"
+done

--- a/templates/ironicconductor/bin/init.sh
+++ b/templates/ironicconductor/bin/init.sh
@@ -20,48 +20,12 @@ echo "Starting conductor init"
 # Get the statefulset pod index
 export PODINDEX=$(echo ${HOSTNAME##*-})
 
-# Get required environment variables
-IRONICPASSWORD=${IronicPassword:-""}
-TRANSPORTURL=${TransportURL:-""}
-QUORUMQUEUES=${QuorumQueues:-"false"}
-
 INIT_CONFIG="/var/lib/config-data/merged/03-init-container-conductor.conf"
 
 if [ -n "${ProvisionNetwork}" ]; then
     export ProvisionNetworkIP=$(/usr/local/bin/container-scripts/get_net_ip ${ProvisionNetwork})
     crudini --set ${INIT_CONFIG} DEFAULT my_ip $ProvisionNetworkIP
 fi
-
-
-export DEPLOY_HTTP_URL=$(python3 -c '
-import os
-import ipaddress
-
-# Get the IP address
-ip_str = os.environ.get("ProvisionNetworkIP", "")
-
-# Check if it is an IPv6 address and format accordingly
-try:
-    ip = ipaddress.ip_address(ip_str)
-    if isinstance(ip, ipaddress.IPv6Address):
-        # For IPv6, we need to wrap the IP in brackets for URL formatting
-        formatted_env = dict(os.environ)
-        formatted_env["ProvisionNetworkIP"] = f"[{ip_str}]"
-        print(os.environ["DeployHTTPURL"] % formatted_env)
-    else:
-        # For IPv4, use as-is
-        print(os.environ["DeployHTTPURL"] % os.environ)
-except ValueError:
-    # If IP parsing fails, use as-is (fallback)
-    print(os.environ["DeployHTTPURL"] % os.environ)
-')
-
-crudini --set ${INIT_CONFIG} deploy http_url ${DEPLOY_HTTP_URL}
-crudini --set ${INIT_CONFIG} conductor bootloader ${DEPLOY_HTTP_URL}esp.img
-crudini --set ${INIT_CONFIG} conductor deploy_kernel ${DEPLOY_HTTP_URL}ironic-python-agent.kernel
-crudini --set ${INIT_CONFIG} conductor deploy_ramdisk ${DEPLOY_HTTP_URL}ironic-python-agent.initramfs
-crudini --set ${INIT_CONFIG} conductor rescue_kernel ${DEPLOY_HTTP_URL}ironic-python-agent.kernel
-crudini --set ${INIT_CONFIG} conductor rescue_ramdisk ${DEPLOY_HTTP_URL}ironic-python-agent.initramfs
 
 
 # Copy required config to modifiable location


### PR DESCRIPTION
## Describe your changes
Refactor HTTP boot asset configuration into `pxe-init.sh` from `init.sh` and adds file existence validation.
Also removes dead code. 

## Jira Ticket Link
Jira: [OSPRH-27906](https://redhat.atlassian.net/browse/OSPRH-27906)
## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [x] Performed `pre-commit run --all`
- [ ] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
