### PR TITLE
Remove irmc drivers

### DIFF
--- a/templates/common/config/ironic.conf
+++ b/templates/common/config/ironic.conf
@@ -18,18 +18,18 @@ region_name={{ .Region }}
 {{- end -}}
 
 [DEFAULT]
-enabled_hardware_types=ipmi,idrac,irmc,fake-hardware,redfish,manual-management,ilo,ilo5
-enabled_bios_interfaces=no-bios,redfish,idrac-redfish,irmc,ilo
+enabled_hardware_types=ipmi,idrac,fake-hardware,redfish,manual-management,ilo,ilo5
+enabled_bios_interfaces=no-bios,redfish,idrac-redfish,ilo
 enabled_boot_interfaces=ipxe,ilo-ipxe,pxe,ilo-pxe,fake,redfish-virtual-media,idrac-redfish-virtual-media,ilo-virtual-media
 enabled_console_interfaces=ipmitool-socat,ilo,no-console,fake
 enabled_deploy_interfaces=direct,fake,ramdisk,custom-agent
 default_deploy_interface=direct
-enabled_inspect_interfaces=inspector,no-inspect,irmc,fake,redfish,ilo
+enabled_inspect_interfaces=inspector,no-inspect,fake,redfish,ilo
 default_inspect_interface=inspector
-enabled_management_interfaces=ipmitool,irmc,fake,redfish,idrac-redfish,ilo,ilo5,noop
+enabled_management_interfaces=ipmitool,fake,redfish,idrac-redfish,ilo,ilo5,noop
 enabled_network_interfaces=flat,neutron,noop
-enabled_power_interfaces=ipmitool,irmc,fake,redfish,idrac-redfish,ilo
-enabled_raid_interfaces=no-raid,irmc,agent,fake,ilo5
+enabled_power_interfaces=ipmitool,fake,redfish,idrac-redfish,ilo
+enabled_raid_interfaces=no-raid,agent,fake,ilo5
 enabled_rescue_interfaces=no-rescue,agent
 default_rescue_interface=agent
 enabled_storage_interfaces=noop,fake


### PR DESCRIPTION
These drivers fail to load due to incompatible RPM dependencies, pysnmp 4.4.12-6 and python-pyasn1 0.6.4-1.


Jira: [OSPRH-31305](https://redhat.atlassian.net/browse/OSPRH-31305)

## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [ ] Performed `pre-commit run --all`
- [ ] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [x] ironic-operator-build-deploy-kuttl
  - [x] podified-multinode-ironic-deployment
