### PR TITLE
Disable directory listing on httpboot Apache vhosts

### DIFF
--- a/templates/common/bin/pxe-init.sh
+++ b/templates/common/bin/pxe-init.sh
@@ -27,6 +27,8 @@ fi
 if [ ! -d "/var/lib/ironic/httpboot" ]; then
     mkdir -p /var/lib/ironic/httpboot
 fi
+# Create an empty index.html so that / returns 200 instead of 403
+touch /var/lib/ironic/httpboot/index.html
 # Check for expected EFI directories
 if [ -d "/boot/efi/EFI/centos" ]; then
     efi_dir=centos

--- a/templates/ironicconductor/config/httpboot-httpd.conf
+++ b/templates/ironicconductor/config/httpboot-httpd.conf
@@ -13,7 +13,6 @@ Listen 8088
 TypesConfig /etc/mime.types
 
 Include conf.modules.d/*.conf
-Include conf.d/*.conf
 
 LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
 LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy
@@ -33,7 +32,7 @@ CustomLog /dev/stdout proxy env=forwarded
   ## Directories, there should at least be a declaration for /var/lib/ironic/httpboot
 
   <Directory "/var/lib/ironic/httpboot">
-    Options Indexes FollowSymLinks
+    Options -Indexes +FollowSymLinks
     AllowOverride None
     Require all granted
   </Directory>

--- a/templates/ironicinspector/config/httpboot-httpd.conf
+++ b/templates/ironicinspector/config/httpboot-httpd.conf
@@ -13,7 +13,6 @@ Listen 8088
 TypesConfig /etc/mime.types
 
 Include conf.modules.d/*.conf
-Include conf.d/*.conf
 
 LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
 LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy
@@ -33,7 +32,7 @@ CustomLog /dev/stdout proxy env=forwarded
   ## Directories, there should at least be a declaration for /var/lib/ironic/httpboot
 
   <Directory "/var/lib/ironic/httpboot">
-    Options Indexes FollowSymLinks
+    Options -Indexes +FollowSymLinks
     AllowOverride None
     Require all granted
   </Directory>


### PR DESCRIPTION
The httpboot Apache vhost on :8088 had Options Indexes enabled, which allows anyone with network reach to the provisioning network to enumerate and browse the contents of /var/lib/ironic/httpboot.

Bare-metal nodes fetch boot artifacts (iPXE, UEFI, IPA ramdisk) via known paths, so directory listing is not required for provisioning to function. Disable it by setting -Indexes while keeping FollowSymLinks, which is needed for serving boot assets.

Also remove the Include conf.d/*.conf directive. This was pulling in default httpd config snippets such as welcome.conf (the Apache test page), autoindex.conf, and userdir.conf. None of these are needed by the httpboot vhost which only serves static boot artifacts from a known document root, and welcome.conf in particular causes the server to return an information-leaking test page for requests to /.

Create an empty index.html in pxe-init.sh so that requests to / return 200 with an empty body instead of 403 Forbidden.

This hardens both the ironicconductor and ironicinspector httpboot configurations.


Jira: [OSPRH-33375](https://redhat.atlassian.net/browse/OSPRH-33375)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code and confirmed it passes tests
- [ ] Performed `pre-commit run --all`
- [x] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
