### PR TITLE
Dynamically configure Ironic for x86_64 and aarch64 boot assets <JIRA:OSPRH-28995>

### DIFF
--- a/templates/common/bin/pxe-init.sh
+++ b/templates/common/bin/pxe-init.sh
@@ -139,6 +139,59 @@ except ValueError:
     crudini --set ${INIT_CONFIG} conductor deploy_ramdisk ${DEPLOY_HTTP_URL}ironic-python-agent.initramfs
     crudini --set ${INIT_CONFIG} conductor rescue_kernel ${DEPLOY_HTTP_URL}ironic-python-agent.kernel
     crudini --set ${INIT_CONFIG} conductor rescue_ramdisk ${DEPLOY_HTTP_URL}ironic-python-agent.initramfs
+
+    # Configure architecture-specific boot parameters if arch directories exist
+    # NOTE: bootloader_by_arch and *_bootfile_name_by_arch were added in upstream Ironic 30.0.0.
+    # These options are ignored by older Ironic versions and will be used when upgraded to 30.0.0+.
+    HTTPBOOT_DIR="/var/lib/ironic/httpboot"
+
+    # Build bootloader_by_arch parameter
+    BOOTLOADER_BY_ARCH=""
+    if [ -d "${HTTPBOOT_DIR}/x86_64" ]; then
+        BOOTLOADER_BY_ARCH="x86_64:${DEPLOY_HTTP_URL}x86_64/esp.img"
+    fi
+    if [ -d "${HTTPBOOT_DIR}/aarch64" ]; then
+        if [ -n "${BOOTLOADER_BY_ARCH}" ]; then
+            BOOTLOADER_BY_ARCH="${BOOTLOADER_BY_ARCH},aarch64:${DEPLOY_HTTP_URL}aarch64/esp.img"
+        else
+            BOOTLOADER_BY_ARCH="aarch64:${DEPLOY_HTTP_URL}aarch64/esp.img"
+        fi
+    fi
+    if [ -n "${BOOTLOADER_BY_ARCH}" ]; then
+        crudini --set ${INIT_CONFIG} conductor bootloader_by_arch "${BOOTLOADER_BY_ARCH}"
+    fi
+
+    # Build pxe_bootfile_name_by_arch parameter
+    PXE_BOOTFILE_BY_ARCH=""
+    if [ -d "${HTTPBOOT_DIR}/x86_64" ]; then
+        PXE_BOOTFILE_BY_ARCH="x86_64:bootx64.efi"
+    fi
+    if [ -d "${HTTPBOOT_DIR}/aarch64" ]; then
+        if [ -n "${PXE_BOOTFILE_BY_ARCH}" ]; then
+            PXE_BOOTFILE_BY_ARCH="${PXE_BOOTFILE_BY_ARCH},aarch64:bootaa64.efi"
+        else
+            PXE_BOOTFILE_BY_ARCH="aarch64:bootaa64.efi"
+        fi
+    fi
+    if [ -n "${PXE_BOOTFILE_BY_ARCH}" ]; then
+        crudini --set ${INIT_CONFIG} pxe pxe_bootfile_name_by_arch "${PXE_BOOTFILE_BY_ARCH}"
+    fi
+
+    # Build ipxe_bootfile_name_by_arch parameter
+    IPXE_BOOTFILE_BY_ARCH=""
+    if [ -d "${HTTPBOOT_DIR}/x86_64" ]; then
+        IPXE_BOOTFILE_BY_ARCH="x86_64:undionly.kpxe"
+    fi
+    if [ -d "${HTTPBOOT_DIR}/aarch64" ]; then
+        if [ -n "${IPXE_BOOTFILE_BY_ARCH}" ]; then
+            IPXE_BOOTFILE_BY_ARCH="${IPXE_BOOTFILE_BY_ARCH},aarch64:snponly.efi"
+        else
+            IPXE_BOOTFILE_BY_ARCH="aarch64:snponly.efi"
+        fi
+    fi
+    if [ -n "${IPXE_BOOTFILE_BY_ARCH}" ]; then
+        crudini --set ${INIT_CONFIG} pxe ipxe_bootfile_name_by_arch "${IPXE_BOOTFILE_BY_ARCH}"
+    fi
 fi
 
 # Validate boot file existence

--- a/templates/ironicconductor/config/01-conductor.conf
+++ b/templates/ironicconductor/config/01-conductor.conf
@@ -13,7 +13,13 @@ heartbeat_interval=20
 heartbeat_timeout=120
 allow_provisioning_in_maintenance=false
 {{ if .ConductorGroup }}conductor_group={{ .ConductorGroup }}{{ end }}
+bootloader=/var/lib/ironic/httpboot/esp.img
 # TODO: uncomment the below entry when we move to ironic release 2025.2 or later
 #{{- if .GracefulShutdownTimeout }}
 # graceful_shutdown_timeout={{ .GracefulShutdownTimeout }}
 #{{- end }}
+
+[pxe]
+uefi_pxe_bootfile_name=bootx64.efi
+ipxe_bootfile_name=undionly.kpxe
+uefi_ipxe_bootfile_name=snponly.efi


### PR DESCRIPTION
## Describe your changes
Enables architecture based bare metal deployments (x86_64,aarch64) using ironic-operator by dynamically configuring Ironic conductor based on per architecture bootloader configuration. 

## Jira Ticket Link
Jira: [OSPRH-28995](https://redhat.atlassian.net/browse/OSPRH-28995)
## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [x] Performed `pre-commit run --all`
- [x] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
