### PR TITLE
Drop ALL capabilities in inspector-pxe-init container

### DIFF
--- a/internal/ironicinspector/initcontainer.go
+++ b/internal/ironicinspector/initcontainer.go
@@ -156,7 +156,18 @@ func InitContainer(init APIDetails) []corev1.Container {
 				// CA-cert patch.
 				RunAsNonRoot: ptr.To(false),
 				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+					// Runs as root but needs, on top of a dropped default
+					// set: DAC_OVERRIDE to write into the fsGroup-owned
+					// var-lib-ironic EmptyDir (e.g. copying dnsmasq.conf),
+					// FOWNER for the shared pxe-init.sh chmod of assets it
+					// does not own, and SYS_CHROOT/SETFCAP for the
+					// chroot-based CA-cert patch. SYS_ADMIN is deliberately
+					// not granted -- the shared unshare/chroot path works
+					// without it.
 					Add: []corev1.Capability{
+						"DAC_OVERRIDE",
+						"FOWNER",
 						"SYS_CHROOT",
 						"SETFCAP",
 					},


### PR DESCRIPTION
The inspector-pxe-init init container added SYS_CHROOT and SETFCAP but did not first drop the default capability set, unlike the conductor pxe-init container. This left the container running with all default capabilities on top of the two it explicitly needs.

Add Drop: ["ALL"] before the Add block, then re-add only the capabilities actually exercised while running as root:

- DAC_OVERRIDE: write into the fsGroup-owned var-lib-ironic EmptyDir   (e.g. copying dnsmasq.conf) -- previously provided implicitly by the default set, so dropping ALL without this broke the init container  with "cp: cannot create regular file ... Permission denied".
- FOWNER: the shared pxe-init.sh chmod of assets the container does  not own.
- SYS_CHROOT/SETFCAP: the chroot-based CA-cert patch.

SYS_ADMIN is deliberately not granted: it is not part of the default set the inspector previously relied on, and the shared unshare/chroot path works without it.

Follow up to https://github.com/openstack-k8s-operators/ironic-operator/pull/768

## Describe your changes

## Jira Ticket Link
Jira: https://redhat.atlassian.net/browse/OSPRH-33503

## Checklist before requesting a review
- [ ] I have performed a self-review of my code and confirmed it passes tests
- [ ] Performed `pre-commit run --all`
- [ ] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
