### PR TITLE
Do not run dbsync as root

### DIFF
--- a/internal/ironic/dbsync.go
+++ b/internal/ironic/dbsync.go
@@ -34,7 +34,6 @@ func DbSyncJob(
 	instance *ironicv1.Ironic,
 	labels map[string]string,
 ) *batchv1.Job {
-	runAsUser := int64(0)
 
 	args := []string{"-c", DBSyncCommand}
 
@@ -70,11 +69,8 @@ func DbSyncJob(
 							Command: []string{
 								"/bin/bash",
 							},
-							Args:  args,
-							Image: instance.Spec.Images.Conductor,
-							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: &runAsUser,
-							},
+							Args:         args,
+							Image:        instance.Spec.Images.Conductor,
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts: volumeMounts,
 						},

--- a/templates/ironic/bin/dbsync.sh
+++ b/templates/ironic/bin/dbsync.sh
@@ -15,7 +15,7 @@
 # under the License.
 set -ex
 
-/usr/local/bin/kolla_set_configs
+sudo -E /usr/local/bin/kolla_set_configs
 
 # prepare for 'upgrade check' loading all drivers
 if [ ! -d "/var/lib/ironic/tmp" ]; then


### PR DESCRIPTION
Jira: [OSPRH-33468](https://redhat.atlassian.net/browse/OSPRH-33468)

This will result in dbsync running as the default intended ironic user.

## Checklist before requesting a review
- [ ] I have performed a self-review of my code and confirmed it passes tests
- [ ] Performed `pre-commit run --all`
- [x] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
