### PR TITLE
Set service_type in [keystone_authtoken] for access rule validation

### DIFF
--- a/templates/common/config/ironic.conf
+++ b/templates/common/config/ironic.conf
@@ -70,6 +70,7 @@ endpoint_override={{ .IronicPublicURL }}
 {{else}}
 [keystone_authtoken]
 www_authenticate_uri={{ .KeystonePublicURL }}
+service_type = baremetal
 # This is part of hardening related to CVE-2023-2088
 # https://docs.openstack.org/nova/latest/configuration/config.html#keystone_authtoken.service_token_roles_required
 # when enabled the service token user must have the service role to be considered valid.

--- a/templates/ironicinspector/config/01-inspector.conf
+++ b/templates/ironicinspector/config/01-inspector.conf
@@ -50,6 +50,7 @@ retry_interval=10
 
 [keystone_authtoken]
 www_authenticate_uri={{ .KeystonePublicURL }}
+service_type = baremetal-introspection
 {{ template "auth_config" . }}
 
 [service_catalog]


### PR DESCRIPTION
Without service_type configured, keystonemiddleware cannot validate application credentials with custom access rules, causing HTTP 401 for end users.

Closes: [OSPRH-22365](https://redhat.atlassian.net/browse/OSPRH-22365)
