### PR TITLE
Do not run conductor init containers Privileged

### DIFF
--- a/internal/ironic/initcontainer.go
+++ b/internal/ironic/initcontainer.go
@@ -32,7 +32,6 @@ type APIDetails struct {
 	OSPSecret              string
 	UserPasswordSelector   string
 	VolumeMounts           []corev1.VolumeMount
-	Privileged             bool
 	PxeInit                bool
 	ConductorInit          bool
 	DeployHTTPURL          string
@@ -150,11 +149,8 @@ func InitContainer(init APIDetails) []corev1.Container {
 
 	if init.ConductorInit {
 		ipaInit := corev1.Container{
-			Name:  "ironic-python-agent-init",
-			Image: init.IronicPythonAgentImage,
-			SecurityContext: &corev1.SecurityContext{
-				Privileged: &init.Privileged,
-			},
+			Name:         "ironic-python-agent-init",
+			Image:        init.IronicPythonAgentImage,
 			Env:          imageCopyEnvs,
 			VolumeMounts: init.VolumeMounts,
 		}
@@ -166,8 +162,13 @@ func InitContainer(init APIDetails) []corev1.Container {
 			Name:  "pxe-init",
 			Image: init.PxeContainerImage,
 			SecurityContext: &corev1.SecurityContext{
-				RunAsUser:  &runAsUser,
-				Privileged: &init.Privileged,
+				RunAsUser: &runAsUser,
+				Capabilities: &corev1.Capabilities{
+					Add: []corev1.Capability{
+						"SYS_CHROOT",
+						"SETFCAP",
+					},
+				},
 			},
 			Command: []string{
 				"/bin/bash",

--- a/internal/ironicconductor/statefulset.go
+++ b/internal/ironicconductor/statefulset.go
@@ -340,7 +340,6 @@ func StatefulSet(
 		VolumeMounts:           initVolumeMounts,
 		PxeInit:                true,
 		ConductorInit:          true,
-		Privileged:             true,
 		DeployHTTPURL:          deployHTTPURL,
 		IngressDomain:          ingressDomain,
 		ProvisionNetwork:       instance.Spec.ProvisionNetwork,


### PR DESCRIPTION
Only pxe-init needs capabilities added to perform its tasks.

Jira: [OSPRH-33429](https://redhat.atlassian.net/browse/OSPRH-33429)


## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [x] Performed `pre-commit run --all`
- [x] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [x] Verified that no failures present in logs(optional):
  - [x] ironic-operator-build-deploy-kuttl
  - [x] podified-multinode-ironic-deployment
