### PR TITLE
Let inspector-dnsmasq container run as root <JIRA:OSPRH-34795>

### DIFF
--- a/internal/ironicinspector/statefulset.go
+++ b/internal/ironicinspector/statefulset.go
@@ -276,6 +276,7 @@ func StatefulSet(
 			},
 			Args: args,
 			SecurityContext: &corev1.SecurityContext{
+				RunAsUser: ptr.To(int64(0)),
 				Capabilities: &corev1.Capabilities{
 					Add: []corev1.Capability{
 						"NET_ADMIN", "NET_RAW",


### PR DESCRIPTION
## Describe your changes
inspector-dnsmasq container fails to create listening socket for port 69 and the ironic-inspector-0 pod goes into a crash loop. In this PR, the run as root capability for the dnsmasq container has been added back. 

## Jira Ticket Link
Jira: [OSPRH-34795](https://redhat.atlassian.net/browse/OSPRH-34795)

## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [x] Performed `pre-commit run --all`
- [x] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
