### PR TITLE
Set automountServiceAccountToken: false on workloads that do not need the Kubernetes API

### DIFF
--- a/internal/ironic/dbsync.go
+++ b/internal/ironic/dbsync.go
@@ -22,6 +22,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -61,8 +62,9 @@ func DbSyncJob(
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ServiceAccountName: instance.RbacResourceName(),
+					RestartPolicy:                corev1.RestartPolicyOnFailure,
+					ServiceAccountName:           instance.RbacResourceName(),
+					AutomountServiceAccountToken: ptr.To(false),
 					Containers: []corev1.Container{
 						{
 							Name: ServiceName + "-db-sync",

--- a/internal/ironicapi/deployment.go
+++ b/internal/ironicapi/deployment.go
@@ -32,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -133,7 +134,8 @@ func Deployment(
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.RbacResourceName(),
+					ServiceAccountName:           instance.RbacResourceName(),
+					AutomountServiceAccountToken: ptr.To(false),
 					Containers: []corev1.Container{
 						// the first container in a pod is the default selected
 						// by oc log so define the log stream container first.

--- a/internal/ironicneutronagent/deployment.go
+++ b/internal/ironicneutronagent/deployment.go
@@ -26,6 +26,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 // Deployment func
@@ -91,7 +92,8 @@ func Deployment(
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: instance.RbacResourceName(),
+					ServiceAccountName:           instance.RbacResourceName(),
+					AutomountServiceAccountToken: ptr.To(false),
 					Containers: []corev1.Container{
 						{
 							Name: ServiceName,

--- a/test/functional/ironic_controller_test.go
+++ b/test/functional/ironic_controller_test.go
@@ -1187,6 +1187,23 @@ var _ = Describe("Ironic controller", func() {
 			}, timeout, interval).Should(Succeed())
 		})
 
+		It("does not mount the service account token on workloads that do not need it", func() {
+			Eventually(func(g Gomega) {
+				// IronicAPI deployment
+				g.Expect(th.GetDeployment(ironicNames.IronicName).Spec.Template.Spec.AutomountServiceAccountToken).ToNot(BeNil())
+				g.Expect(*th.GetDeployment(ironicNames.IronicName).Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
+				// IronicNeutronAgent deployment
+				g.Expect(th.GetDeployment(ironicNames.INAName).Spec.Template.Spec.AutomountServiceAccountToken).ToNot(BeNil())
+				g.Expect(*th.GetDeployment(ironicNames.INAName).Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
+				// Ironic dbsync job
+				g.Expect(th.GetJob(ironicNames.IronicDBSyncJobName).Spec.Template.Spec.AutomountServiceAccountToken).ToNot(BeNil())
+				g.Expect(*th.GetJob(ironicNames.IronicDBSyncJobName).Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
+				// Conductor needs the token, so it should NOT be set to false
+				conductorAutoMount := th.GetStatefulSet(ironicNames.ConductorName).Spec.Template.Spec.AutomountServiceAccountToken
+				g.Expect(conductorAutoMount == nil || *conductorAutoMount).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
+		})
+
 		It("updates nodeSelector in resource specs when changed", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(th.GetJob(ironicNames.IronicDBSyncJobName).Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))

--- a/test/functional/ironicapi_controller_test.go
+++ b/test/functional/ironicapi_controller_test.go
@@ -191,6 +191,13 @@ var _ = Describe("IronicAPI controller", func() {
 				corev1.ConditionTrue,
 			)
 		})
+		It("does not mount the service account token", func() {
+			Eventually(func(g Gomega) {
+				depl := th.GetDeployment(ironicNames.IronicName)
+				g.Expect(depl.Spec.Template.Spec.AutomountServiceAccountToken).ToNot(BeNil())
+				g.Expect(*depl.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
+			}, timeout, interval).Should(Succeed())
+		})
 		It("Creates a Services for internal and public", func() {
 			var name types.NamespacedName
 			// Verify Service ironic-internal created

--- a/test/functional/ironicneutronagent_controller_test.go
+++ b/test/functional/ironicneutronagent_controller_test.go
@@ -208,6 +208,13 @@ var _ = Describe("IronicNeutronAgent controller", func() {
 				instance := GetIronicNeutronAgent(ironicNames.INAName)
 				Expect(instance.Status.ReadyCount).To(Equal(int32(1)))
 			})
+			It("does not mount the service account token", func() {
+				Eventually(func(g Gomega) {
+					depl := th.GetDeployment(ironicNames.INAName)
+					g.Expect(depl.Spec.Template.Spec.AutomountServiceAccountToken).ToNot(BeNil())
+					g.Expect(*depl.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
+				}, timeout, interval).Should(Succeed())
+			})
 		})
 	})
 


### PR DESCRIPTION
The SA token (which grants use on SCCs) was automatically mounted into every container. If a container were compromised, the token would be immediately available for further escalation.

Set AutomountServiceAccountToken to false on the pod templates for:
- IronicAPI Deployment
- IronicNeutronAgent Deployment
- Ironic db-sync Job

IronicConductor is intentionally left unchanged because it needs the token for OCI image operations and (eventually) graphical console pod management. IronicInspector is out of scope as it is being removed.

Functional tests are added to verify the field is set on affected workloads and that the conductor retains access to the token.

Jira: [OSPRH-33430](https://redhat.atlassian.net/browse/OSPRH-33430)

## Describe your changes

## Jira Ticket Link
Jira: <OSPRH link>

## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [x] Performed `pre-commit run --all`
- [x] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [x] Verified that no failures present in logs(optional):
  - [x] ironic-operator-build-deploy-kuttl
  - [x] podified-multinode-ironic-deployment
