### PR TITLE
Set TLS 1.3 as minimum version for operator webhook and metrics servers <JIRA:OSPRH-27737>

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -115,6 +115,10 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
+	tlsOpts = append(tlsOpts, func(c *tls.Config) {
+		c.MinVersion = tls.VersionTLS13
+	})
+
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will
 	// prevent from being vulnerable to the HTTP/2 Stream Cancellation and


### PR DESCRIPTION
## Describe your changes
Added the MinVersion option to set TLS 1.3 for operator webhook and metrics servers.

## Jira Ticket Link
Jira: [OSPRH-27737](https://redhat.atlassian.net/browse/OSPRH-27737)

## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [x] Performed `pre-commit run --all`
- [ ] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
