### PR TITLE
Do not set ipxe_bootfile_name_by_arch for x86_64

### DIFF
--- a/templates/common/bin/pxe-init.sh
+++ b/templates/common/bin/pxe-init.sh
@@ -163,9 +163,8 @@ except ValueError:
 
     # Build pxe_bootfile_name_by_arch parameter
     PXE_BOOTFILE_BY_ARCH=""
-    if [ -d "${HTTPBOOT_DIR}/x86_64" ]; then
-        PXE_BOOTFILE_BY_ARCH="x86_64:bootx64.efi"
-    fi
+    # NOTE(OSPRH-31469): Only set bootfile for aarch64, to allow x86_64 to use
+    # [pxe]/uefi_pxe_bootfile_name and [pxe]/pxe_bootfile_name values.
     if [ -d "${HTTPBOOT_DIR}/aarch64" ]; then
         if [ -n "${PXE_BOOTFILE_BY_ARCH}" ]; then
             PXE_BOOTFILE_BY_ARCH="${PXE_BOOTFILE_BY_ARCH},aarch64:bootaa64.efi"
@@ -179,9 +178,8 @@ except ValueError:
 
     # Build ipxe_bootfile_name_by_arch parameter
     IPXE_BOOTFILE_BY_ARCH=""
-    if [ -d "${HTTPBOOT_DIR}/x86_64" ]; then
-        IPXE_BOOTFILE_BY_ARCH="x86_64:undionly.kpxe"
-    fi
+    # NOTE(OSPRH-31469): Only set bootfile for aarch64, to allow x86_64 to use
+    # [pxe]/uefi_ipxe_bootfile_name and [pxe]/ipxe_bootfile_name values.
     if [ -d "${HTTPBOOT_DIR}/aarch64" ]; then
         if [ -n "${IPXE_BOOTFILE_BY_ARCH}" ]; then
             IPXE_BOOTFILE_BY_ARCH="${IPXE_BOOTFILE_BY_ARCH},aarch64:snponly.efi"


### PR DESCRIPTION
Since PR: https://github.com/openstack-k8s-operators/ironic-operator/pull/709 the [pxe]/ipxe_bootfile_name_by_arch paramter is set. This disables ironic's boot_mode logic, e.g. we ended up hardcoding to undionly.kpxe for all x86_64 nodes.
    
If we set only aarch64 mapping in (i)pxe_bootfile_name_by_arch to allow ironic to pick uefi_(i)pxe_bootfile_name or (i)pxe_bootfile_name based on boot_mode.


Related LP bug: https://bugs.launchpad.net/ironic/+bug/2157027

Jira: [OSPRH-31469](https://redhat.atlassian.net/browse/OSPRH-31469)

