### PR TITLE
Run ironic-inspector containers as non-root

### DIFF
--- a/internal/ironicinspector/dbsync.go
+++ b/internal/ironicinspector/dbsync.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// DBSyncCommand -
-	DBSyncCommand = "/usr/local/bin/kolla_set_configs && /bin/bash -c 'ironic-inspector-dbsync --config-file /etc/ironic-inspector/inspector.conf --config-dir /etc/ironic-inspector/inspector.conf.d upgrade'"
+	DBSyncCommand = "sudo -E /usr/local/bin/kolla_set_configs && /bin/bash -c 'ironic-inspector-dbsync --config-file /etc/ironic-inspector/inspector.conf --config-dir /etc/ironic-inspector/inspector.conf.d upgrade'"
 )
 
 // DbSyncJob func
@@ -35,7 +35,6 @@ func DbSyncJob(
 	instance *ironicv1.IronicInspector,
 	labels map[string]string,
 ) *batchv1.Job {
-	runAsUser := int64(0)
 
 	args := []string{"-c", DBSyncCommand}
 
@@ -71,11 +70,8 @@ func DbSyncJob(
 							Command: []string{
 								"/bin/bash",
 							},
-							Args:  args,
-							Image: instance.Spec.ContainerImage,
-							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: &runAsUser,
-							},
+							Args:         args,
+							Image:        instance.Spec.ContainerImage,
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts: volumeMounts,
 						},

--- a/internal/ironicinspector/initcontainer.go
+++ b/internal/ironicinspector/initcontainer.go
@@ -34,7 +34,6 @@ type APIDetails struct {
 	OSPSecret              string
 	UserPasswordSelector   string
 	VolumeMounts           []corev1.VolumeMount
-	Privileged             bool
 	InspectorHTTPURL       string
 	IngressDomain          string
 	InspectionNetwork      string
@@ -131,9 +130,6 @@ func InitContainer(init APIDetails) []corev1.Container {
 		ipaInit := corev1.Container{
 			Name:  "ironic-python-agent-init",
 			Image: init.IronicPythonAgentImage,
-			SecurityContext: &corev1.SecurityContext{
-				Privileged: &init.Privileged,
-			},
 			Command: []string{
 				"/bin/bash",
 			},

--- a/internal/ironicinspector/statefulset.go
+++ b/internal/ironicinspector/statefulset.go
@@ -32,13 +32,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
 	k8snet "k8s.io/utils/net"
+	"k8s.io/utils/ptr"
 )
 
 const (
 	// ServiceCommand -
-	ServiceCommand = "/usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start"
-	// IronicInspectorHttpdCommand -
-	IronicInspectorHttpdCommand = "/usr/sbin/httpd -DFOREGROUND"
+	ServiceCommand = "/usr/local/bin/kolla_start"
 )
 
 // StatefulSet func
@@ -50,7 +49,6 @@ func StatefulSet(
 	annotations map[string]string,
 	topology *topologyv1.Topology,
 ) (*appsv1.StatefulSet, error) {
-	runAsUser := int64(0)
 
 	livenessProbe := &corev1.Probe{
 		TimeoutSeconds:      5,
@@ -190,14 +188,13 @@ func StatefulSet(
 		Command: []string{
 			"/bin/bash",
 		},
-		Args:            args,
-		SecurityContext: &corev1.SecurityContext{RunAsUser: &runAsUser},
-		Env:             env.MergeEnvs([]corev1.EnvVar{}, httpdEnvVars),
-		VolumeMounts:    httpdVolumeMounts,
-		Resources:       instance.Spec.Resources,
-		ReadinessProbe:  readinessProbe,
-		LivenessProbe:   livenessProbe,
-		StartupProbe:    startupProbe,
+		Args:           args,
+		Env:            env.MergeEnvs([]corev1.EnvVar{}, httpdEnvVars),
+		VolumeMounts:   httpdVolumeMounts,
+		Resources:      instance.Spec.Resources,
+		ReadinessProbe: readinessProbe,
+		LivenessProbe:  livenessProbe,
+		StartupProbe:   startupProbe,
 	}
 	containers = append(containers, httpdContainer)
 
@@ -210,14 +207,13 @@ func StatefulSet(
 		Command: []string{
 			"/bin/bash",
 		},
-		Args:            args,
-		SecurityContext: &corev1.SecurityContext{RunAsUser: &runAsUser},
-		Env:             env.MergeEnvs([]corev1.EnvVar{}, inspectorEnvVars),
-		VolumeMounts:    inspectorVolumeMounts,
-		Resources:       instance.Spec.Resources,
-		ReadinessProbe:  readinessProbe,
-		LivenessProbe:   livenessProbe,
-		StartupProbe:    startupProbe,
+		Args:           args,
+		Env:            env.MergeEnvs([]corev1.EnvVar{}, inspectorEnvVars),
+		VolumeMounts:   inspectorVolumeMounts,
+		Resources:      instance.Spec.Resources,
+		ReadinessProbe: readinessProbe,
+		LivenessProbe:  livenessProbe,
+		StartupProbe:   startupProbe,
 	}
 	containers = append(containers, inspectorContainer)
 
@@ -230,10 +226,7 @@ func StatefulSet(
 		Command: []string{
 			"/bin/bash",
 		},
-		Args: args,
-		SecurityContext: &corev1.SecurityContext{
-			RunAsUser: &runAsUser,
-		},
+		Args:           args,
 		Env:            env.MergeEnvs([]corev1.EnvVar{}, httpbootEnvVars),
 		VolumeMounts:   httpbootVolumeMounts,
 		Resources:      instance.Spec.Resources,
@@ -255,9 +248,6 @@ func StatefulSet(
 		Image:        instance.Spec.ContainerImage,
 		Env:          env.MergeEnvs([]corev1.EnvVar{}, ramdiskLogsEnvVars),
 		VolumeMounts: ramdiskLogsVolumeMounts,
-		SecurityContext: &corev1.SecurityContext{
-			RunAsUser: &runAsUser,
-		},
 		// inotifywait doesn't terminate on SIGTERM so call SIGKILL as a
 		// pre-stop command
 		Lifecycle: &corev1.Lifecycle{
@@ -286,7 +276,6 @@ func StatefulSet(
 			},
 			Args: args,
 			SecurityContext: &corev1.SecurityContext{
-				RunAsUser: &runAsUser,
 				Capabilities: &corev1.Capabilities{
 					Add: []corev1.Capability{
 						"NET_ADMIN", "NET_RAW",
@@ -324,6 +313,7 @@ func StatefulSet(
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName:            instance.RbacResourceName(),
+					AutomountServiceAccountToken:  ptr.To(false),
 					Containers:                    containers,
 					TerminationGracePeriodSeconds: &terminationGracePeriod,
 					Volumes:                       volumes,
@@ -367,7 +357,6 @@ func StatefulSet(
 		VolumeMounts:           initVolumeMounts,
 		PxeInit:                true,
 		IpaInit:                true,
-		Privileged:             true,
 		InspectorHTTPURL:       inspectorHTTPURL,
 		IngressDomain:          ingressDomain,
 		InspectionNetwork:      instance.Spec.InspectionNetwork,

--- a/templates/ironicinspector/config/db-sync-config.json
+++ b/templates/ironicinspector/config/db-sync-config.json
@@ -4,13 +4,13 @@
         {
             "source": "/var/lib/config-data/default/01-inspector.conf",
             "dest": "/etc/ironic-inspector/inspector.conf.d/01-inspector.conf",
-            "owner": "root:ironic-inspector",
+            "owner": "ironic-inspector",
             "perm": "0640"
         },
         {
             "source": "/var/lib/config-data/default/02-inspector-custom.conf",
             "dest": "/etc/ironic-inspector/inspector.conf.d/02-inspector-custom.conf",
-            "owner": "root:ironic-inspector",
+            "owner": "ironic-inspector",
             "perm": "0640"
         },
         {

--- a/templates/ironicinspector/config/httpboot-config.json
+++ b/templates/ironicinspector/config/httpboot-config.json
@@ -10,16 +10,11 @@
         {
             "source": "/var/lib/config-data/default/inspector.ipxe",
             "dest": "/var/lib/ironic/httpboot/inspector.ipxe",
-            "owner": "root:ironic",
+            "owner": "ironic",
             "perm": "0644"
         }
     ],
     "permissions": [
-        {
-            "path": "/var/log/ironic",
-            "owner": "ironic:ironic",
-            "recurse": true
-        },
         {
             "path": "/var/lib/ironic",
             "owner": "ironic:ironic",

--- a/templates/ironicinspector/config/httpd-config.json
+++ b/templates/ironicinspector/config/httpd-config.json
@@ -4,19 +4,19 @@
         {
             "source": "/var/lib/config-data/default/httpd.conf",
             "dest": "/etc/httpd/conf/httpd.conf",
-            "owner": "root",
+            "owner": "apache",
             "perm": "0644"
         },
         {
             "source": "/var/lib/config-data/default/ssl.conf",
             "dest": "/etc/httpd/conf.d/ssl.conf",
-            "owner": "root",
-            "perm": "0644"
+            "owner": "apache",
+            "perm": "0444"
         },
         {
             "source": "/var/lib/config-data/tls/certs/*",
             "dest": "/etc/pki/tls/certs/",
-            "owner": "root",
+            "owner": "ironic-inspector",
             "perm": "0640",
             "optional": true,
             "merge": true
@@ -24,7 +24,7 @@
         {
             "source": "/var/lib/config-data/tls/private/*",
             "dest": "/etc/pki/tls/private/",
-            "owner": "root",
+            "owner": "ironic-inspector",
             "perm": "0600",
             "optional": true,
             "merge": true
@@ -33,12 +33,12 @@
     "permissions": [
         {
             "path": "/var/log/ironic-inspector",
-            "owner": "ironic-inspector:ironic-inspector",
+            "owner": "ironic-inspector:apache",
             "recurse": true
         },
         {
-            "path": "/var/lib/ironic-inspector",
-            "owner": "ironic-inspector:ironic-inspector",
+            "path": "/etc/httpd/run/",
+            "owner": "ironic-inspector:apache",
             "recurse": true
         }
     ]


### PR DESCRIPTION
- Remove RunAsUser: 0 from dbsync and ironic-inspector pod
- Remove Privileged from ironic-inspector containers
- Adjust file ownership as required
- AutomountServiceAccountToken is set to false on the StatefulSet PodSpec

Jira: [OSPRH-33615](https://redhat.atlassian.net/browse/OSPRH-33615)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code and confirmed it passes tests
- [ ] Performed `pre-commit run --all`
- [x] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
