### PR TITLE
Print ironic-status, ironic-dbsync to stderr

### DIFF
--- a/templates/ironic/bin/dbsync.sh
+++ b/templates/ironic/bin/dbsync.sh
@@ -23,6 +23,9 @@ if [ ! -d "/var/lib/ironic/httpboot" ]; then
     mkdir -p /var/lib/ironic/httpboot
 fi
 
+# Ensure logging is shown as part of this script execution
+crudini --set /etc/ironic/ironic.conf DEFAULT use_stderr true
+
 ironic-status upgrade check && ret_val=$? || ret_val=$?
 if [ $ret_val -gt 1 ] ; then
     # NOTE(TheJulia): We need to evaluate the return code from the


### PR DESCRIPTION
Currently the logging for these tools goes to the configured log, which is more appropriate for the service containers, not a job. This changes the logging so it is printed to stderr.

## Describe your changes

## Jira Ticket Link
Jira: <OSPRH link>

## Checklist before requesting a review
- [ ] I have performed a self-review of my code and confirmed it passes tests
- [ ] Performed `pre-commit run --all`
- [ ] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
