### PR TITLE
Move ipa extraction to arch specific directory <JIRA:OSPRH-27957>

### DIFF
--- a/internal/ironic/const.go
+++ b/internal/ironic/const.go
@@ -44,7 +44,7 @@ const (
 	// ConductorGroupSelector -
 	ConductorGroupSelector = "conductorGroup"
 	// ImageDirectory -
-	ImageDirectory = "/var/lib/ironic/httpboot"
+	ImageDirectory = "/var/lib/ironic/httpboot/x86_64"
 	// LogPath - Log path for Ironc API
 	LogPath = "/var/log/ironic/ironic-api.log"
 

--- a/templates/common/bin/pxe-init.sh
+++ b/templates/common/bin/pxe-init.sh
@@ -61,12 +61,12 @@ done
 chmod -R +r /var/lib/ironic/httpboot /var/lib/ironic/tftpboot
 
 # Patch ironic-python-agent with custom CA certificates
-if [ -f "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" ] && [ -f "/var/lib/ironic/httpboot/ironic-python-agent.initramfs" ]; then
+if [ -f "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" ] && [ -f "/var/lib/ironic/httpboot/x86_64/ironic-python-agent.initramfs" ]; then
     # Extract the initramfs
     cd /
     mkdir initramfs
     pushd initramfs
-    zcat /var/lib/ironic/httpboot/ironic-python-agent.initramfs | cpio -idmV
+    zcat /var/lib/ironic/httpboot/x86_64/ironic-python-agent.initramfs | cpio -idmV
     popd
 
     # Copy the CA certificates
@@ -75,9 +75,19 @@ if [ -f "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" ] && [ -f "/var/lib/
 
     # Repack the initramfs
     pushd initramfs
-    find . | cpio -o -c --quiet -R root:root | gzip -1 > /var/lib/ironic/httpboot/ironic-python-agent.initramfs
+    find . | cpio -o -c --quiet -R root:root | gzip -1 > /var/lib/ironic/httpboot/x86_64/ironic-python-agent.initramfs
     popd
     rm -rf /initramfs
+fi
+
+# Create symlinks from arch-specific IPA files to root httpboot for backwards compatibility
+# with existing deploy_kernel/deploy_ramdisk/rescue_kernel/rescue_ramdisk config values
+if [ -d "/var/lib/ironic/httpboot/x86_64" ]; then
+    for ipa_file in ironic-python-agent.kernel ironic-python-agent.initramfs; do
+        if [ -f "/var/lib/ironic/httpboot/x86_64/${ipa_file}" ]; then
+            ln -sf "x86_64/${ipa_file}" "/var/lib/ironic/httpboot/${ipa_file}"
+        fi
+    done
 fi
 
 # TODO: Remove the block below when esp.img is prebuilt in the ironic-pxe container for 2 minor releases
@@ -139,6 +149,14 @@ except ValueError:
     crudini --set ${INIT_CONFIG} conductor deploy_ramdisk ${DEPLOY_HTTP_URL}ironic-python-agent.initramfs
     crudini --set ${INIT_CONFIG} conductor rescue_kernel ${DEPLOY_HTTP_URL}ironic-python-agent.kernel
     crudini --set ${INIT_CONFIG} conductor rescue_ramdisk ${DEPLOY_HTTP_URL}ironic-python-agent.initramfs
+
+    # Set arch-specific kernel/ramdisk config values only if IPA files are present in x86_64
+    if [ -f "${HTTPBOOT_DIR}/x86_64/ironic-python-agent.kernel" ]; then
+        crudini --set ${INIT_CONFIG} conductor deploy_kernel_by_arch "x86_64:${DEPLOY_HTTP_URL}x86_64/ironic-python-agent.kernel"
+        crudini --set ${INIT_CONFIG} conductor deploy_ramdisk_by_arch "x86_64:${DEPLOY_HTTP_URL}x86_64/ironic-python-agent.initramfs"
+        crudini --set ${INIT_CONFIG} conductor rescue_kernel_by_arch "x86_64:${DEPLOY_HTTP_URL}x86_64/ironic-python-agent.kernel"
+        crudini --set ${INIT_CONFIG} conductor rescue_ramdisk_by_arch "x86_64:${DEPLOY_HTTP_URL}x86_64/ironic-python-agent.initramfs"
+    fi
 
     # Configure architecture-specific boot parameters if arch directories exist
     # NOTE: bootloader_by_arch and *_bootfile_name_by_arch were added in upstream Ironic 30.0.0.

--- a/templates/ironicconductor/bin/init.sh
+++ b/templates/ironicconductor/bin/init.sh
@@ -45,6 +45,9 @@ fi
 if [ ! -d "/var/lib/ironic/httpboot" ]; then
     mkdir /var/lib/ironic/httpboot
 fi
+if [ ! -d "/var/lib/ironic/httpboot/x86_64" ]; then
+    mkdir /var/lib/ironic/httpboot/x86_64
+fi
 if [ ! -d "/var/lib/ironic/ramdisk-logs" ]; then
     mkdir /var/lib/ironic/ramdisk-logs
 fi


### PR DESCRIPTION
## Describe your changes
Move IPA kernel/ramdisk extraction to an arch-specific `x86_64/` subdirectory under httpboot. The  `ironic-python-agent-init` container now writes to `httpboot/x86_64/` instead of it directly. Add symlinks for backwards compatibility. Arch-specific config values set when files are present. 

## Jira Ticket Link
Jira: [OSPRH-27957](https://redhat.atlassian.net/browse/OSPRH-27957)

## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [x] Performed `pre-commit run --all`
- [x] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
