### PR TITLE
Remove ilo hardware and interfaces

### DIFF
--- a/templates/common/config/ironic.conf
+++ b/templates/common/config/ironic.conf
@@ -18,22 +18,22 @@ region_name={{ .Region }}
 {{- end -}}
 
 [DEFAULT]
-enabled_hardware_types=ipmi,idrac,fake-hardware,redfish,manual-management,ilo,ilo5
-enabled_bios_interfaces=no-bios,redfish,idrac-redfish,ilo
-enabled_boot_interfaces=ipxe,ilo-ipxe,pxe,ilo-pxe,fake,redfish-virtual-media,idrac-redfish-virtual-media,ilo-virtual-media
-enabled_console_interfaces=ipmitool-socat,ilo,no-console,fake
+enabled_hardware_types=ipmi,idrac,fake-hardware,redfish,manual-management
+enabled_bios_interfaces=no-bios,redfish,idrac-redfish
+enabled_boot_interfaces=ipxe,pxe,fake,redfish-virtual-media,idrac-redfish-virtual-media
+enabled_console_interfaces=ipmitool-socat,no-console,fake
 enabled_deploy_interfaces=direct,fake,ramdisk,custom-agent
 default_deploy_interface=direct
-enabled_inspect_interfaces=inspector,no-inspect,fake,redfish,ilo
+enabled_inspect_interfaces=inspector,no-inspect,fake,redfish
 default_inspect_interface=inspector
-enabled_management_interfaces=ipmitool,fake,redfish,idrac-redfish,ilo,ilo5,noop
+enabled_management_interfaces=ipmitool,fake,redfish,idrac-redfish,noop
 enabled_network_interfaces=flat,neutron,noop
-enabled_power_interfaces=ipmitool,fake,redfish,idrac-redfish,ilo
-enabled_raid_interfaces=no-raid,agent,fake,ilo5
+enabled_power_interfaces=ipmitool,fake,redfish,idrac-redfish
+enabled_raid_interfaces=no-raid,agent,fake
 enabled_rescue_interfaces=no-rescue,agent
 default_rescue_interface=agent
 enabled_storage_interfaces=noop,fake
-enabled_vendor_interfaces=no-vendor,ipmitool,idrac-redfish,redfish,ilo,fake
+enabled_vendor_interfaces=no-vendor,ipmitool,idrac-redfish,redfish,fake
 # This is a knob to allow service role users from the service project
 # to have "elevated" API access to see the whole of the API surface.
 # https://review.opendev.org/c/openstack/ironic/+/907269


### PR DESCRIPTION
ilo related hardware and interfaces were removed in 2026.1 (ironic 35.0). The upgrade check will fail unless they are removed from enabled interfaces.

## Describe your changes

Jira: [OSPRH-34544](https://redhat.atlassian.net/browse/OSPRH-34544)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code and confirmed it passes tests
- [ ] Performed `pre-commit run --all`
- [x] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
