### PR TITLE
Defer failure if /boot/efi/EFI doesn't exist

### DIFF
--- a/templates/common/bin/pxe-init.sh
+++ b/templates/common/bin/pxe-init.sh
@@ -29,14 +29,11 @@ if [ ! -d "/var/lib/ironic/httpboot" ]; then
 fi
 # Create an empty index.html so that / returns 200 instead of 403
 touch /var/lib/ironic/httpboot/index.html
-# Check for expected EFI directories
+# Check for EFI directories if /var/lib/ironic is not already populated
 if [ -d "/boot/efi/EFI/centos" ]; then
     efi_dir=centos
 elif [ -d "/boot/efi/EFI/redhat" ]; then
     efi_dir=redhat
-else
-    echo "No EFI directory detected"
-    exit 1
 fi
 
 # Copy iPXE and grub files to tftpboot, httpboot
@@ -52,9 +49,17 @@ for dir in httpboot tftpboot; do
         cp /usr/share/ipxe/ipxe.lkrn /var/lib/ironic/$dir/ipxe.lkrn
     fi
     if [ ! -e "/var/lib/ironic/$dir/bootx64.efi" ]; then
+        if [ -n "${efi_dir:-}" ]; then
+            echo "ERROR: bootx64.efi is missing from /var/lib/ironic/$dir and no /boot/efi directory is available to copy them from"
+            exit 1
+        fi
         cp /boot/efi/EFI/$efi_dir/shimx64.efi /var/lib/ironic/$dir/bootx64.efi
     fi
     if [ ! -e "/var/lib/ironic/$dir/grubx64.efi" ]; then
+        if [ -n "${efi_dir:-}" ]; then
+            echo "ERROR: grubx64.efi is missing from /var/lib/ironic/$dir and no /boot/efi directory is available to copy them from"
+            exit 1
+        fi
         cp /boot/efi/EFI/$efi_dir/grubx64.efi /var/lib/ironic/$dir/grubx64.efi
     fi
 done


### PR DESCRIPTION
Grub and shim files in /boot/efi/EFI won't be required if /var/lib/ironic is already pre-populated from
/usr/share/ironic-operator/var-lib-ironic/, so it should only fail if those files need to be sourced from /boot/efi/EFI.

This won't cause issues with older images, and allows for s2i images which won't have /boot/efi/EFI files available.

Jira: [OSPRH-34544](https://redhat.atlassian.net/browse/OSPRH-34544)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code and confirmed it passes tests
- [ ] Performed `pre-commit run --all`
- [x] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
