### PR TITLE
Add capabilities required by pxe-init and dnsmasq containers <JIRA:OSPRH-35271>

### DIFF
--- a/internal/ironic/initcontainer.go
+++ b/internal/ironic/initcontainer.go
@@ -179,6 +179,7 @@ func InitContainer(init APIDetails) []corev1.Container {
 				Capabilities: &corev1.Capabilities{
 					Drop: []corev1.Capability{"ALL"},
 					Add: []corev1.Capability{
+						"CHOWN",
 						"DAC_OVERRIDE",
 						"FOWNER",
 						"SYS_ADMIN",

--- a/internal/ironicconductor/statefulset.go
+++ b/internal/ironicconductor/statefulset.go
@@ -238,9 +238,13 @@ func StatefulSet(
 				RunAsNonRoot: ptr.To(false),
 				Capabilities: &corev1.Capabilities{
 					Drop: []corev1.Capability{"ALL"},
+					// With ALL dropped, root grants nothing on its own --
+					// each capability dnsmasq uses must be listed:
 					Add: []corev1.Capability{
+						"NET_BIND_SERVICE", // bind TFTP 69 / DHCP 67,547 (<1024)
 						"NET_ADMIN",
 						"NET_RAW",
+						"SETGID", // drop to the unprivileged dnsmasq group
 					},
 				},
 			},

--- a/internal/ironicinspector/statefulset.go
+++ b/internal/ironicinspector/statefulset.go
@@ -286,8 +286,13 @@ func StatefulSet(
 				RunAsNonRoot: ptr.To(false),
 				Capabilities: &corev1.Capabilities{
 					Drop: []corev1.Capability{"ALL"},
+					// With ALL dropped, root grants nothing on its own --
+					// each capability dnsmasq uses must be listed:
 					Add: []corev1.Capability{
-						"NET_ADMIN", "NET_RAW",
+						"NET_BIND_SERVICE", // bind TFTP 69 / DHCP 67,547 (<1024)
+						"NET_ADMIN",
+						"NET_RAW",
+						"SETGID", // drop to the unprivileged dnsmasq group
 					},
 				},
 			},

--- a/templates/common/bin/pxe-init.sh
+++ b/templates/common/bin/pxe-init.sh
@@ -80,7 +80,10 @@ if [ -f "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" ] && [ -f "/var/lib/
 
     # Copy the CA certificates
     cp /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /initramfs/etc/pki/ca-trust/source/anchors/
-    echo update-ca-trust | unshare -r chroot ./initramfs
+    # chroot directly as real root; `unshare -r`'s single-uid userns breaks
+    # update-ca-trust's symlink creation because it cannot access files
+    # owned by another user
+    chroot ./initramfs /bin/sh -c "update-ca-trust"
 
     # Repack the initramfs
     pushd initramfs


### PR DESCRIPTION
## Describe your changes
The kolla removal changes added `Drop: ["ALL"]` to the conductor and inspector pods. Running as root uid 0 no longer grants root privileges and so every operation that required it started failing, crashlooping  `ironic-conductor-0` and `ironic-inspector-0` pods. This change restores each container's needed capabilities:
- Conductor pxe-init: add CHOWN so the init script can chown assets to the ironic user.
- Inspector pxe-init: run as root (uid 0) with a scoped cap set (DAC_OVERRIDE, FOWNER, SYS_CHROOT, SETFCAP) for its chroot-based CA-cert patch.
- dnsmasq (conductor + inspector): add NET_BIND_SERVICE to bind the privileged TFTP/DHCP ports (69/67/547) and SETGID so dnsmasq can drop to its unprivileged dnsmasq group after binding.
- pxe-init.sh: replace unshare -r chroot with a plain chroot for update-ca-trust (the single-uid userns couldn't write files owned by other uids).

## Checklist before requesting a review
- [x] I have performed a self-review of my code and confirmed it passes tests
- [x] Performed `pre-commit run --all`
- [x] Tested operator image in a test/dev environment. It can be CRC via [install_yamls](https://github.com/openstack-k8s-operators/install_yamls) or a [hotstack](https://github.com/openstack-k8s-operators/hotstack/tree/main) instance (optional)
- [ ] Verified that no failures present in logs(optional):
  - [ ] ironic-operator-build-deploy-kuttl
  - [ ] podified-multinode-ironic-deployment
