### PR TITLE
Remove unnecessary pods RBAC permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,7 +9,6 @@ rules:
   resources:
   - configmaps
   - persistentvolumeclaims
-  - pods
   - secrets
   - services
   verbs:
@@ -20,6 +19,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
 - apiGroups:
   - ""
   resources:

--- a/internal/controller/funcs.go
+++ b/internal/controller/funcs.go
@@ -95,11 +95,6 @@ func getCommonRbacRules() []rbacv1.PolicyRule {
 			Resources:     []string{"securitycontextconstraints"},
 			Verbs:         []string{"use"},
 		},
-		{
-			APIGroups: []string{""},
-			Resources: []string{"pods"},
-			Verbs:     []string{"create", "get", "list", "watch", "update", "patch", "delete"},
-		},
 	}
 }
 

--- a/internal/controller/ironic_controller.go
+++ b/internal/controller/ironic_controller.go
@@ -103,7 +103,6 @@ func (r *IronicReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged,resources=securitycontextconstraints,verbs=use
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controller/ironicapi_controller.go
+++ b/internal/controller/ironicapi_controller.go
@@ -103,7 +103,6 @@ func (r *IronicAPIReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged,resources=securitycontextconstraints,verbs=use
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=topology.openstack.org,resources=topologies,verbs=get;list;watch;update
 
 // Reconcile -

--- a/internal/controller/ironicconductor_controller.go
+++ b/internal/controller/ironicconductor_controller.go
@@ -95,7 +95,6 @@ func (r *IronicConductorReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged,resources=securitycontextconstraints,verbs=use
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=topology.openstack.org,resources=topologies,verbs=get;list;watch;update
 
 // Reconcile -

--- a/internal/controller/ironicinspector_controller.go
+++ b/internal/controller/ironicinspector_controller.go
@@ -117,7 +117,6 @@ func (r *IronicInspectorReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged,resources=securitycontextconstraints,verbs=use
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=topology.openstack.org,resources=topologies,verbs=get;list;watch;update
 
 // Reconcile -

--- a/internal/controller/ironicneutronagent_controller.go
+++ b/internal/controller/ironicneutronagent_controller.go
@@ -90,7 +90,6 @@ func (r *IronicNeutronAgentReconciler) GetLogger(ctx context.Context) logr.Logge
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged,resources=securitycontextconstraints,verbs=use
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=topology.openstack.org,resources=topologies,verbs=get;list;watch;update
 
 // Reconcile -

--- a/test/functional/ironic_controller_test.go
+++ b/test/functional/ironic_controller_test.go
@@ -117,9 +117,8 @@ var _ = Describe("Ironic controller", func() {
 				corev1.ConditionTrue,
 			)
 			role := th.GetRole(ironicNames.IronicRole)
-			Expect(role.Rules).To(HaveLen(2))
+			Expect(role.Rules).To(HaveLen(1))
 			Expect(role.Rules[0].Resources).To(Equal([]string{"securitycontextconstraints"}))
-			Expect(role.Rules[1].Resources).To(Equal([]string{"pods"}))
 			th.ExpectCondition(
 				ironicNames.IronicName,
 				ConditionGetterFunc(IronicConditionGetter),

--- a/test/functional/ironicapi_controller_test.go
+++ b/test/functional/ironicapi_controller_test.go
@@ -114,9 +114,8 @@ var _ = Describe("IronicAPI controller", func() {
 				corev1.ConditionTrue,
 			)
 			role := th.GetRole(ironicNames.APIRole)
-			Expect(role.Rules).To(HaveLen(2))
+			Expect(role.Rules).To(HaveLen(1))
 			Expect(role.Rules[0].Resources).To(Equal([]string{"securitycontextconstraints"}))
-			Expect(role.Rules[1].Resources).To(Equal([]string{"pods"}))
 			th.ExpectCondition(
 				ironicNames.APIName,
 				ConditionGetterFunc(IronicAPIConditionGetter),

--- a/test/functional/ironicconductor_controller_test.go
+++ b/test/functional/ironicconductor_controller_test.go
@@ -116,9 +116,8 @@ var _ = Describe("IronicConductor controller", func() {
 				corev1.ConditionTrue,
 			)
 			role := th.GetRole(ironicNames.ConductorRole)
-			Expect(role.Rules).To(HaveLen(2))
+			Expect(role.Rules).To(HaveLen(1))
 			Expect(role.Rules[0].Resources).To(Equal([]string{"securitycontextconstraints"}))
-			Expect(role.Rules[1].Resources).To(Equal([]string{"pods"}))
 			th.ExpectCondition(
 				ironicNames.ConductorName,
 				ConditionGetterFunc(IronicConductorConditionGetter),

--- a/test/functional/ironicinspector_controller_test.go
+++ b/test/functional/ironicinspector_controller_test.go
@@ -105,9 +105,8 @@ var _ = Describe("IronicInspector controller", func() {
 				corev1.ConditionTrue,
 			)
 			role := th.GetRole(ironicNames.InspectorRole)
-			Expect(role.Rules).To(HaveLen(2))
+			Expect(role.Rules).To(HaveLen(1))
 			Expect(role.Rules[0].Resources).To(Equal([]string{"securitycontextconstraints"}))
-			Expect(role.Rules[1].Resources).To(Equal([]string{"pods"}))
 			th.ExpectCondition(
 				ironicNames.InspectorName,
 				ConditionGetterFunc(IronicInspectorConditionGetter),


### PR DESCRIPTION
The workload rbacRules and kubebuilder RBAC markers granted full CRUD (create/delete/get/list/patch/update/watch) on core Pods, which was never exercised. Remove the unused permission and regenerate config/rbac/role.yaml.

The narrower get;list markers on ironicconductor, ironicinspector and ironicneutronagent are kept, since those controllers list pods by label to track conductor/inspector pod status.


