### PR TITLE
Set readOnlyRootFilesystem on controller-manager container

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -71,6 +71,7 @@ spec:
           capabilities:
             drop:
             - "ALL"
+          readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /healthz
@@ -92,7 +93,11 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
-        volumeMounts: []
-      volumes: []
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+      volumes:
+      - emptyDir: {}
+        name: tmp
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Add readOnlyRootFilesystem: true to the manager container's securityContext to complete the restricted Pod Security Standards profile. Mount an emptyDir at /tmp to support controller-runtime metrics cert auto-generation and Go stdlib temporary file needs.

Jira: [OSPRH-33373](https://redhat.atlassian.net/browse/OSPRH-33373)

## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [ ] Performed `pre-commit run --all`
- [x] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
