### PR TITLE
Enable debug logging for inspector and neutron-agent in kuttl tests <JIRA:OSPRH-29718>

### DIFF
--- a/config/samples/ironic_v1beta1_ironic.yaml
+++ b/config/samples/ironic_v1beta1_ironic.yaml
@@ -13,5 +13,11 @@ spec:
   ironicAPI: {}
   ironicConductors:
   - storageRequest: 10G
-  ironicInspector: {}
-  ironicNeutronAgent: {}
+  ironicInspector:
+    customServiceConfig: |
+      [DEFAULT]
+      debug = true
+  ironicNeutronAgent:
+    customServiceConfig: |
+      [DEFAULT]
+      debug = true

--- a/config/samples/ironic_v1beta1_ironic_conductor_groups.yaml
+++ b/config/samples/ironic_v1beta1_ironic_conductor_groups.yaml
@@ -16,6 +16,12 @@ spec:
     storageRequest: 10G
   - conductorGroup: stockholm
     storageRequest: 10G
-  ironicInspector: {}
-  ironicNeutronAgent: {}
+  ironicInspector:
+    customServiceConfig: |
+      [DEFAULT]
+      debug = true
+  ironicNeutronAgent:
+    customServiceConfig: |
+      [DEFAULT]
+      debug = true
   secret: osp-secret

--- a/config/samples/ironic_v1beta1_ironic_standalone.yaml
+++ b/config/samples/ironic_v1beta1_ironic_standalone.yaml
@@ -13,7 +13,13 @@ spec:
   ironicAPI: {}
   ironicConductors:
   - storageRequest: 10G
-  ironicInspector: {}
+  ironicInspector:
+    customServiceConfig: |
+      [DEFAULT]
+      debug = true
   ironicNeutronAgent:
     replicas: 0  # Neutron agent replicas is zero, i.e disabled for standalone.
+    customServiceConfig: |
+      [DEFAULT]
+      debug = true
   secret: osp-secret

--- a/config/samples/ironic_v1beta1_ironic_tls.yaml
+++ b/config/samples/ironic_v1beta1_ironic_tls.yaml
@@ -21,6 +21,9 @@ spec:
   ironicConductors:
   - storageRequest: 10G
   ironicInspector:
+    customServiceConfig: |
+      [DEFAULT]
+      debug = true
     tls:
       api:
         internal:
@@ -28,4 +31,7 @@ spec:
         public:
           secretName: cert-ironic-inspector-public-svc
       caBundleSecretName: combined-ca-bundle
-  ironicNeutronAgent: {}
+  ironicNeutronAgent:
+    customServiceConfig: |
+      [DEFAULT]
+      debug = true

--- a/test/kuttl/tests/deploy/10-assert-deploy-ironic.yaml
+++ b/test/kuttl/tests/deploy/10-assert-deploy-ironic.yaml
@@ -25,7 +25,9 @@ spec:
   - replicas: 1
     storageRequest: 10G
   ironicInspector:
-    customServiceConfig: '# add your customization here'
+    customServiceConfig: |
+      [DEFAULT]
+      debug = true
     databaseAccount: ironic-inspector
     passwordSelectors:
       service: IronicInspectorPassword
@@ -33,7 +35,9 @@ spec:
     replicas: 1
     serviceUser: ironic-inspector
   ironicNeutronAgent:
-    customServiceConfig: "# add your customization here"
+    customServiceConfig: |
+      [DEFAULT]
+      debug = true
     replicas: 1
   databaseAccount: ironic
   passwordSelectors:
@@ -121,7 +125,9 @@ metadata:
     kind: Ironic
     name: ironic
 spec:
-  customServiceConfig: '# add your customization here'
+  customServiceConfig: |
+    [DEFAULT]
+    debug = true
   databaseInstance: openstack
   databaseAccount: ironic-inspector
   passwordSelectors:
@@ -152,7 +158,9 @@ metadata:
     kind: Ironic
     name: ironic
 spec:
-  customServiceConfig: "# add your customization here"
+  customServiceConfig: |
+    [DEFAULT]
+    debug = true
   passwordSelectors:
     service: IronicPassword
   messagingBus:

--- a/test/kuttl/tests/standalone/10-assert-deploy-ironic-standalone.yaml
+++ b/test/kuttl/tests/standalone/10-assert-deploy-ironic-standalone.yaml
@@ -25,7 +25,9 @@ spec:
   - replicas: 1
     storageRequest: 10G
   ironicInspector:
-    customServiceConfig: '# add your customization here'
+    customServiceConfig: |
+      [DEFAULT]
+      debug = true
     databaseAccount: ironic-inspector
     passwordSelectors:
       service: IronicInspectorPassword
@@ -116,7 +118,9 @@ metadata:
     kind: Ironic
     name: ironic
 spec:
-  customServiceConfig: '# add your customization here'
+  customServiceConfig: |
+    [DEFAULT]
+    debug = true
   databaseInstance: openstack
   databaseAccount: ironic-inspector
   passwordSelectors:


### PR DESCRIPTION
## Describe your changes
The top-level Ironic CR customServiceConfig propagates to conductor and API via 02-ironic-custom.conf, but inspector and neutron-agent use separate config systems and do not mount the parent ConfigMap. Add explicit debug = true to ironicInspector and ironicNeutronAgent specs in all sample files used by kuttl tests.

## Jira Ticket Link
Jira: [OSPRH-29718](https://redhat.atlassian.net/browse/OSPRH-29718)

## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [x] Performed `pre-commit run --all`
- [ ] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [x] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
