### PR TITLE
Run ironic-conductor containers as non-root

### DIFF
--- a/internal/ironicconductor/statefulset.go
+++ b/internal/ironicconductor/statefulset.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	// ServiceCommand -
-	ServiceCommand = "/usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start"
+	ServiceCommand = "/usr/local/bin/kolla_start"
 )
 
 // StatefulSet func
@@ -50,7 +50,6 @@ func StatefulSet(
 	annotations map[string]string,
 	topology *topologyv1.Topology,
 ) (*appsv1.StatefulSet, error) {
-	runAsUser := int64(0)
 
 	livenessProbe := &corev1.Probe{
 		TimeoutSeconds: 5,
@@ -175,11 +174,8 @@ func StatefulSet(
 		Command: []string{
 			"/bin/bash",
 		},
-		Args:  args,
-		Image: instance.Spec.ContainerImage,
-		SecurityContext: &corev1.SecurityContext{
-			RunAsUser: &runAsUser,
-		},
+		Args:          args,
+		Image:         instance.Spec.ContainerImage,
 		Env:           env.MergeEnvs([]corev1.EnvVar{}, envVars),
 		VolumeMounts:  conductorVolumeMounts,
 		Resources:     instance.Spec.Resources,
@@ -191,11 +187,8 @@ func StatefulSet(
 		Command: []string{
 			"/bin/bash",
 		},
-		Args:  args,
-		Image: instance.Spec.PxeContainerImage,
-		SecurityContext: &corev1.SecurityContext{
-			RunAsUser: &runAsUser,
-		},
+		Args:           args,
+		Image:          instance.Spec.PxeContainerImage,
 		Env:            env.MergeEnvs([]corev1.EnvVar{}, httpbootEnvVars),
 		VolumeMounts:   httpbootVolumeMounts,
 		Resources:      instance.Spec.Resources,
@@ -212,9 +205,6 @@ func StatefulSet(
 		Image:        instance.Spec.ContainerImage,
 		Env:          env.MergeEnvs([]corev1.EnvVar{}, ramdiskLogsEnvVars),
 		VolumeMounts: ramdiskLogsVolumeMounts,
-		SecurityContext: &corev1.SecurityContext{
-			RunAsUser: &runAsUser,
-		},
 		// inotifywait doesn't terminate on SIGTERM so call SIGKILL as a
 		// pre-stop command
 		Lifecycle: &corev1.Lifecycle{
@@ -245,7 +235,6 @@ func StatefulSet(
 			Args:  args,
 			Image: instance.Spec.PxeContainerImage,
 			SecurityContext: &corev1.SecurityContext{
-				RunAsUser: &runAsUser,
 				Capabilities: &corev1.Capabilities{
 					Add: []corev1.Capability{
 						"NET_ADMIN",


### PR DESCRIPTION
Remove RunAsUser: 0 from the conductor, httpboot, and ramdisk-logs containers so they run as the default ironic user from the container image instead of root.

The dnsmasq sidecar retains its SecurityContext for the NET_ADMIN and NET_RAW capabilities it requires, but also drops RunAsUser: 0.

The kolla_set_configs call is removed from the conductor ServiceCommand since kolla_start already handles config setup. The permissions section of the kolla config will chown /var/lib/ironic files to ironic:ironic, which also handles the upgrade case where existing files were previously written as root.

Jira: [OSPRH-33557](https://redhat.atlassian.net/browse/OSPRH-33557)

## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [x] Performed `pre-commit run --all`
- [x] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [x] Verified that no failures present in logs(optional):
  - [x] ironic-operator-build-deploy-kuttl
  - [x] podified-multinode-ironic-deployment
