### PR TITLE
Add CRD change check workflow for maintenance branches

### DIFF
--- a/.github/workflows/crd-change-check.yaml
+++ b/.github/workflows/crd-change-check.yaml
@@ -1,0 +1,11 @@
+name: CRD change check
+
+on:
+  pull_request:
+    branches:
+      - '18.0-fr[0-9]*'
+      - '19.[0-9]*'
+
+jobs:
+  crd-change-check:
+    uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/reusable-crd-change-check.yaml@main


### PR DESCRIPTION
Calls the shared reusable-crd-change-check workflow on PRs targeting 18.0-frX and 19.X maintenance branches to prevent unintended CRD changes.

Jira: [OSPRH-32473](https://redhat.atlassian.net/browse/OSPRH-32473)

## Describe your changes

## Jira Ticket Link
Jira: <OSPRH link>

## Checklist before requesting a review
- [ ] I have performed a self-review of my code and confirmed it passes tests
- [ ] Performed `pre-commit run --all`
- [ ] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
