### PR TITLE
Run ironic-neutron-agent as user neutron

### DIFF
--- a/internal/ironicneutronagent/const.go
+++ b/internal/ironicneutronagent/const.go
@@ -25,5 +25,5 @@ const (
 	ServiceType = "baremetal"
 
 	// ServiceCommand -
-	ServiceCommand = "/usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start"
+	ServiceCommand = "/usr/local/bin/kolla_start"
 )

--- a/internal/ironicneutronagent/deployment.go
+++ b/internal/ironicneutronagent/deployment.go
@@ -35,7 +35,6 @@ func Deployment(
 	labels map[string]string,
 	topology *topologyv1.Topology,
 ) *appsv1.Deployment {
-	runAsUser := int64(0)
 
 	livenessProbe := &corev1.Probe{
 		TimeoutSeconds:      5,
@@ -99,11 +98,8 @@ func Deployment(
 							Command: []string{
 								"/bin/bash",
 							},
-							Args:  args,
-							Image: instance.Spec.ContainerImage,
-							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: &runAsUser,
-							},
+							Args:           args,
+							Image:          instance.Spec.ContainerImage,
 							Env:            env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:   volumeMounts,
 							Resources:      instance.Spec.Resources,

--- a/templates/ironicneutronagent/config/ironic-neutron-agent-config.json
+++ b/templates/ironicneutronagent/config/ironic-neutron-agent-config.json
@@ -4,13 +4,13 @@
         {
             "source": "/var/lib/config-data/default/01-ironic_neutron_agent.conf",
             "dest": "/etc/neutron/neutron.conf.d/01-ironic_neutron_agent.conf",
-            "owner": "root:neutron",
+            "owner": "neutron:neutron",
             "perm": "0640"
         },
         {
             "source": "/var/lib/config-data/default/02-ironic_neutron_agent-custom.conf",
             "dest": "/etc/neutron/neutron.conf.d/02-ironic_neutron_agent-custom.conf",
-            "owner": "root:neutron",
+            "owner": "neutron:neutron",
             "perm": "0640"
         }
     ],


### PR DESCRIPTION
This stops running ironic-neutron-agent as user root.

Jira: [OSPRH-33467](https://redhat.atlassian.net/browse/OSPRH-33467)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code and confirmed it passes tests
- [ ] Performed `pre-commit run --all`
- [x] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
